### PR TITLE
ci: enable uv cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: "true"
       - run: uv run ruff format --diff
       - run: uv run ruff check
       - run: uv run ty check
@@ -49,6 +51,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: "true"
       - run: uv add "torch==${{ matrix.torch-version }}"
       - run: uv run pytest tests
 


### PR DESCRIPTION
## Summary
- enable uv cache in CI for python static check and tests

## Testing
- not run (CI)