### PR TITLE
ci: limit trigger paths to source and config files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,25 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - 'src/**'
+      - 'torchfont/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/**'
   pull_request:
+    paths:
+      - 'src/**'
+      - 'torchfont/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- CIトリガーを `paths-ignore`（denylist）から `paths`（allowlist）方式に変更
- ソースコード・テスト・依存関係・ワークフロー設定の変更時のみCIを実行
- ドキュメント (`docs/`)、README、`examples/`、`.readthedocs.yaml` 等の非コードファイルではCIをスキップ

## 対象パス
| パス | 理由 |
|---|---|
| `src/**` | Rust ソースコード |
| `torchfont/**` | Python ソースコード |
| `tests/**` | テストファイル |
| `Cargo.toml` / `Cargo.lock` | Rust 依存関係 |
| `pyproject.toml` / `uv.lock` | Python 依存関係・ビルド設定 |
| `.github/workflows/**` | CI 設定 |

`workflow_dispatch` は paths 制約を受けないため手動実行は常に可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)