### PR TITLE
fix: use relative path for root page redirect

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ layout: page
 
 <script setup>
 if (typeof window !== 'undefined') {
-  window.location.replace('/ja/')
+  window.location.replace('./ja/')
 }
 </script>
 
-<meta http-equiv="refresh" content="0;url=/ja/">
+<meta http-equiv="refresh" content="0;url=./ja/">


### PR DESCRIPTION
## Summary
- ドキュメントのルートページ (`docs/index.md`) のリダイレクト先を絶対パス (`/ja/`) から相対パス (`./ja/`) に変更
- ReadTheDocs の base path (`/<version>/`) が無視され、`/latest/` → `/ja/` にリダイレクトされてしまう問題を修正

## Test plan
- [ ] `https://torchfont.readthedocs.io/latest/` にアクセスして `/latest/ja/` にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)