### PR TITLE
Fix example DataLoader multiprocessing defaults

### DIFF
--- a/docs/en/examples/index.md
+++ b/docs/en/examples/index.md
@@ -5,9 +5,8 @@ Runnable examples live in the repository `examples/` directory.
 ::: tip Before running
 Run from the repository root, e.g. `python examples/google_fonts.py`.
 
-Some scripts use `multiprocessing_context="fork"` (Linux only) and
-`num_workers=8`. On macOS/Windows, switch to `"spawn"`. If you set
-`num_workers=0`, also remove `prefetch_factor` and `multiprocessing_context`.
+Some scripts use `num_workers=8`. If you set `num_workers=0`, also remove
+`prefetch_factor`.
 :::
 
 ## Scripts by use case

--- a/docs/ja/examples/index.md
+++ b/docs/ja/examples/index.md
@@ -7,7 +7,7 @@
 ::: tip 実行前に
 リポジトリのルートで実行してください（例: `python examples/google_fonts.py`）。
 
-一部スクリプトは `multiprocessing_context="fork"`（Linux 向け）と `num_workers=8` を前提にしています。macOS/Windows では `"spawn"` に変更してください。`num_workers=0` にする場合は `prefetch_factor` と `multiprocessing_context` も削除してください。
+一部スクリプトは `num_workers=8` を前提にしています。`num_workers=0` にする場合は `prefetch_factor` も削除してください。
 :::
 
 ## 用途別スクリプト

--- a/examples/font_awesome.py
+++ b/examples/font_awesome.py
@@ -40,7 +40,6 @@ dataloader = DataLoader(
     num_workers=8,
     prefetch_factor=2,
     collate_fn=collate_fn,
-    multiprocessing_context="fork",
 )
 
 print(f"{len(dataset)=}")

--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -52,7 +52,6 @@ dataloader = DataLoader(
     num_workers=8,
     prefetch_factor=2,
     collate_fn=collate_fn,
-    multiprocessing_context="fork",
 )
 
 print(f"{len(dataset)=}")

--- a/examples/material_design_icons.py
+++ b/examples/material_design_icons.py
@@ -40,7 +40,6 @@ dataloader = DataLoader(
     num_workers=8,
     prefetch_factor=2,
     collate_fn=collate_fn,
-    multiprocessing_context="fork",
 )
 
 print(f"{len(dataset)=}")

--- a/examples/source_han_sans.py
+++ b/examples/source_han_sans.py
@@ -40,7 +40,6 @@ dataloader = DataLoader(
     num_workers=8,
     prefetch_factor=2,
     collate_fn=collate_fn,
-    multiprocessing_context="fork",
 )
 
 print(f"{len(dataset)=}")


### PR DESCRIPTION
## Summary
- remove hard-coded `multiprocessing_context="fork"` from runnable examples
- keep the examples aligned with platform defaults so they work on macOS and Windows
- update the examples guide in English and Japanese to match the new behavior

## Testing
- `devcontainer up --workspace-folder .`
- `devcontainer exec --workspace-folder . bash -lc 'mise run check'`\n- `devcontainer exec --workspace-folder . bash -lc 'mise run test'`\n\nCloses #58