### PR TITLE
Fix style index gaps after codepoint filtering

### DIFF
--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -24,13 +24,14 @@ pub(super) fn load_entries_and_index(
     let mut all_cps = Vec::new();
 
     for path in files {
-        let mut faces = FontEntry::load_faces(&path, filter)?;
-        all_cps.extend(
-            faces
-                .iter()
-                .flat_map(|entry| entry.codepoints.iter().copied()),
-        );
-        entries.append(&mut faces);
+        let faces = FontEntry::load_faces(&path, filter)?;
+        for entry in faces
+            .into_iter()
+            .filter(|entry| !entry.codepoints.is_empty())
+        {
+            all_cps.extend(entry.codepoints.iter().copied());
+            entries.push(entry);
+        }
     }
 
     let sample_offsets = std::iter::once(0)

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -162,6 +162,21 @@ def test_font_folder_cjk_support() -> None:
     assert content_idx is not None
 
 
+def test_font_folder_skips_styles_without_samples_after_filtering() -> None:
+    dataset = FontFolder(
+        root="tests/fonts",
+        patterns=("lato/Lato-Regular.ttf", "notosansjp/NotoSansJP*.ttf"),
+        codepoint_filter=[ord(c) for c in "あいう"],
+    )
+
+    assert len(dataset) > 0
+    assert len(dataset.style_classes) == len(set(dataset.targets[:, 0].tolist()))
+    assert sorted(set(dataset.targets[:, 0].tolist())) == list(
+        range(len(dataset.style_classes))
+    )
+    assert all("Lato" not in name for name in dataset.style_classes)
+
+
 def test_font_folder_codepoint_filter() -> None:
     dataset_upper = FontFolder(
         root="tests/fonts",


### PR DESCRIPTION
## Summary
- drop font entries that produce no samples after applying `codepoint_filter`
- keep `style_classes` aligned with the samples that actually remain indexed
- add a regression test covering mixed-font filtering with an empty style

## Testing
- Dev Container: `mise exec -- cargo fmt --all -- --check`
- Dev Container: `mise exec -- uv run pytest tests/test_folder.py`

Closes #62