### PR TITLE
Add npm ecosystem to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,12 @@ updates:
       rust-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #55

## Summary
- Add npm ecosystem to `.github/dependabot.yml` to enable automatic security updates for VitePress documentation dependencies (`vitepress`, `@types/node`, etc.)

## Test plan
- No test needed; configuration change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)