### PR TITLE
Remove unsupported PyPy classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Closes #56

## Summary
- Remove `Programming Language :: Python :: Implementation :: PyPy` classifier from `pyproject.toml`
- PyO3's `abi3-py38` feature targets CPython's Stable ABI; PyPy compatibility is not guaranteed
- Removes misleading metadata rather than adding untested CI coverage

## Test plan
- No functional change; classifier metadata update only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)