### PR TITLE
Add __repr__ to dataset classes

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -42,8 +42,18 @@ impl FontDataset {
     }
 
     #[getter]
+    pub fn content_class_count(&self) -> usize {
+        self.index.content_classes.len()
+    }
+
+    #[getter]
     pub fn content_classes(&self) -> Vec<u32> {
         self.index.content_classes.clone()
+    }
+
+    #[getter]
+    pub fn style_class_count(&self) -> usize {
+        self.index.inst_offsets.last().copied().unwrap_or(0)
     }
 
     #[getter]

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -442,13 +442,14 @@ def test_font_folder_repr() -> None:
         codepoint_filter=range(0x41, 0x44),
     )
 
-    r = repr(dataset)
-    assert r.startswith("FontFolder(")
-    assert "root=" in r
-    assert "samples=" in r
-    assert "styles=" in r
-    assert "content_classes=" in r
-    assert str(dataset.root) in r
+    expected = (
+        f"FontFolder("
+        f"root={str(dataset.root)!r}, "
+        f"samples={len(dataset)}, "
+        f"styles={len(dataset.style_classes)}, "
+        f"content_classes={len(dataset.content_classes)})"
+    )
+    assert repr(dataset) == expected
 
 
 def test_targets_survives_pickle() -> None:

--- a/torchfont/datasets/folder.py
+++ b/torchfont/datasets/folder.py
@@ -111,20 +111,24 @@ class FontFolder(Dataset[tuple[Tensor, Tensor, int, int]]):
 
         Returns:
             str: String showing the class name, root path, sample count,
-            number of style classes, and number of content classes.
+                number of style classes, and number of content classes.
 
         Examples:
-            >>> ds = FontFolder(root="tests/fonts", codepoint_filter=range(0x41, 0x5B))
-            >>> repr(ds)
-            "FontFolder(root='...', samples=26, styles=1, content_classes=26)"
+            >>> ds = FontFolder(
+            ...     root="tests/fonts",
+            ...     codepoint_filter=range(0x41, 0x5B),
+            ...     patterns=("**/Lato-Regular.ttf",),
+            ... )
+            >>> len(ds), len(ds.style_classes), len(ds.content_classes)
+            (26, 1, 26)
 
         """
         return (
             f"{type(self).__name__}("
             f"root={str(self.root)!r}, "
             f"samples={len(self)}, "
-            f"styles={len(self.style_classes)}, "
-            f"content_classes={len(self.content_classes)})"
+            f"styles={self._dataset.style_class_count}, "
+            f"content_classes={self._dataset.content_class_count})"
         )
 
     def __getstate__(self) -> dict[str, object]:

--- a/torchfont/datasets/google_fonts.py
+++ b/torchfont/datasets/google_fonts.py
@@ -94,17 +94,18 @@ class GoogleFonts(FontRepo):
         """Return a human-readable summary of this dataset.
 
         Returns:
-            str: String showing the class name, root, ref, commit hash,
-            patterns, sample count, style count, and content class count.
+            str: String showing the class name, root, url, ref, commit hash,
+                patterns, sample count, style count, and content class count.
 
         """
         return (
             f"{type(self).__name__}("
             f"root={str(self.root)!r}, "
+            f"url={self.url!r}, "
             f"ref={self.ref!r}, "
             f"commit={self.commit_hash!r}, "
             f"patterns={self.patterns!r}, "
             f"samples={len(self)}, "
-            f"styles={len(self.style_classes)}, "
-            f"content_classes={len(self.content_classes)})"
+            f"styles={self._dataset.style_class_count}, "
+            f"content_classes={self._dataset.content_class_count})"
         )

--- a/torchfont/datasets/repo.py
+++ b/torchfont/datasets/repo.py
@@ -116,7 +116,7 @@ class FontRepo(FontFolder):
 
         Returns:
             str: String showing the class name, root, url, ref, commit hash,
-            sample count, style count, and content class count.
+                sample count, style count, and content class count.
 
         """
         return (
@@ -126,6 +126,6 @@ class FontRepo(FontFolder):
             f"ref={self.ref!r}, "
             f"commit={self.commit_hash!r}, "
             f"samples={len(self)}, "
-            f"styles={len(self.style_classes)}, "
-            f"content_classes={len(self.content_classes)})"
+            f"styles={self._dataset.style_class_count}, "
+            f"content_classes={self._dataset.content_class_count})"
         )


### PR DESCRIPTION
Closes #57

## Summary

- Add `__repr__` to `FontFolder`, `FontRepo`, and `GoogleFonts` for better interactive debugging
- `FontFolder` shows: `root`, `samples`, `styles`, `content_classes`
- `FontRepo` shows: above + `url`, `ref`, `commit`
- `GoogleFonts` shows: above + `patterns`
- Add `test_font_folder_repr` to verify the output format

## Test plan

- [ ] `test_font_folder_repr` passes
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)