### PR TITLE
test: fix Python 3.10 collection error in folder tests

### DIFF
--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import multiprocessing as mp
 import pickle
 import warnings
@@ -13,7 +15,7 @@ from torchfont.io.outline import CommandType
 
 
 def _read_first_sample_from_pickled_dataset(
-    payload: bytes, queue: mp.Queue
+    payload: bytes, queue: mp.Queue[tuple[int, int, int, tuple[int, int]]]
 ) -> None:
     dataset = pickle.loads(payload)  # noqa: S301
     sample = dataset[0]


### PR DESCRIPTION
## Summary
- fix test type annotation that caused runtime evaluation on Python 3.10
- add `from __future__ import annotations` to `tests/test_folder.py` to make all annotations lazily evaluated (PEP 563), restoring the original `mp.Queue[tuple[int, int, int, tuple[int, int]]]` type annotation
- keep behavior unchanged; only avoids collection-time `TypeError`

## Verification
- `devcontainer exec --workspace-folder . bash -lc 'uv run pytest tests/test_folder.py'`
- `devcontainer exec --workspace-folder . bash -lc 'uv run --python 3.10 pytest tests/test_folder.py -q'`
- `devcontainer exec --workspace-folder . bash -lc 'uv run --python 3.10 pytest tests'`