### PR TITLE
fix: validate transform constructor arguments

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -47,6 +47,7 @@ Returns a `GlyphSample` whose `types` and `coords` are truncated to `max_len`.
 
 - no padding
 - elements beyond `max_len` are truncated
+- `max_len` must be `>= 0`; invalid values raise `ValueError` at construction
 
 ### I/O shape (`LimitSequenceLength`)
 
@@ -103,7 +104,7 @@ into patches.
 
 - type padding value: `0` (`pad`)
 - coordinate padding value: `0.0`
-- `patch_size` must be `> 0` (`0` or negative values fail at runtime)
+- `patch_size` must be `>= 1`; invalid values raise `ValueError` at construction
 
 ### Example (`Patchify`)
 

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -46,6 +46,7 @@ LimitSequenceLength(max_len: int)
 
 - パディングは行いません
 - `max_len` を超えた後半は切り捨て
+- `max_len` は `>= 0` が必須で、不正値は constructor 時点で `ValueError` になります
 
 ### 入出力（`LimitSequenceLength`）
 
@@ -100,7 +101,7 @@ Patchify(patch_size: int)
 
 - `types` の埋め値は `0`（`pad`）
 - `coords` の埋め値は `0.0`
-- `patch_size` は `> 0` が必須（`0` や負値は実行時エラー）
+- `patch_size` は `>= 1` が必須で、不正値は constructor 時点で `ValueError` になります
 
 ### 例（`Patchify`）
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,8 +1,9 @@
+import pytest
 import torch
 
 from torchfont.datasets import GlyphSample
 from torchfont.io import CommandType
-from torchfont.transforms import Compose, LimitSequenceLength, QuadToCubic
+from torchfont.transforms import Compose, LimitSequenceLength, Patchify, QuadToCubic
 
 
 def test_quad_to_cubic_converts_quadratic_segments() -> None:
@@ -152,3 +153,20 @@ def test_compose_preserves_metadata_across_sample_first_pipeline() -> None:
     assert out.content_idx == sample.content_idx
     assert out.types.shape[0] == 2
     assert out.coords.shape[0] == 2
+
+
+@pytest.mark.parametrize(
+    ("transform_cls", "kwargs", "expected_message"),
+    [
+        (LimitSequenceLength, {"max_len": -1}, "max_len must be >= 0"),
+        (Patchify, {"patch_size": 0}, "patch_size must be >= 1"),
+        (Patchify, {"patch_size": -1}, "patch_size must be >= 1"),
+    ],
+)
+def test_transform_constructors_validate_invalid_arguments(
+    transform_cls: type[LimitSequenceLength] | type[Patchify],
+    kwargs: dict[str, int],
+    expected_message: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        transform_cls(**kwargs)

--- a/torchfont/transforms.py
+++ b/torchfont/transforms.py
@@ -88,8 +88,9 @@ class LimitSequenceLength:
         """Initialize the transform with the desired maximum length.
 
         Args:
-            max_len (int): Maximum number of time steps to keep. Any surplus
-                command or coordinate pairs are discarded.
+            max_len (int): Maximum number of time steps to keep. Must be
+                non-negative. Any surplus command or coordinate pairs are
+                discarded.
 
         Examples:
             Cap sequences at 512 steps::
@@ -97,6 +98,9 @@ class LimitSequenceLength:
                 LimitSequenceLength(512)
 
         """
+        if max_len < 0:
+            msg = "max_len must be >= 0"
+            raise ValueError(msg)
         self.max_len = max_len
 
     def __call__(self, sample: GlyphSample) -> GlyphSample:
@@ -198,9 +202,9 @@ class Patchify:
         """Configure the patch length for reshaping sequences.
 
         Args:
-            patch_size (int): Number of time steps captured in each patch. Choose
-                values that align with the receptive field of your downstream
-                model.
+            patch_size (int): Number of time steps captured in each patch. Must
+                be positive. Choose values that align with the receptive field
+                of your downstream model.
 
         Examples:
             Create 32-step patches for transformer models::
@@ -208,6 +212,9 @@ class Patchify:
                 Patchify(32)
 
         """
+        if patch_size < 1:
+            msg = "patch_size must be >= 1"
+            raise ValueError(msg)
         self.patch_size = patch_size
 
     def __call__(self, sample: GlyphSample) -> GlyphSample:


### PR DESCRIPTION
## Summary

- validate `Patchify` and `LimitSequenceLength` constructor arguments eagerly
- add regression coverage for invalid transform arguments
- document the stricter constructor contract in the EN/JA transform reference

Closes #102

## Validation

- `uv run pytest tests/test_transforms.py -q`
- `mise run format`
- `mise run check`
- `mise run test`
- `mise exec -- npm run docs:build`
