### PR TITLE
fix: validate dataset codepoint filters

### DIFF
--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -59,6 +59,8 @@ GlyphDataset(
 - supported extensions: `.ttf` / `.otf` / `.ttc` / `.otc`
 - `root` is resolved to an absolute `Path` during initialization
 - `codepoints` are normalized to sorted unique integers before indexing
+- invalid `codepoints` values raise `ValueError`; accepted values must be
+  Unicode scalar values (`0 <= cp <= 0x10FFFF`, excluding surrogates)
 - `__getitem__` supports negative indices (`dataset[-1]`)
 - out-of-range index raises `IndexError`
 

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -59,6 +59,8 @@ GlyphDataset(
 - 走査対象拡張子: `.ttf` / `.otf` / `.ttc` / `.otc`
 - `root` は初期化時に絶対 `Path` へ解決される
 - `codepoints` は index 化前に sort 済み・重複なしの整数列へ正規化される
+- 不正な `codepoints` は `ValueError` になり、受け入れる値は Unicode scalar
+  value（`0 <= cp <= 0x10FFFF` かつ surrogate を除く）に限る
 - `__getitem__` は負インデックス対応（`dataset[-1]` など）
 - 範囲外インデックスは `IndexError`
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -361,6 +361,25 @@ def test_glyph_dataset_normalizes_codepoints_on_instance() -> None:
     assert restored.codepoints == dataset.codepoints
 
 
+@pytest.mark.parametrize(
+    ("codepoints", "message"),
+    [
+        ([-1], "expected 0 <= cp <= 0x10FFFF"),
+        ([0x110000], "expected 0 <= cp <= 0x10FFFF"),
+        ([0xD800], "surrogate code points"),
+    ],
+)
+def test_glyph_dataset_rejects_invalid_unicode_codepoints(
+    codepoints: list[int], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        GlyphDataset(
+            root="tests/fonts",
+            patterns=("lato/Lato-Regular.ttf",),
+            codepoints=codepoints,
+        )
+
+
 def test_glyph_dataset_pattern_filter() -> None:
     dataset_all = GlyphDataset(
         root="tests/fonts",

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -34,6 +34,10 @@ from torchfont.metadata import (
     build_dataset_metadata,
 )
 
+UNICODE_MAX_CODEPOINT = 0x10FFFF
+UNICODE_SURROGATE_START = 0xD800
+UNICODE_SURROGATE_END = 0xDFFF
+
 
 class GlyphSample(NamedTuple):
     """One glyph sample returned by a dataset.
@@ -150,7 +154,8 @@ class GlyphDataset(Dataset[GlyphSample]):
             codepoints (Sequence[SupportsIndex] | None): Optional iterable
                 of Unicode code points used to restrict the dataset content.
                 Duplicate values are ignored and the effective filter is stored
-                as sorted unique integers on ``dataset.codepoints``.
+                as sorted unique integers on ``dataset.codepoints``. Values
+                must be Unicode scalar values.
             patterns (Sequence[str] | None): Optional gitignore-style patterns
                 describing which font paths to include.
             transform (Callable[[GlyphSample], GlyphSample] | None):
@@ -231,7 +236,26 @@ class GlyphDataset(Dataset[GlyphSample]):
         """Convert an optional codepoint filter into a canonical tuple."""
         if codepoints is None:
             return None
-        return tuple(sorted({index(cp) for cp in codepoints}))
+        return tuple(
+            sorted({GlyphDataset._validate_codepoint(index(cp)) for cp in codepoints})
+        )
+
+    @staticmethod
+    def _validate_codepoint(codepoint: int) -> int:
+        """Validate one Unicode scalar value for dataset indexing."""
+        if codepoint < 0 or codepoint > UNICODE_MAX_CODEPOINT:
+            msg = (
+                "invalid Unicode codepoint "
+                f"{codepoint}: expected 0 <= cp <= 0x{UNICODE_MAX_CODEPOINT:06X}"
+            )
+            raise ValueError(msg)
+        if UNICODE_SURROGATE_START <= codepoint <= UNICODE_SURROGATE_END:
+            msg = (
+                "invalid Unicode codepoint "
+                f"U+{codepoint:04X}: surrogate code points are not valid scalar values"
+            )
+            raise ValueError(msg)
+        return codepoint
 
     def _normalize_index(self, idx: SupportsIndex) -> int:
         """Resolve one dataset index, including negative indices."""


### PR DESCRIPTION
## Summary
- validate `GlyphDataset(codepoints=...)` against Unicode scalar boundaries before native initialization
- reject negative, out-of-range, and surrogate codepoints with consistent `ValueError`s
- add regression tests and dataset reference docs for the constructor contract

Closes #107

## Validation
- `mise run format`
- `uv run pytest tests/test_dataset.py -q`
- `mise run check`
- `mise run test`
- `mise exec -- npm run docs:build`
