### PR TITLE
fix: validate collate sample shapes

### DIFF
--- a/docs/en/reference/utils.md
+++ b/docs/en/reference/utils.md
@@ -35,6 +35,7 @@ collate_fn(batch: Sequence[GlyphSample]) -> GlyphBatch
 Pads the leading variable-length sequence dimension to the longest sample in the
 batch and returns a `GlyphBatch`.
 
+- `batch` must be non-empty; empty input raises `ValueError`
 - all samples in `batch` must share the same trailing `types.shape[1:]` and
   `coords.shape[1:]`; incompatible layouts raise `ValueError`
 

--- a/docs/ja/reference/utils.md
+++ b/docs/ja/reference/utils.md
@@ -35,6 +35,7 @@ collate_fn(batch: Sequence[GlyphSample]) -> GlyphBatch
 可変長 glyph sample の先頭シーケンス次元だけを batch 内最長に合わせて
 padding し、`GlyphBatch` を返します。
 
+- `batch` は非空である必要があり、空入力では `ValueError` を送出します。
 - `batch` 内の sample は `types.shape[1:]` と `coords.shape[1:]` を
   そろえる必要があり、互換性のない layout は `ValueError` を送出します。
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -120,6 +120,11 @@ def test_collate_fn_preserves_trailing_patch_dimensions() -> None:
     assert glyph_batch.coords.shape[2:] == (4, 6)
 
 
+def test_collate_fn_rejects_empty_batch() -> None:
+    with pytest.raises(ValueError, match="batch must be non-empty"):
+        collate_fn([])
+
+
 def test_collate_fn_rejects_incompatible_trailing_types_shapes() -> None:
     samples = [
         GlyphSample(
@@ -160,21 +165,29 @@ def test_collate_fn_rejects_incompatible_trailing_coords_shapes() -> None:
         collate_fn(samples)
 
 
-def test_collate_fn_rejects_zero_dim_types_tensor() -> None:
+def test_collate_fn_rejects_zero_dim_trailing_types_inputs() -> None:
     samples = [
-        GlyphSample(
-            types=torch.tensor([1, 2], dtype=torch.long),
-            coords=torch.zeros(2, 6),
-            style_idx=0,
-            content_idx=0,
-        ),
         GlyphSample(
             types=torch.tensor(1, dtype=torch.long),
             coords=torch.zeros(1, 6),
-            style_idx=1,
-            content_idx=1,
+            style_idx=0,
+            content_idx=0,
         ),
     ]
 
     with pytest.raises(ValueError, match="at least 1-D for 'types'"):
+        collate_fn(samples)
+
+
+def test_collate_fn_rejects_zero_dim_trailing_coords_inputs() -> None:
+    samples = [
+        GlyphSample(
+            types=torch.tensor([1], dtype=torch.long),
+            coords=torch.tensor(0.0),
+            style_idx=0,
+            content_idx=0,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="at least 1-D for 'coords'"):
         collate_fn(samples)

--- a/torchfont/utils.py
+++ b/torchfont/utils.py
@@ -55,6 +55,7 @@ def _validate_trailing_shape(name: str, tensors: Sequence[Tensor]) -> None:
     if not tensors:
         return
 
+    # Require at least one leading sequence dimension for every tensor.
     for idx, tensor in enumerate(tensors):
         if tensor.ndim < 1:
             msg = (
@@ -101,6 +102,10 @@ def collate_fn(
             loader = DataLoader(dataset, batch_size=32, collate_fn=collate_fn)
 
     """
+    if not batch:
+        msg = "batch must be non-empty"
+        raise ValueError(msg)
+
     types_list = [sample.types for sample in batch]
     coords_list = [sample.coords for sample in batch]
     style_label_list = [sample.style_idx for sample in batch]


### PR DESCRIPTION
- [x] Fix docs/ja/reference/utils.md sentence (done in 5ebed96)
- [x] Fix test_collate_fn_rejects_incompatible_trailing_types_shapes to keep coords compatible (done in 5ebed96)
- [x] Add `tensor.ndim >= 1` validation in `_validate_trailing_shape()` with descriptive comment
- [x] Add regression tests for 0-D types and coords tensors (`test_collate_fn_rejects_zero_dim_trailing_types_inputs`, `test_collate_fn_rejects_zero_dim_trailing_coords_inputs`)