### PR TITLE
fix: validate malformed LimitSequenceLength inputs

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -51,8 +51,14 @@ Returns a `GlyphSample` whose `types` and `coords` are truncated to `max_len`.
 
 ### I/O shape (`LimitSequenceLength`)
 
-- input: `types=(seq_len,)`, `coords=(seq_len, d)`
-- output: `types=(min(seq_len, max_len),)`, `coords=(min(seq_len, max_len), d)`
+- input: `types=(seq_len,)`, `coords=(seq_len, 6)`
+- output: `types=(min(seq_len, max_len),)`, `coords=(min(seq_len, max_len), 6)`
+
+### Notes
+
+- malformed input samples also raise `ValueError`; `LimitSequenceLength`
+  expects untruncated tensors with `types.ndim == 1`, `coords.ndim == 2`,
+  `coords.shape[1] == 6`, and aligned leading sequence lengths
 
 ---
 

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -50,8 +50,14 @@ LimitSequenceLength(max_len: int)
 
 ### 入出力（`LimitSequenceLength`）
 
-- 入力: `types=(seq_len,)`, `coords=(seq_len, d)`
-- 出力: `types=(min(seq_len, max_len),)`, `coords=(min(seq_len, max_len), d)`
+- 入力: `types=(seq_len,)`, `coords=(seq_len, 6)`
+- 出力: `types=(min(seq_len, max_len),)`, `coords=(min(seq_len, max_len), 6)`
+
+### 備考
+
+- malformed な入力 sample も `ValueError` になり、`LimitSequenceLength` は
+  未切り詰めの `types.ndim == 1`、`coords.ndim == 2`、`coords.shape[1] == 6`、
+  および先頭シーケンス長の一致を前提にします
 
 ---
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -182,6 +182,58 @@ def test_transform_constructors_validate_invalid_arguments(
                 style_idx=0,
                 content_idx=0,
             ),
+            r"LimitSequenceLength expects types\.ndim == 1; got 0",
+        ),
+        (
+            GlyphSample(
+                types=torch.tensor([1, 2], dtype=torch.long),
+                coords=torch.zeros(2),
+                style_idx=0,
+                content_idx=0,
+            ),
+            r"LimitSequenceLength expects coords\.ndim == 2; got 1",
+        ),
+        (
+            GlyphSample(
+                types=torch.tensor([1, 2], dtype=torch.long),
+                coords=torch.zeros(2, 5),
+                style_idx=0,
+                content_idx=0,
+            ),
+            r"LimitSequenceLength expects coords\.shape\[1\] == 6; got 5",
+        ),
+        (
+            GlyphSample(
+                types=torch.tensor([1, 2], dtype=torch.long),
+                coords=torch.zeros(3, 6),
+                style_idx=0,
+                content_idx=0,
+            ),
+            (
+                r"LimitSequenceLength expects types\.shape\[0\] and "
+                r"coords\.shape\[0\] to match; got 2 and 3"
+            ),
+        ),
+    ],
+)
+def test_limit_sequence_length_rejects_malformed_samples(
+    sample: GlyphSample,
+    expected_message: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        LimitSequenceLength(2)(sample)
+
+
+@pytest.mark.parametrize(
+    ("sample", "expected_message"),
+    [
+        (
+            GlyphSample(
+                types=torch.tensor(1, dtype=torch.long),
+                coords=torch.zeros(1, 6),
+                style_idx=0,
+                content_idx=0,
+            ),
             r"Patchify expects types\.ndim == 1; got 0",
         ),
         (

--- a/torchfont/transforms.py
+++ b/torchfont/transforms.py
@@ -103,6 +103,38 @@ class LimitSequenceLength:
             raise ValueError(msg)
         self.max_len = max_len
 
+    @staticmethod
+    def _validate_sample(sample: GlyphSample) -> None:
+        """Validate the untruncated sample contract required by the transform."""
+        expected_types_ndim = 1
+        expected_coords_ndim = 2
+
+        if sample.types.ndim != expected_types_ndim:
+            msg = (
+                f"LimitSequenceLength expects types.ndim == "
+                f"{expected_types_ndim}; got {sample.types.ndim}"
+            )
+            raise ValueError(msg)
+        if sample.coords.ndim != expected_coords_ndim:
+            msg = (
+                f"LimitSequenceLength expects coords.ndim == "
+                f"{expected_coords_ndim}; got {sample.coords.ndim}"
+            )
+            raise ValueError(msg)
+        if sample.coords.shape[1] != COORD_DIM:
+            msg = (
+                f"LimitSequenceLength expects coords.shape[1] == {COORD_DIM}; "
+                f"got {sample.coords.shape[1]}"
+            )
+            raise ValueError(msg)
+        if sample.types.shape[0] != sample.coords.shape[0]:
+            msg = (
+                "LimitSequenceLength expects types.shape[0] and "
+                "coords.shape[0] to match; "
+                f"got {sample.types.shape[0]} and {sample.coords.shape[0]}"
+            )
+            raise ValueError(msg)
+
     def __call__(self, sample: GlyphSample) -> GlyphSample:
         """Clip the sequence and coordinate tensors to the specified length.
 
@@ -123,6 +155,7 @@ class LimitSequenceLength:
                 sample = LimitSequenceLength(128)(sample)
 
         """
+        self._validate_sample(sample)
         sample_type = type(sample)
         return sample_type(
             types=sample.types[: self.max_len],


### PR DESCRIPTION
## Summary
- validate malformed `LimitSequenceLength` samples eagerly before slicing
- add regression coverage for rank, coord-width, and leading-length contract violations
- align the English and Japanese transform docs with the stricter public contract

Closes #119

## Verification
- `mise run format`
- `uv run pytest tests/test_transforms.py -q`
- `mise run check`
- `mise exec -- uv run maturin develop`
- `mise run test`
- `mise run docs-build`