### PR TITLE
[codex] Avoid metadata overhead for content classes

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -784,19 +784,6 @@ def test_targets_empty_dataset() -> None:
     assert dataset.targets.dtype == torch.long
 
 
-def test_targets_are_cached() -> None:
-    dataset = GlyphDataset(
-        root="tests/fonts",
-        patterns=("lato/Lato-Regular.ttf",),
-        codepoints=range(0x41, 0x44),
-    )
-
-    first = dataset.targets
-    second = dataset.targets
-
-    assert second is first
-
-
 def test_targets_variable_fonts() -> None:
     """Test that targets is correct for variable fonts with multiple instances."""
     dataset = GlyphDataset(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -784,6 +784,19 @@ def test_targets_empty_dataset() -> None:
     assert dataset.targets.dtype == torch.long
 
 
+def test_targets_are_cached() -> None:
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("lato/Lato-Regular.ttf",),
+        codepoints=range(0x41, 0x44),
+    )
+
+    first = dataset.targets
+    second = dataset.targets
+
+    assert second is first
+
+
 def test_targets_variable_fonts() -> None:
     """Test that targets is correct for variable fonts with multiple instances."""
     dataset = GlyphDataset(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -508,6 +508,34 @@ def test_content_class_to_idx() -> None:
         assert dataset.content_class_to_idx[char] == idx
 
 
+def test_content_classes_do_not_materialize_metadata() -> None:
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("lato/Lato-Regular.ttf",),
+        codepoints=range(0x41, 0x44),
+    )
+
+    with patch.object(GlyphDataset, "metadata", new_callable=PropertyMock) as metadata:
+        metadata.side_effect = AssertionError(
+            "content_classes should not materialize metadata"
+        )
+        assert dataset.content_classes == ["A", "B", "C"]
+
+
+def test_content_class_to_idx_does_not_materialize_metadata() -> None:
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("lato/Lato-Regular.ttf",),
+        codepoints=range(0x41, 0x44),
+    )
+
+    with patch.object(GlyphDataset, "metadata", new_callable=PropertyMock) as metadata:
+        metadata.side_effect = AssertionError(
+            "content_class_to_idx should not materialize metadata"
+        )
+        assert dataset.content_class_to_idx == {"A": 0, "B": 1, "C": 2}
+
+
 def test_style_classes() -> None:
     """Test style_classes returns descriptive names."""
     dataset = GlyphDataset(

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -191,6 +191,7 @@ class GlyphDataset(Dataset[GlyphSample]):
             self.patterns,
         )
         self._metadata: DatasetMetadata | None = None
+        self._targets: Tensor | None = None
 
     def __repr__(self) -> str:
         """Return a human-readable summary of this dataset.
@@ -221,6 +222,7 @@ class GlyphDataset(Dataset[GlyphSample]):
         """Return state without the native backend for worker reconstruction."""
         state = self.__dict__.copy()
         state.pop("_dataset", None)
+        state.pop("_targets", None)
         return state
 
     def __setstate__(self, state: dict[str, object]) -> None:
@@ -234,6 +236,8 @@ class GlyphDataset(Dataset[GlyphSample]):
         )
         if not hasattr(self, "_metadata"):
             self._metadata = None
+        if not hasattr(self, "_targets"):
+            self._targets = None
 
     @staticmethod
     def _validate_root_dir(root: Path) -> None:
@@ -383,10 +387,15 @@ class GlyphDataset(Dataset[GlyphSample]):
             tensor([style_idx, content_idx])
 
         """
-        raw = self._dataset.targets()
-        if not raw:
-            return torch.empty(0, 2, dtype=torch.long)
-        return torch.frombuffer(bytearray(raw), dtype=torch.long).view(-1, 2)
+        if self._targets is None:
+            raw = self._dataset.targets()
+            if not raw:
+                self._targets = torch.empty(0, 2, dtype=torch.long)
+            else:
+                self._targets = torch.frombuffer(bytearray(raw), dtype=torch.long).view(
+                    -1, 2
+                )
+        return self._targets
 
     @property
     def content_classes(self) -> list[str]:

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -407,7 +407,7 @@ class GlyphDataset(Dataset[GlyphSample]):
             ['A', 'B', 'C']
 
         """
-        return [label.char for label in self.metadata.contents]
+        return [chr(codepoint) for codepoint in self._dataset.content_classes]
 
     @property
     def content_class_to_idx(self) -> dict[str, int]:
@@ -421,7 +421,7 @@ class GlyphDataset(Dataset[GlyphSample]):
             0
 
         """
-        return {label.char: label.idx for label in self.metadata.contents}
+        return {char: idx for idx, char in enumerate(self.content_classes)}
 
     def _style_sources(self) -> list[tuple[Path, int, int | None]]:
         """Return style source tuples aligned with ``style_classes`` order."""

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -191,7 +191,6 @@ class GlyphDataset(Dataset[GlyphSample]):
             self.patterns,
         )
         self._metadata: DatasetMetadata | None = None
-        self._targets: Tensor | None = None
 
     def __repr__(self) -> str:
         """Return a human-readable summary of this dataset.
@@ -222,7 +221,6 @@ class GlyphDataset(Dataset[GlyphSample]):
         """Return state without the native backend for worker reconstruction."""
         state = self.__dict__.copy()
         state.pop("_dataset", None)
-        state.pop("_targets", None)
         return state
 
     def __setstate__(self, state: dict[str, object]) -> None:
@@ -236,8 +234,6 @@ class GlyphDataset(Dataset[GlyphSample]):
         )
         if not hasattr(self, "_metadata"):
             self._metadata = None
-        if not hasattr(self, "_targets"):
-            self._targets = None
 
     @staticmethod
     def _validate_root_dir(root: Path) -> None:
@@ -387,15 +383,10 @@ class GlyphDataset(Dataset[GlyphSample]):
             tensor([style_idx, content_idx])
 
         """
-        if self._targets is None:
-            raw = self._dataset.targets()
-            if not raw:
-                self._targets = torch.empty(0, 2, dtype=torch.long)
-            else:
-                self._targets = torch.frombuffer(bytearray(raw), dtype=torch.long).view(
-                    -1, 2
-                )
-        return self._targets
+        raw = self._dataset.targets()
+        if not raw:
+            return torch.empty(0, 2, dtype=torch.long)
+        return torch.frombuffer(bytearray(raw), dtype=torch.long).view(-1, 2)
 
     @property
     def content_classes(self) -> list[str]:


### PR DESCRIPTION
## Summary
- stop routing `content_classes` through full `DatasetMetadata` construction
- derive `content_class_to_idx` from the same direct native codepoint view
- keep these lightweight dataset views stateless on the Python side

## Why
Issue #129 called out dataset initialization and first-use performance regressions after more metadata assembly moved to Python.

The key cheap-path regression here was that `content_classes` and `content_class_to_idx` forced full `DatasetMetadata` construction even when callers only wanted simple content-label views.

This PR fixes that direct-path regression without adding another Python-side cache. `targets` stays stateless here; the native-side materialization cleanup lives separately in #136.

## Validation
- `mise run format`
- `mise run check`
- `mise run test`

Closes #129
