### PR TITLE
[codex] Make dataset metadata stateless

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -584,6 +584,21 @@ def test_dataset_metadata_does_not_add_python_cache_state() -> None:
     assert first is not second
 
 
+def test_unpickling_drops_legacy_metadata_cache_state() -> None:
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("lato/Lato-Regular.ttf",),
+        codepoints=range(0x41, 0x44),
+    )
+
+    state = dataset.__getstate__()
+    state["_metadata"] = "legacy-cache"
+
+    dataset.__setstate__(state)
+
+    assert "_metadata" not in dataset.__dict__
+
+
 def test_style_label_metadata_handles_duplicate_names() -> None:
     """Test duplicate style names are preserved in collision-safe metadata."""
     dataset = GlyphDataset(

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -224,6 +224,7 @@ class GlyphDataset(Dataset[GlyphSample]):
 
     def __setstate__(self, state: dict[str, object]) -> None:
         """Restore state and recreate the native backend after unpickling."""
+        state.pop("_metadata", None)
         self.__dict__.update(state)
         self._validate_root_dir(self.root)
         self._dataset = _torchfont.FontDataset(


### PR DESCRIPTION
## Summary
- remove the Python-side `_metadata` cache from `GlyphDataset`
- build `DatasetMetadata` directly on each `metadata` access
- add a regression test that metadata reads do not add Python cache state

Closes #138.
Part of #137.

## Why
The library-wide direction in #137 is to keep implementations as stateless and thin as practical.

On current `main`, one of the few remaining explicit Python-side state fields in `GlyphDataset` was `_metadata`. That cache slightly complicated the object and its pickle path, but the rebuild cost is small on the repository corpus, so keeping the extra state around is not buying much.

This PR makes `metadata` a straightforward derived view again and keeps `GlyphDataset` thinner.

## Validation
- `mise run format`
- `mise run check`
- `mise run test`
- local check on `tests/fonts`: repeated `dataset.metadata` rebuilds are still sub-millisecond (`~0.00067s` mean)
