### PR TITLE
[codex] Feed metadata from native style rows

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -59,46 +59,47 @@ impl FontDataset {
 
     #[getter]
     pub fn style_classes(&self) -> Vec<String> {
-        let mut names = Vec::new();
-        for entry in self.entries.iter() {
-            let family_name = entry.family_name();
-            if entry.is_variable() {
-                let instance_names = entry.named_instance_names();
-                if instance_names.is_empty() {
-                    if let Some(subfamily) = entry.subfamily_name() {
-                        names.push(format!("{family_name} {subfamily}"));
-                    } else {
-                        names.push(family_name);
-                    }
-                } else {
-                    for name_opt in instance_names.iter() {
-                        let instance_name = name_opt.as_deref().unwrap_or("");
-                        if instance_name.is_empty() {
-                            names.push(family_name.clone());
-                        } else {
-                            names.push(format!("{family_name} {instance_name}"));
-                        }
-                    }
-                }
-            } else if let Some(subfamily) = entry.subfamily_name() {
-                names.push(format!("{family_name} {subfamily}"));
-            } else {
-                names.push(family_name);
-            }
-        }
-        names
+        self.style_rows()
+            .into_iter()
+            .map(|(name, _, _, _)| name)
+            .collect()
     }
 
     #[getter]
-    pub fn style_sources(&self) -> Vec<(String, u32, Option<usize>)> {
-        let mut sources = Vec::new();
+    pub fn style_rows(&self) -> Vec<(String, String, u32, Option<usize>)> {
+        let mut rows = Vec::new();
         for entry in self.entries.iter() {
-            for inst_idx in 0..entry.instance_count() {
-                let instance = entry.is_variable().then_some(inst_idx);
-                sources.push((entry.path().to_owned(), entry.face_index(), instance));
+            let path = entry.path().to_owned();
+            let face_idx = entry.face_index();
+            let family_name = entry.family_name();
+
+            if entry.is_variable() {
+                let instance_names = entry.named_instance_names();
+                if instance_names.is_empty() {
+                    let display_name = if let Some(subfamily) = entry.subfamily_name() {
+                        format!("{family_name} {subfamily}")
+                    } else {
+                        family_name
+                    };
+                    rows.push((display_name, path, face_idx, None));
+                } else {
+                    for (inst_idx, name_opt) in instance_names.iter().enumerate() {
+                        let instance_name = name_opt.as_deref().unwrap_or("");
+                        let display_name = if instance_name.is_empty() {
+                            family_name.clone()
+                        } else {
+                            format!("{family_name} {instance_name}")
+                        };
+                        rows.push((display_name, path.clone(), face_idx, Some(inst_idx)));
+                    }
+                }
+            } else if let Some(subfamily) = entry.subfamily_name() {
+                rows.push((format!("{family_name} {subfamily}"), path, face_idx, None));
+            } else {
+                rows.push((family_name, path, face_idx, None));
             }
         }
-        sources
+        rows
     }
 
     pub fn locate(&self, idx: usize) -> PyResult<(String, u32, Option<usize>, u32, usize, usize)> {

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -648,24 +648,6 @@ def test_style_label_metadata_handles_duplicate_names() -> None:
     assert metadata.style_name_to_idxs["Unique"] == (1,)
 
 
-def test_dataset_metadata_handles_duplicate_names() -> None:
-    """DatasetMetadata preserves all indices for duplicate style names."""
-    root = Path("tests/fonts").resolve()
-    metadata = build_dataset_metadata(
-        root=root,
-        style_rows=[
-            ("Shared", root / "lato/Lato-Regular.ttf", 0, None),
-            ("Unique", root / "roboto/Roboto[wdth,wght].ttf", 0, 0),
-            ("Shared", root / "roboto/Roboto[wdth,wght].ttf", 0, 1),
-        ],
-        content_codepoints=[ord("A"), ord("B"), ord("C")],
-    )
-
-    assert len({label.label_id for label in metadata.styles}) == 3
-    assert metadata.style_name_to_idxs["Shared"] == (0, 2)
-    assert metadata.style_name_to_idxs["Unique"] == (1,)
-
-
 def test_build_dataset_metadata_rejects_style_row_outside_root() -> None:
     root = Path("tests/fonts").resolve()
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -599,33 +599,49 @@ def test_dataset_metadata_does_not_add_python_cache_state() -> None:
     assert first is not second
 
 
-def test_style_label_metadata_handles_duplicate_names() -> None:
-    """Test duplicate style names are preserved in collision-safe metadata."""
+def test_dataset_metadata_does_not_route_through_python_projections() -> None:
     dataset = GlyphDataset(
         root="tests/fonts",
         patterns=("lato/Lato-Regular.ttf",),
         codepoints=range(0x41, 0x44),
     )
 
-    raw_names = ["Shared", "Unique", "Shared"]
     with (
         patch.object(
             GlyphDataset,
             "style_classes",
             new_callable=PropertyMock,
-            return_value=raw_names,
-        ),
+        ) as style_classes,
         patch.object(
             GlyphDataset,
-            "_style_sources",
-            return_value=[
-                (dataset.root / "lato/Lato-Regular.ttf", 0, None),
-                (dataset.root / "roboto/Roboto[wdth,wght].ttf", 0, 0),
-                (dataset.root / "roboto/Roboto[wdth,wght].ttf", 0, 1),
-            ],
-        ),
+            "content_classes",
+            new_callable=PropertyMock,
+        ) as content_classes,
     ):
+        style_classes.side_effect = AssertionError(
+            "metadata should not materialize style_classes",
+        )
+        content_classes.side_effect = AssertionError(
+            "metadata should not materialize content_classes",
+        )
         metadata = dataset.metadata
+
+    assert metadata.styles
+    assert metadata.contents
+
+
+def test_style_label_metadata_handles_duplicate_names() -> None:
+    """Test duplicate style names are preserved in collision-safe metadata."""
+    root = Path("tests/fonts").resolve()
+    metadata = build_dataset_metadata(
+        root=root,
+        style_rows=[
+            ("Shared", root / "lato/Lato-Regular.ttf", 0, None),
+            ("Unique", root / "roboto/Roboto[wdth,wght].ttf", 0, 0),
+            ("Shared", root / "roboto/Roboto[wdth,wght].ttf", 0, 1),
+        ],
+        content_codepoints=[ord("A"), ord("B"), ord("C")],
+    )
 
     assert len({label.label_id for label in metadata.styles}) == 3
     assert metadata.style_name_to_idxs["Shared"] == (0, 2)
@@ -634,52 +650,31 @@ def test_style_label_metadata_handles_duplicate_names() -> None:
 
 def test_dataset_metadata_handles_duplicate_names() -> None:
     """DatasetMetadata preserves all indices for duplicate style names."""
-    dataset = GlyphDataset(
-        root="tests/fonts",
-        patterns=("lato/Lato-Regular.ttf",),
-        codepoints=range(0x41, 0x44),
+    root = Path("tests/fonts").resolve()
+    metadata = build_dataset_metadata(
+        root=root,
+        style_rows=[
+            ("Shared", root / "lato/Lato-Regular.ttf", 0, None),
+            ("Unique", root / "roboto/Roboto[wdth,wght].ttf", 0, 0),
+            ("Shared", root / "roboto/Roboto[wdth,wght].ttf", 0, 1),
+        ],
+        content_codepoints=[ord("A"), ord("B"), ord("C")],
     )
-
-    raw_names = ["Shared", "Unique", "Shared"]
-    with (
-        patch.object(
-            GlyphDataset,
-            "style_classes",
-            new_callable=PropertyMock,
-            return_value=raw_names,
-        ),
-        patch.object(
-            GlyphDataset,
-            "_style_sources",
-            return_value=[
-                (dataset.root / "lato/Lato-Regular.ttf", 0, None),
-                (dataset.root / "roboto/Roboto[wdth,wght].ttf", 0, 0),
-                (dataset.root / "roboto/Roboto[wdth,wght].ttf", 0, 1),
-            ],
-        ),
-    ):
-        metadata = dataset.metadata
 
     assert len({label.label_id for label in metadata.styles}) == 3
     assert metadata.style_name_to_idxs["Shared"] == (0, 2)
     assert metadata.style_name_to_idxs["Unique"] == (1,)
 
 
-def test_build_dataset_metadata_rejects_mismatched_style_inputs() -> None:
-    dataset = GlyphDataset(
-        root="tests/fonts",
-        patterns=("lato/Lato-Regular.ttf",),
-        codepoints=range(0x41, 0x44),
-    )
+def test_build_dataset_metadata_rejects_style_row_outside_root() -> None:
+    root = Path("tests/fonts").resolve()
 
-    with pytest.raises(
-        ValueError,
-        match="style_names and style_sources must have the same length",
-    ):
+    with pytest.raises(ValueError, match="is not under dataset root"):
         build_dataset_metadata(
-            root=dataset.root,
-            style_names=["Lato Regular"],
-            style_sources=[],
+            root=root,
+            style_rows=[
+                ("Outside", root.parent / "outside.ttf", 0, None),
+            ],
             content_codepoints=[ord("A")],
         )
 

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -15,7 +15,7 @@ class FontDataset:
     content_classes: list[int]
 
     style_classes: list[str]
-    style_sources: list[tuple[str, int, int | None]]
+    style_rows: list[tuple[str, str, int, int | None]]
 
     def item(
         self,

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -19,7 +19,7 @@ Examples:
 from collections.abc import Callable, Sequence
 from operator import index
 from pathlib import Path
-from typing import NamedTuple, SupportsIndex
+from typing import NamedTuple, SupportsIndex, cast
 
 import torch
 from torch import Tensor
@@ -31,6 +31,7 @@ from torchfont.metadata import (
     ContentLabel,
     DatasetMetadata,
     StyleLabel,
+    StyleMetadataRow,
     build_dataset_metadata,
 )
 
@@ -410,24 +411,12 @@ class GlyphDataset(Dataset[GlyphSample]):
         """
         return {label.char: label.idx for label in self.metadata.contents}
 
-    def _style_sources(self) -> list[tuple[Path, int, int | None]]:
-        """Return style source tuples aligned with ``style_classes`` order."""
-        return [
-            (
-                Path(font_path),
-                int(face_idx),
-                None if instance_idx is None else int(instance_idx),
-            )
-            for font_path, face_idx, instance_idx in self._dataset.style_sources
-        ]
-
     @property
     def metadata(self) -> DatasetMetadata:
         """Structured style/content metadata for this dataset."""
         return build_dataset_metadata(
             root=self.root,
-            style_names=self.style_classes,
-            style_sources=self._style_sources(),
+            style_rows=cast("list[StyleMetadataRow]", self._dataset.style_rows),
             content_codepoints=self._dataset.content_classes,
         )
 

--- a/torchfont/metadata.py
+++ b/torchfont/metadata.py
@@ -45,10 +45,12 @@ class DatasetMetadata(NamedTuple):
     content_id_to_idx: dict[str, int]
 
 
+StyleMetadataRow = tuple[str, str | Path, int, int | None]
+
+
 def build_dataset_metadata(
     root: Path,
-    style_names: list[str],
-    style_sources: list[tuple[Path, int, int | None]],
+    style_rows: list[StyleMetadataRow],
     content_codepoints: list[int],
 ) -> DatasetMetadata:
     """Build a DatasetMetadata object for a glyph dataset.
@@ -56,18 +58,16 @@ def build_dataset_metadata(
     This constructs style and content label entries and their lookup tables.
     Style ``label_id`` values are derived from the underlying font file
     locations (relative to ``root``) and the ``(face_idx, instance_idx)``
-    values in ``style_sources``, via :func:`_style_label_id`.
+    values in ``style_rows``, via :func:`_style_label_id`.
 
     Args:
         root: Common root directory used to relativize font paths when
             constructing stable style ``label_id`` values.  Every font path
-            in ``style_sources`` must be located inside ``root``; a
+            in ``style_rows`` must be located inside ``root``; a
             ``ValueError`` is raised if any path falls outside it.
-        style_names: Human-readable display names for each style.  Must have
-            the same length and order as ``style_sources``.
-        style_sources: Triples of ``(font_path, face_idx, instance_idx)`` that
-            identify the concrete font source corresponding to each style
-            name.  ``instance_idx`` is ``None`` for static faces.
+        style_rows: Tuples of ``(name, font_path, face_idx, instance_idx)``
+            aligned to the dataset's style indices. ``instance_idx`` is
+            ``None`` for static faces.
         content_codepoints: Unicode code points to turn into ``ContentLabel``
             entries.
 
@@ -76,24 +76,22 @@ def build_dataset_metadata(
         entries and their associated lookup dictionaries.
 
     Raises:
-        ValueError: If ``style_names`` and ``style_sources`` have different
-            lengths, or if any font path in ``style_sources`` is not located
-            under ``root``.
+        ValueError: If any font path in ``style_rows`` is not located under
+            ``root``.
 
     """
-    try:
-        paired_styles = tuple(zip(style_names, style_sources, strict=True))
-    except ValueError:
-        msg = "style_names and style_sources must have the same length"
-        raise ValueError(msg) from None
-
     styles = tuple(
         StyleLabel(
             idx=idx,
-            label_id=_style_label_id(root, font_path, face_idx, instance_idx),
+            label_id=_style_label_id(
+                root,
+                Path(font_path),
+                face_idx,
+                instance_idx,
+            ),
             name=name,
         )
-        for idx, (name, (font_path, face_idx, instance_idx)) in enumerate(paired_styles)
+        for idx, (name, font_path, face_idx, instance_idx) in enumerate(style_rows)
     )
     contents = tuple(
         ContentLabel(


### PR DESCRIPTION
- [x] expose `style_rows` getter from Rust backend (replaces `style_classes` + `style_sources`)
- [x] `style_classes` delegates to `style_rows` for single source of truth
- [x] `build_dataset_metadata` accepts unified `style_rows: list[StyleMetadataRow]` input
- [x] `GlyphDataset.metadata` routes through native rows via `cast`
- [x] add `test_dataset_metadata_does_not_route_through_python_projections` regression test
- [x] remove duplicate `test_dataset_metadata_handles_duplicate_names` (identical body to `test_style_label_metadata_handles_duplicate_names` after refactor)