### PR TITLE
[codex] Build style label ids in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "pyo3",
  "shellexpand",
  "skrifa",
+ "urlencoding",
  "walkdir",
 ]
 
@@ -434,6 +435,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ ignore = "0.4.25"
 memmap2 = "0.9.10"
 shellexpand = "3.1.2"
 skrifa = "0.41.0"
+urlencoding = "2.1.3"
 walkdir = "2.5.0"
 
 [dependencies.pyo3]

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -9,6 +9,7 @@ use index::{DatasetIndex, load_entries_and_index};
 use io::{canonicalize_root, discover_font_files};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+use std::path::Path;
 
 #[pyclass]
 pub struct FontDataset {
@@ -65,41 +66,17 @@ impl FontDataset {
             .collect()
     }
 
-    #[getter]
-    pub fn style_rows(&self) -> Vec<(String, String, u32, Option<usize>)> {
-        let mut rows = Vec::new();
-        for entry in self.entries.iter() {
-            let path = entry.path().to_owned();
-            let face_idx = entry.face_index();
-            let family_name = entry.family_name();
-
-            if entry.is_variable() {
-                let instance_names = entry.named_instance_names();
-                if instance_names.is_empty() {
-                    let display_name = if let Some(subfamily) = entry.subfamily_name() {
-                        format!("{family_name} {subfamily}")
-                    } else {
-                        family_name
-                    };
-                    rows.push((display_name, path, face_idx, None));
-                } else {
-                    for (inst_idx, name_opt) in instance_names.iter().enumerate() {
-                        let instance_name = name_opt.as_deref().unwrap_or("");
-                        let display_name = if instance_name.is_empty() {
-                            family_name.clone()
-                        } else {
-                            format!("{family_name} {instance_name}")
-                        };
-                        rows.push((display_name, path.clone(), face_idx, Some(inst_idx)));
-                    }
-                }
-            } else if let Some(subfamily) = entry.subfamily_name() {
-                rows.push((format!("{family_name} {subfamily}"), path, face_idx, None));
-            } else {
-                rows.push((family_name, path, face_idx, None));
-            }
-        }
-        rows
+    pub fn style_metadata_rows(&self, root: String) -> PyResult<Vec<(String, String)>> {
+        let root_path = Path::new(&root);
+        self.style_rows()
+            .into_iter()
+            .map(|(name, path, face_idx, instance_idx)| {
+                Ok((
+                    name,
+                    style_label_id(root_path, Path::new(&path), face_idx, instance_idx)?,
+                ))
+            })
+            .collect()
     }
 
     pub fn locate(&self, idx: usize) -> PyResult<(String, u32, Option<usize>, u32, usize, usize)> {
@@ -142,6 +119,42 @@ impl FontDataset {
 }
 
 impl FontDataset {
+    fn style_rows(&self) -> Vec<(String, String, u32, Option<usize>)> {
+        let mut rows = Vec::new();
+        for entry in self.entries.iter() {
+            let path = entry.path().to_owned();
+            let face_idx = entry.face_index();
+            let family_name = entry.family_name();
+
+            if entry.is_variable() {
+                let instance_names = entry.named_instance_names();
+                if instance_names.is_empty() {
+                    let display_name = if let Some(subfamily) = entry.subfamily_name() {
+                        format!("{family_name} {subfamily}")
+                    } else {
+                        family_name
+                    };
+                    rows.push((display_name, path, face_idx, None));
+                } else {
+                    for (inst_idx, name_opt) in instance_names.iter().enumerate() {
+                        let instance_name = name_opt.as_deref().unwrap_or("");
+                        let display_name = if instance_name.is_empty() {
+                            family_name.clone()
+                        } else {
+                            format!("{family_name} {instance_name}")
+                        };
+                        rows.push((display_name, path.clone(), face_idx, Some(inst_idx)));
+                    }
+                }
+            } else if let Some(subfamily) = entry.subfamily_name() {
+                rows.push((format!("{family_name} {subfamily}"), path, face_idx, None));
+            } else {
+                rows.push((family_name, path, face_idx, None));
+            }
+        }
+        rows
+    }
+
     fn locate_parts(&self, idx: usize) -> PyResult<(usize, Option<usize>, u32, usize, usize)> {
         let total = self.sample_count();
         if idx >= total {
@@ -183,4 +196,28 @@ impl FontDataset {
 
         Ok((font_idx, instance, cp, style_idx, content_idx))
     }
+}
+
+fn style_label_id(
+    root: &Path,
+    font_path: &Path,
+    face_idx: u32,
+    instance_idx: Option<usize>,
+) -> PyResult<String> {
+    let relative_path = font_path.strip_prefix(root).map_err(|_| {
+        crate::error::py_err(format!(
+            "font path '{}' is not under dataset root '{}'",
+            font_path.display(),
+            root.display()
+        ))
+    })?;
+    let quoted_path = relative_path
+        .components()
+        .map(|component| urlencoding::encode(&component.as_os_str().to_string_lossy()).into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    let instance_value = instance_idx.map_or_else(|| "static".to_string(), |idx| idx.to_string());
+    Ok(format!(
+        "style:path={quoted_path};face={face_idx};instance={instance_value}"
+    ))
 }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -632,13 +632,17 @@ def test_dataset_metadata_does_not_route_through_python_projections() -> None:
 
 def test_style_label_metadata_handles_duplicate_names() -> None:
     """Test duplicate style names are preserved in collision-safe metadata."""
-    root = Path("tests/fonts").resolve()
     metadata = build_dataset_metadata(
-        root=root,
         style_rows=[
-            ("Shared", root / "lato/Lato-Regular.ttf", 0, None),
-            ("Unique", root / "roboto/Roboto[wdth,wght].ttf", 0, 0),
-            ("Shared", root / "roboto/Roboto[wdth,wght].ttf", 0, 1),
+            ("Shared", "style:path=lato/Lato-Regular.ttf;face=0;instance=static"),
+            (
+                "Unique",
+                "style:path=roboto/Roboto%5Bwdth%2Cwght%5D.ttf;face=0;instance=0",
+            ),
+            (
+                "Shared",
+                "style:path=roboto/Roboto%5Bwdth%2Cwght%5D.ttf;face=0;instance=1",
+            ),
         ],
         content_codepoints=[ord("A"), ord("B"), ord("C")],
     )
@@ -648,17 +652,17 @@ def test_style_label_metadata_handles_duplicate_names() -> None:
     assert metadata.style_name_to_idxs["Unique"] == (1,)
 
 
-def test_build_dataset_metadata_rejects_style_row_outside_root() -> None:
-    root = Path("tests/fonts").resolve()
+def test_build_dataset_metadata_uses_precomputed_style_label_ids() -> None:
+    metadata = build_dataset_metadata(
+        style_rows=[
+            ("Lato Regular", "style:path=lato/Lato-Regular.ttf;face=0;instance=static"),
+        ],
+        content_codepoints=[ord("A")],
+    )
 
-    with pytest.raises(ValueError, match="is not under dataset root"):
-        build_dataset_metadata(
-            root=root,
-            style_rows=[
-                ("Outside", root.parent / "outside.ttf", 0, None),
-            ],
-            content_codepoints=[ord("A")],
-        )
+    assert metadata.styles[0].label_id == (
+        "style:path=lato/Lato-Regular.ttf;face=0;instance=static"
+    )
 
 
 def test_style_label_ids_are_stable_across_codepoint_filters() -> None:

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -15,8 +15,7 @@ class FontDataset:
     content_classes: list[int]
 
     style_classes: list[str]
-    style_rows: list[tuple[str, str, int, int | None]]
-
+    def style_metadata_rows(self, root: str) -> list[tuple[str, str]]: ...
     def item(
         self,
         idx: int,

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -415,8 +415,10 @@ class GlyphDataset(Dataset[GlyphSample]):
     def metadata(self) -> DatasetMetadata:
         """Structured style/content metadata for this dataset."""
         return build_dataset_metadata(
-            root=self.root,
-            style_rows=cast("list[StyleMetadataRow]", self._dataset.style_rows),
+            style_rows=cast(
+                "list[StyleMetadataRow]",
+                self._dataset.style_metadata_rows(str(self.root)),
+            ),
             content_codepoints=self._dataset.content_classes,
         )
 

--- a/torchfont/metadata.py
+++ b/torchfont/metadata.py
@@ -1,8 +1,6 @@
 """Structured metadata objects for glyph datasets."""
 
-from pathlib import Path
 from typing import NamedTuple
-from urllib.parse import quote
 
 
 class StyleLabel(NamedTuple):
@@ -45,29 +43,21 @@ class DatasetMetadata(NamedTuple):
     content_id_to_idx: dict[str, int]
 
 
-StyleMetadataRow = tuple[str, str | Path, int, int | None]
+StyleMetadataRow = tuple[str, str]
 
 
 def build_dataset_metadata(
-    root: Path,
     style_rows: list[StyleMetadataRow],
     content_codepoints: list[int],
 ) -> DatasetMetadata:
     """Build a DatasetMetadata object for a glyph dataset.
 
     This constructs style and content label entries and their lookup tables.
-    Style ``label_id`` values are derived from the underlying font file
-    locations (relative to ``root``) and the ``(face_idx, instance_idx)``
-    values in ``style_rows``, via :func:`_style_label_id`.
+    Style rows already carry precomputed, collision-safe ``label_id`` values.
 
     Args:
-        root: Common root directory used to relativize font paths when
-            constructing stable style ``label_id`` values.  Every font path
-            in ``style_rows`` must be located inside ``root``; a
-            ``ValueError`` is raised if any path falls outside it.
-        style_rows: Tuples of ``(name, font_path, face_idx, instance_idx)``
-            aligned to the dataset's style indices. ``instance_idx`` is
-            ``None`` for static faces.
+        style_rows: Tuples of ``(name, label_id)`` aligned to the dataset's
+            style indices.
         content_codepoints: Unicode code points to turn into ``ContentLabel``
             entries.
 
@@ -75,23 +65,14 @@ def build_dataset_metadata(
         DatasetMetadata: Immutable metadata containing style and content label
         entries and their associated lookup dictionaries.
 
-    Raises:
-        ValueError: If any font path in ``style_rows`` is not located under
-            ``root``.
-
     """
     styles = tuple(
         StyleLabel(
             idx=idx,
-            label_id=_style_label_id(
-                root,
-                Path(font_path),
-                face_idx,
-                instance_idx,
-            ),
+            label_id=label_id,
             name=name,
         )
-        for idx, (name, font_path, face_idx, instance_idx) in enumerate(style_rows)
+        for idx, (name, label_id) in enumerate(style_rows)
     )
     contents = tuple(
         ContentLabel(
@@ -114,26 +95,3 @@ def build_dataset_metadata(
         style_name_to_idxs={name: tuple(idxs) for name, idxs in grouped_names.items()},
         content_id_to_idx={label.label_id: label.idx for label in contents},
     )
-
-
-def _style_label_id(
-    root: Path,
-    font_path: Path,
-    face_idx: int,
-    instance_idx: int | None,
-) -> str:
-    """Build a stable, source-based style label ID.
-
-    Raises:
-        ValueError: If ``font_path`` is not located under ``root``.
-
-    """
-    try:
-        relative_path = font_path.relative_to(root)
-    except ValueError:
-        msg = f"font path {font_path!r} is not under dataset root {root!r}"
-        raise ValueError(msg) from None
-
-    instance_value = "static" if instance_idx is None else str(instance_idx)
-    quoted_path = quote(relative_path.as_posix(), safe="/")
-    return f"style:path={quoted_path};face={face_idx};instance={instance_value}"


### PR DESCRIPTION
## Summary
- move style label-id construction from Python into the Rust dataset backend
- simplify `build_dataset_metadata(...)` so Python only assembles metadata objects from precomputed rows
- remove Python-side path quoting/root validation logic and update metadata tests

## Testing
- mise run format
- mise run check
- mise run test
