### PR TITLE
[codex] Build content metadata rows in Rust

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -53,6 +53,26 @@ impl FontDataset {
         self.index.content_classes.clone()
     }
 
+    pub fn content_metadata_rows(&self) -> PyResult<Vec<(String, String, u32)>> {
+        self.index
+            .content_classes
+            .iter()
+            .copied()
+            .map(|codepoint| {
+                let ch = char::from_u32(codepoint).ok_or_else(|| {
+                    crate::error::py_err(format!(
+                        "indexed codepoint U+{codepoint:04X} is not a Unicode scalar value"
+                    ))
+                })?;
+                Ok((
+                    format!("content:U+{codepoint:04X}"),
+                    ch.to_string(),
+                    codepoint,
+                ))
+            })
+            .collect()
+    }
+
     #[getter]
     pub fn style_class_count(&self) -> usize {
         self.index.inst_offsets.last().copied().unwrap_or(0)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -644,7 +644,11 @@ def test_style_label_metadata_handles_duplicate_names() -> None:
                 "style:path=roboto/Roboto%5Bwdth%2Cwght%5D.ttf;face=0;instance=1",
             ),
         ],
-        content_codepoints=[ord("A"), ord("B"), ord("C")],
+        content_rows=[
+            ("content:U+0041", "A", 0x41),
+            ("content:U+0042", "B", 0x42),
+            ("content:U+0043", "C", 0x43),
+        ],
     )
 
     assert len({label.label_id for label in metadata.styles}) == 3
@@ -657,12 +661,27 @@ def test_build_dataset_metadata_uses_precomputed_style_label_ids() -> None:
         style_rows=[
             ("Lato Regular", "style:path=lato/Lato-Regular.ttf;face=0;instance=static"),
         ],
-        content_codepoints=[ord("A")],
+        content_rows=[
+            ("content:U+0041", "A", 0x41),
+        ],
     )
 
     assert metadata.styles[0].label_id == (
         "style:path=lato/Lato-Regular.ttf;face=0;instance=static"
     )
+
+
+def test_build_dataset_metadata_uses_precomputed_content_rows() -> None:
+    metadata = build_dataset_metadata(
+        style_rows=[],
+        content_rows=[
+            ("content:U+0041", "A", 0x41),
+        ],
+    )
+
+    assert metadata.contents[0].label_id == "content:U+0041"
+    assert metadata.contents[0].char == "A"
+    assert metadata.contents[0].codepoint == 0x41
 
 
 def test_style_label_ids_are_stable_across_codepoint_filters() -> None:

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -13,6 +13,7 @@ class FontDataset:
     content_class_count: int
 
     content_classes: list[int]
+    def content_metadata_rows(self) -> list[tuple[str, str, int]]: ...
 
     style_classes: list[str]
     def style_metadata_rows(self, root: str) -> list[tuple[str, str]]: ...

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -29,6 +29,7 @@ from torchfont import _torchfont
 from torchfont.io import COORD_DIM
 from torchfont.metadata import (
     ContentLabel,
+    ContentMetadataRow,
     DatasetMetadata,
     StyleLabel,
     StyleMetadataRow,
@@ -419,7 +420,10 @@ class GlyphDataset(Dataset[GlyphSample]):
                 "list[StyleMetadataRow]",
                 self._dataset.style_metadata_rows(str(self.root)),
             ),
-            content_codepoints=self._dataset.content_classes,
+            content_rows=cast(
+                "list[ContentMetadataRow]",
+                self._dataset.content_metadata_rows(),
+            ),
         )
 
     @property

--- a/torchfont/metadata.py
+++ b/torchfont/metadata.py
@@ -44,11 +44,12 @@ class DatasetMetadata(NamedTuple):
 
 
 StyleMetadataRow = tuple[str, str]
+ContentMetadataRow = tuple[str, str, int]
 
 
 def build_dataset_metadata(
     style_rows: list[StyleMetadataRow],
-    content_codepoints: list[int],
+    content_rows: list[ContentMetadataRow],
 ) -> DatasetMetadata:
     """Build a DatasetMetadata object for a glyph dataset.
 
@@ -58,8 +59,8 @@ def build_dataset_metadata(
     Args:
         style_rows: Tuples of ``(name, label_id)`` aligned to the dataset's
             style indices.
-        content_codepoints: Unicode code points to turn into ``ContentLabel``
-            entries.
+        content_rows: Tuples of ``(label_id, char, codepoint)`` aligned to the
+            dataset's content indices.
 
     Returns:
         DatasetMetadata: Immutable metadata containing style and content label
@@ -77,11 +78,11 @@ def build_dataset_metadata(
     contents = tuple(
         ContentLabel(
             idx=idx,
-            label_id=f"content:U+{cp:04X}",
-            char=chr(cp),
-            codepoint=cp,
+            label_id=label_id,
+            char=char,
+            codepoint=codepoint,
         )
-        for idx, cp in enumerate(content_codepoints)
+        for idx, (label_id, char, codepoint) in enumerate(content_rows)
     )
 
     grouped_names: dict[str, list[int]] = {}


### PR DESCRIPTION
## Summary
- expose precomputed content metadata rows from the Rust dataset backend
- simplify `build_dataset_metadata(...)` so Python assembles both style and content metadata from native rows
- remove Python-side content label formatting from metadata assembly and lock it down with tests

## Testing
- mise run format
- mise run check
- mise run test
