### PR TITLE
[codex] Codify coding-agent repository guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+# Copilot Instructions for TorchFont
+
+## Repository Context
+
+- TorchFont is a beta, font-domain ML library using Python + Rust.
+- Performance-critical font operations should run in Rust (fontations crates such as `skrifa` / `read-fonts`).
+- Python should stay thin and orchestration-focused.
+
+## Implementation Direction
+
+- Prefer stateless, deterministic implementations.
+- Avoid adding mutable runtime caches by default, especially in Rust.
+- Keep Rust-side state minimal to avoid multiprocessing/pickle complexity.
+- Keep Python-side state minimal and pickle-friendly.
+- Do not add broad fallback branches or defensive validation unless explicitly required.
+- Backward compatibility is not a priority for refactors in this beta phase.
+
+## Tooling and Commands
+
+- Prefer repository task entrypoints via `mise`.
+- Setup: `mise run setup`
+- Format: `mise run format`
+- Lint/type-check: `mise run check`
+- Test: `mise run test`
+- Python package manager: `uv`
+- Rust tooling: `cargo`
+- Docs tooling: `npm`
+
+## Development Environment
+
+- Prefer using the repository Dev Container when available.
+- Do not overlook hidden config directories like `.devcontainer/`.
+
+## PR and Review Workflow
+
+- Keep changes focused and avoid mixing unrelated refactors.
+- Use `gh` for GitHub operations when scripting or reproducing CI context.
+- Request Copilot review when opening/updating PRs.
+- Resolve conversation threads before merge.
+- Use clear branch names; avoid ambiguous prefixes such as `maint`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,18 @@
 
 Prefer the repository's standard command entrypoints.
 
+## Agent Scope
+
+- This repository is a font-focused ML library (Python + Rust) targeting PyTorch workflows.
+- Prefer stateless and thin designs across the codebase.
+- Avoid over-engineered fallback paths and excessive validation.
+- TorchFont is beta: prioritize better architecture over backward compatibility.
+
 ## Workflow
 
 - If available, prefer the repository Dev Container for setup and verification.
+- Do not miss hidden config directories such as `.devcontainer/`.
+- If running outside a container and Dev Container CLI is available, prefer running development inside the project container.
 - Run `mise run setup` for local setup.
 - Prefer `mise` tasks when an equivalent task exists.
 - The repository uses `uv` for Python, `cargo` for Rust, and `npm` for documentation tooling.
@@ -24,6 +33,20 @@ Prefer the repository's standard command entrypoints.
 - Before finishing Python or Rust changes, run `mise run check`.
 - If behavior changes, run relevant tests in addition to the standard checks.
 - Keep changes focused; avoid mixing unrelated refactors with behavior changes.
+
+## Architecture Direction
+
+- Use fast Rust font crates (`skrifa`, `read-fonts`, etc.) for computation instead of Python-side caching.
+- Do not keep runtime state in Rust objects when avoidable.
+- Keep minimum required state on the Python side in pickle-friendly structures.
+- Keep Rust surfaces small and deterministic, and keep Python as a thin orchestration layer.
+
+## GitHub
+
+- Use GitHub CLI (`gh`) for issue/PR operations.
+- When possible, request Copilot review on active PRs.
+- Resolve PR conversations before merging.
+- Use clear branch names; avoid ambiguous prefixes like `maint`.
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+This file gives repository-specific guidance for coding agents.
+
+## Project and Architecture
+
+- TorchFont is a beta Python + Rust library for font-centric ML workflows.
+- Favor stateless, thin implementations.
+- Prefer computing in Rust with fast font crates (`skrifa`, `read-fonts`) over Python-side caches.
+- Avoid introducing mutable Rust runtime state unless there is a clear, measured need.
+- Keep unavoidable Python state pickle-friendly.
+- Compatibility is not a goal during this beta refactor phase.
+- Avoid over-engineered fallbacks and excessive validation.
+
+## Standard Workflow
+
+- Prefer Dev Container-based development when available.
+- Do not miss hidden configuration directories (for example `.devcontainer/`).
+- Prefer `mise` tasks over ad-hoc commands.
+- Run:
+  - `mise run setup`
+  - `mise run format`
+  - `mise run check`
+  - `mise run test`
+- Package managers:
+  - Python: `uv`
+  - Rust: `cargo`
+  - Docs: `npm`
+
+## GitHub Workflow
+
+- Use `gh` CLI for issue/PR operations.
+- Request Copilot review for active PR updates when possible.
+- Resolve review conversations before merge.
+- Use clear branch names and avoid ambiguous prefixes such as `maint`.


### PR DESCRIPTION
## Summary
- expand AGENTS.md with explicit architecture and workflow direction for coding agents
- add .github/copilot-instructions.md so Copilot review and code generation follow repo policy
- add CLAUDE.md with the same core guidance for Claude-based coding workflows

## Why
- addresses #151 by moving repeated ad-hoc instructions into repository-managed agent config
- aligns all agent surfaces on the same stateless and thin implementation policy

## Validation
- mise run format
- mise run check

Closes #151