### PR TITLE
Make GlyphDataset transform return type generic

### DIFF
--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -10,8 +10,8 @@
 from torchfont.datasets import GlyphSample
 ```
 
-Structured return type for `GlyphDataset.__getitem__` and the sample type used
-throughout `torchfont.transforms`.
+Default return type for `GlyphDataset.__getitem__`, and the input sample type
+for dataset transforms and `torchfont.transforms`.
 
 ## DatasetMetadata
 
@@ -35,16 +35,18 @@ GlyphDataset(
     *,
     codepoints: Sequence[SupportsIndex] | None = None,
     patterns: Sequence[str] | None = None,
-    transform: Callable[[GlyphSample], GlyphSample] | None = None,
+    transform: Callable[[GlyphSample], T] | None = None,
 )
 ```
+
+`T` is the transform return type and therefore the dataset item type.
 
 | Parameter          | Type                              | Description                         |
 | ------------------ | --------------------------------- | ----------------------------------- |
 | `root`             | `Path \| str`                     | root directory for font discovery   |
 | `codepoints` | `Sequence[SupportsIndex] \| None` | restrict indexed Unicode codepoints |
 | `patterns`         | `Sequence[str] \| None`           | gitignore-style path filtering      |
-| `transform`        | `Callable \| None`                | sample-first preprocessing (`GlyphSample -> GlyphSample`) |
+| `transform`        | `Callable \| None`                | sample-first preprocessing (`GlyphSample -> T`) |
 
 ### Behavior
 
@@ -80,7 +82,8 @@ sample = dataset[idx]
 | `sample.style_idx`   | `int`               | scalar         |
 | `sample.content_idx` | `int`               | scalar         |
 
-`sample` is a `GlyphSample`.
+Without `transform`, `sample` is a `GlyphSample`. With `transform`, the
+dataset item type is inferred from the transform return type.
 
 ### Properties
 

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -10,8 +10,8 @@
 from torchfont.datasets import GlyphSample
 ```
 
-`GlyphDataset.__getitem__` の返り値であり、`torchfont.transforms` 全体で使う
-sample 型です。
+`transform` なしの `GlyphDataset.__getitem__` の返り値であり、dataset
+transform や `torchfont.transforms` へ渡す入力 sample 型です。
 
 ## DatasetMetadata
 
@@ -35,16 +35,18 @@ GlyphDataset(
     *,
     codepoints: Sequence[SupportsIndex] | None = None,
     patterns: Sequence[str] | None = None,
-    transform: Callable[[GlyphSample], GlyphSample] | None = None,
+    transform: Callable[[GlyphSample], T] | None = None,
 )
 ```
+
+`T` は transform の返り値型であり、そのまま dataset item の型になります。
 
 | 引数               | 型                                | 説明                               |
 | ------------------ | --------------------------------- | ---------------------------------- |
 | `root`             | `Path \| str`                     | フォント探索の起点ディレクトリ     |
 | `codepoints` | `Sequence[SupportsIndex] \| None` | 対象 Unicode codepoint を制限      |
 | `patterns`         | `Sequence[str] \| None`           | gitignore 互換パターンでパスを絞る |
-| `transform`        | `Callable \| None`                | sample-first 前処理（`GlyphSample -> GlyphSample`） |
+| `transform`        | `Callable \| None`                | sample-first 前処理（`GlyphSample -> T`） |
 
 ### 振る舞い
 
@@ -82,7 +84,8 @@ sample = dataset[idx]
 | `sample.metrics`     | `bytes`             | 15 × f32      |
 | `sample.glyph_name`  | `str`               | —             |
 
-`sample` 自体の型は `GlyphSample` です。
+`transform` なしでは `sample` 自体の型は `GlyphSample` です。`transform`
+ありでは、dataset item の型は transform の返り値型から推論されます。
 
 ### プロパティ
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -186,6 +186,28 @@ def test_glyph_dataset_transform_uses_sample_first_contract() -> None:
     assert sample.coords.shape[0] == 2
 
 
+def test_glyph_dataset_transform_can_change_return_type() -> None:
+    def transform(sample: GlyphSample) -> tuple[torch.Tensor, int]:
+        return sample.types[:2], sample.content_idx
+
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("lato/Lato-Regular.ttf",),
+        codepoints=range(0x41, 0x5B),
+        transform=transform,
+    )
+    typed_dataset: GlyphDataset[tuple[torch.Tensor, int]] = dataset
+    typed_item: tuple[torch.Tensor, int] = dataset[0]
+    typed_item_from_dataset: tuple[torch.Tensor, int] = typed_dataset[0]
+
+    types, content_idx = typed_item
+
+    assert types.shape[0] == 2
+    assert isinstance(content_idx, int)
+    assert torch.equal(types, typed_item_from_dataset[0])
+    assert content_idx == typed_item_from_dataset[1]
+
+
 def test_glyph_dataset_preserves_quadratic_curves() -> None:
     dataset = GlyphDataset(
         root="tests/fonts",

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -22,7 +22,7 @@ import dataclasses
 from collections.abc import Callable, Sequence
 from operator import index
 from pathlib import Path
-from typing import SupportsIndex, cast
+from typing import Generic, SupportsIndex, TypeVar, cast, overload
 
 import torch
 from torch import Tensor
@@ -39,6 +39,8 @@ from torchfont.metadata import (
     StyleMetadataRow,
     build_dataset_metadata,
 )
+
+_T = TypeVar("_T")
 
 
 @dataclasses.dataclass
@@ -72,12 +74,13 @@ class GlyphSample:
     glyph_name: str
 
 
-class GlyphDataset(Dataset[GlyphSample]):
-    """Dataset that yields glyph samples from a directory of font files.
+class GlyphDataset(Dataset[_T], Generic[_T]):
+    """Dataset that yields glyph samples or transform outputs from font files.
 
     The dataset flattens every available code point and variation instance into
-    a single indexable sequence. Each item returns the loader output along with
-    style and content targets.
+    a single indexable sequence. By default, each item returns the loader output
+    along with style and content targets as a ``GlyphSample``. When ``transform``
+    is provided, each item returns the transform output instead.
 
     Attributes:
         targets (torch.LongTensor): Label matrix of shape ``(N, 2)`` where
@@ -100,13 +103,33 @@ class GlyphDataset(Dataset[GlyphSample]):
 
     """
 
+    @overload
+    def __init__(
+        self: "GlyphDataset[GlyphSample]",
+        root: Path | str,
+        *,
+        codepoints: Sequence[SupportsIndex] | None = None,
+        patterns: Sequence[str] | None = None,
+        transform: None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: "GlyphDataset[_T]",
+        root: Path | str,
+        *,
+        codepoints: Sequence[SupportsIndex] | None = None,
+        patterns: Sequence[str] | None = None,
+        transform: Callable[[GlyphSample], _T],
+    ) -> None: ...
+
     def __init__(
         self,
         root: Path | str,
         *,
         codepoints: Sequence[SupportsIndex] | None = None,
         patterns: Sequence[str] | None = None,
-        transform: (Callable[[GlyphSample], GlyphSample] | None) = None,
+        transform: (Callable[[GlyphSample], _T] | None) = None,
     ) -> None:
         """Initialize the dataset by scanning font files and indexing samples.
 
@@ -127,9 +150,10 @@ class GlyphDataset(Dataset[GlyphSample]):
                 ``.ignore``, global gitignore, or git exclude rules) is applied;
                 all such behavior must be expressed via ``patterns``. VCS metadata
                 directories such as ``.git`` remain excluded.
-            transform (Callable[[GlyphSample], GlyphSample] | None):
-                Optional transformation applied to each sample before the item
-                is returned.
+            transform (Callable[[GlyphSample], _T] | None): Optional
+                transformation applied to each sample before the item is returned.
+                When provided, ``_T`` is inferred from the transform return type
+                and becomes the dataset item type.
 
         Examples:
             Restrict the dataset to uppercase ASCII glyphs::
@@ -238,7 +262,16 @@ class GlyphDataset(Dataset[GlyphSample]):
         """
         return int(self._dataset.sample_count)
 
-    def __getitem__(self, idx: SupportsIndex) -> GlyphSample:
+    @overload
+    def __getitem__(
+        self: "GlyphDataset[GlyphSample]",
+        idx: SupportsIndex,
+    ) -> GlyphSample: ...
+
+    @overload
+    def __getitem__(self, idx: SupportsIndex) -> _T: ...
+
+    def __getitem__(self, idx: SupportsIndex) -> _T:
         """Load a glyph sample and its associated targets.
 
         Args:
@@ -248,8 +281,8 @@ class GlyphDataset(Dataset[GlyphSample]):
                 count from the end of the dataset.
 
         Returns:
-            GlyphSample: Structured sample containing ``types``, ``coords``,
-            ``style_idx``, ``content_idx``, ``metrics``, and ``glyph_name``.
+            _T: A ``GlyphSample`` when no transform is provided; otherwise the
+            value returned by ``transform``.
 
         Examples:
             Retrieve the first glyph sample and its target labels::
@@ -278,7 +311,7 @@ class GlyphDataset(Dataset[GlyphSample]):
         )
         if self.transform is not None:
             return self.transform(sample)
-        return sample
+        return cast("_T", sample)
 
     @property
     def targets(self) -> Tensor:


### PR DESCRIPTION
## Summary

- Make `GlyphDataset` generic so the item type follows the `transform` return type.
- Keep the no-transform overload as `GlyphDataset[GlyphSample]`.
- Add a type-checking regression test that assigns `dataset[0]` to the transformed return type.
- Update English and Japanese dataset reference docs to describe the generic transform contract.

## Impact

Users can now pass transforms that return model-specific tuples, tensors, or other structures while preserving static type inference for `dataset[idx]`.

## Validation

- `mise run format`
- `mise run check`
- `mise run test`
