### PR TITLE
[codex] Speed up glyph command extraction

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -133,16 +133,8 @@ impl GlyphDataset {
             italic_angle,
             glyph_name,
         ) = self.entries[font_idx].glyph_complete(codepoint, inst_idx)?;
-        let mut types_bytes = Vec::with_capacity(types.len() * std::mem::size_of::<i64>());
-        for &t in &types {
-            types_bytes.extend_from_slice(&(t as i64).to_ne_bytes());
-        }
-        let coords_bytes: Vec<u8> = {
-            let bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(coords.as_ptr().cast::<u8>(), coords.len() * 4)
-            };
-            bytes.to_vec()
-        };
+        let types_bytes = bytes_from_slice(&types);
+        let coords_bytes = bytes_from_slice(&coords);
         let metrics_f32: [f32; 15] = [
             adv_w,
             lsb,
@@ -160,11 +152,7 @@ impl GlyphDataset {
             upem as f32,
             if is_monospace { 1.0_f32 } else { 0.0_f32 },
         ];
-        let metrics_bytes: Vec<u8> = {
-            let bytes: &[u8] =
-                unsafe { std::slice::from_raw_parts(metrics_f32.as_ptr().cast::<u8>(), 15 * 4) };
-            bytes.to_vec()
-        };
+        let metrics_bytes = bytes_from_slice(&metrics_f32);
         Ok(GlyphItem {
             types: types_bytes,
             coords: coords_bytes,
@@ -277,6 +265,13 @@ impl GlyphDataset {
 
         Ok((font_idx, instance, cp, style_idx, content_idx))
     }
+}
+
+fn bytes_from_slice<T: Copy>(values: &[T]) -> Vec<u8> {
+    let bytes = unsafe {
+        std::slice::from_raw_parts(values.as_ptr().cast::<u8>(), std::mem::size_of_val(values))
+    };
+    bytes.to_vec()
 }
 
 fn style_label_id(

--- a/src/dataset/reader.rs
+++ b/src/dataset/reader.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 pub(super) type GlyphItemData = (
-    Vec<i32>,
+    Vec<i64>,
     Vec<f32>,
     f32,
     f32,

--- a/src/pen.rs
+++ b/src/pen.rs
@@ -1,7 +1,7 @@
 use skrifa::outline::OutlinePen;
 
 #[derive(Clone, Copy)]
-#[repr(i32)]
+#[repr(i64)]
 enum Command {
     MoveTo = 1,
     LineTo = 2,
@@ -12,7 +12,7 @@ enum Command {
 }
 
 pub struct SegmentPen {
-    commands: Vec<i32>,
+    commands: Vec<i64>,
     coords: Vec<f32>,
     scale: f32,
 }
@@ -27,13 +27,13 @@ impl SegmentPen {
         }
     }
 
-    pub fn finish(mut self) -> (Vec<i32>, Vec<f32>) {
+    pub fn finish(mut self) -> (Vec<i64>, Vec<f32>) {
         self.push(Command::End, [0.0; 6]);
         (self.commands, self.coords)
     }
 
     fn push(&mut self, command: Command, values: [f32; 6]) {
-        self.commands.push(command as i32);
+        self.commands.push(command as i64);
         let scaled = values.map(|v| v * self.scale);
         self.coords.extend_from_slice(&scaled);
     }


### PR DESCRIPTION
## Summary
- Store glyph command IDs as native `i64` in `SegmentPen`, matching the `torch.long` tensor shape expected by Python.
- Serialize glyph item buffers through one shared slice-to-bytes helper, removing the per-command widening loop from `GlyphDataset::item`.

## Impact
- Keeps the public Python API unchanged while reducing a small amount of work in glyph sample extraction.
- Does not include bitmap rendering or eager glyph caching changes from the exploratory work.

## Validation
- `mise run format`
- `mise run check`
- `mise exec -- uv run pytest tests/test_dataset.py tests/test_utils.py`
