### PR TITLE
Update examples to use simple slicing transform

### DIFF
--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -4,13 +4,13 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from torchfont.datasets import GlyphDataset, GlyphSample
-from torchfont.transforms import quad_to_cubic
 from torchfont.utils import collate_fn
 
 
-def normalize_curves(sample: GlyphSample) -> GlyphSample:
-    types, coords = quad_to_cubic(sample.types, sample.coords)
-    return dataclasses.replace(sample, types=types, coords=coords)
+def transform(sample: GlyphSample) -> GlyphSample:
+    return dataclasses.replace(
+        sample, types=sample.types[:512], coords=sample.coords[:512]
+    )
 
 
 def main() -> None:
@@ -22,7 +22,7 @@ def main() -> None:
             "ufl/*/*.ttf",
             "!ofl/adobeblank/*.ttf",
         ),
-        transform=normalize_curves,
+        transform=transform,
     )
 
     dataloader = DataLoader(

--- a/examples/local_fonts.py
+++ b/examples/local_fonts.py
@@ -3,13 +3,13 @@ import dataclasses
 from torch.utils.data import DataLoader
 
 from torchfont.datasets import GlyphDataset, GlyphSample
-from torchfont.transforms import quad_to_cubic
 from torchfont.utils import collate_fn
 
 
-def normalize_curves(sample: GlyphSample) -> GlyphSample:
-    types, coords = quad_to_cubic(sample.types, sample.coords)
-    return dataclasses.replace(sample, types=types, coords=coords)
+def transform(sample: GlyphSample) -> GlyphSample:
+    return dataclasses.replace(
+        sample, types=sample.types[:512], coords=sample.coords[:512]
+    )
 
 
 def main() -> None:
@@ -17,7 +17,7 @@ def main() -> None:
         root="tests/fonts",
         patterns=("*.ttf",),
         codepoints=range(0x20, 0x7F),
-        transform=normalize_curves,
+        transform=transform,
     )
 
     dataloader = DataLoader(


### PR DESCRIPTION
## Summary

- Remove `quad_to_cubic` import and usage from `examples/google_fonts.py` and `examples/local_fonts.py`
- Replace `normalize_curves` with a simple `transform` function that truncates `types` and `coords` to 512 elements
- Reflects more typical/minimal transform usage without depending on a specific utility

## Test plan

- [ ] Run `python examples/local_fonts.py` and verify it runs without error
- [ ] Run `python examples/google_fonts.py` (with Google Fonts data) and verify it runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)