### PR TITLE
Add render_bitmap transform using tiny-skia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +16,18 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "bitflags"
@@ -52,6 +70,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -97,6 +124,25 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -192,6 +238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +258,19 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -371,6 +440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "skrifa"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +454,12 @@ dependencies = [
  "bytemuck",
  "read-fonts",
 ]
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "syn"
@@ -418,6 +499,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "torchfont"
 version = "0.8.1"
 dependencies = [
@@ -426,6 +533,7 @@ dependencies = [
  "pyo3",
  "shellexpand",
  "skrifa",
+ "tiny-skia",
  "urlencoding",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ ignore = "0.4.25"
 memmap2 = "0.9.10"
 shellexpand = "3.1.2"
 skrifa = "0.42.1"
+tiny-skia = "0.12.0"
 urlencoding = "2.1.3"
 walkdir = "2.5.0"
 

--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -1,16 +1,15 @@
-import dataclasses
-
+from torch import Tensor
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from torchfont.datasets import GlyphDataset, GlyphSample
-from torchfont.utils import collate_fn
+from torchfont.transforms import render_bitmap
 
 
-def transform(sample: GlyphSample) -> GlyphSample:
-    return dataclasses.replace(
-        sample, types=sample.types[:512], coords=sample.coords[:512]
-    )
+def transform(sample: GlyphSample) -> Tensor:
+    types = sample.types[:512]
+    coords = sample.coords[:512]
+    return render_bitmap(types, coords)
 
 
 def main() -> None:
@@ -31,7 +30,6 @@ def main() -> None:
         shuffle=True,
         num_workers=8,
         prefetch_factor=2,
-        collate_fn=collate_fn,
     )
 
     print(f"{len(dataset)=}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,29 @@
 mod dataset;
 mod error;
 mod pen;
+mod render;
 
 use dataset::{GlyphDataset, GlyphItem};
 use pyo3::{Bound, prelude::*, types::PyModule};
+
+#[pyfunction]
+fn render_bitmap(types_bytes: &[u8], coords_bytes: &[u8], size: u32) -> PyResult<Vec<u8>> {
+    if size == 0 || size > 4096 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "size must be between 1 and 4096",
+        ));
+    }
+    Ok(render::render_bitmap_from_bytes(
+        types_bytes,
+        coords_bytes,
+        size,
+    ))
+}
 
 #[pymodule]
 fn _torchfont(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GlyphDataset>()?;
     m.add_class::<GlyphItem>()?;
+    m.add_function(wrap_pyfunction!(render_bitmap, &m)?)?;
     Ok(())
 }

--- a/src/pen.rs
+++ b/src/pen.rs
@@ -2,7 +2,7 @@ use skrifa::outline::OutlinePen;
 
 #[derive(Clone, Copy)]
 #[repr(i32)]
-enum Command {
+pub(crate) enum Command {
     MoveTo = 1,
     LineTo = 2,
     QuadTo = 3,

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,79 @@
+use tiny_skia::{FillRule, Mask, Path, PathBuilder, Transform};
+
+use crate::pen::Command;
+
+const PADDING: f32 = 4.0;
+
+pub(crate) fn render_bitmap_from_bytes(
+    types_bytes: &[u8],
+    coords_bytes: &[u8],
+    size: u32,
+) -> Vec<u8> {
+    let types: Vec<i32> = types_bytes
+        .chunks_exact(8)
+        .map(|b| i64::from_ne_bytes(b.try_into().unwrap()) as i32)
+        .collect();
+    let coords: Vec<f32> = coords_bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_ne_bytes(b.try_into().unwrap()))
+        .collect();
+    render_bitmap(&types, &coords, size)
+}
+
+fn render_bitmap(types: &[i32], coords: &[f32], size: u32) -> Vec<u8> {
+    let Some(path) = build_path(types, coords) else {
+        return blank_bitmap(size);
+    };
+    let bounds = path.compute_tight_bounds().unwrap_or_else(|| path.bounds());
+    let width = bounds.width();
+    let height = bounds.height();
+    if width <= f32::EPSILON || height <= f32::EPSILON {
+        return blank_bitmap(size);
+    }
+
+    let bitmap_size = size as f32;
+    let content_size = bitmap_size - 2.0 * PADDING;
+    if content_size <= 0.0 {
+        return blank_bitmap(size);
+    }
+    let scale = content_size / width.max(height);
+    let offset_x = (bitmap_size - width * scale) * 0.5;
+    let offset_y = (bitmap_size - height * scale) * 0.5;
+    let transform = Transform::from_row(
+        scale,
+        0.0,
+        0.0,
+        -scale,
+        offset_x - bounds.left() * scale,
+        offset_y + bounds.bottom() * scale,
+    );
+
+    let Some(mut mask) = Mask::new(size, size) else {
+        return blank_bitmap(size);
+    };
+    mask.fill_path(&path, FillRule::Winding, true, transform);
+    mask.data().to_vec()
+}
+
+fn build_path(types: &[i32], coords: &[f32]) -> Option<Path> {
+    let mut builder = PathBuilder::with_capacity(types.len(), coords.len() / 2);
+    for (&command, values) in types.iter().zip(coords.chunks_exact(6)) {
+        match command {
+            v if v == Command::MoveTo as i32 => builder.move_to(values[4], values[5]),
+            v if v == Command::LineTo as i32 => builder.line_to(values[4], values[5]),
+            v if v == Command::QuadTo as i32 => {
+                builder.quad_to(values[0], values[1], values[4], values[5])
+            }
+            v if v == Command::CurveTo as i32 => builder.cubic_to(
+                values[0], values[1], values[2], values[3], values[4], values[5],
+            ),
+            v if v == Command::Close as i32 => builder.close(),
+            _ => break,
+        }
+    }
+    builder.finish()
+}
+
+fn blank_bitmap(size: u32) -> Vec<u8> {
+    vec![0u8; (size as usize).saturating_mul(size as usize)]
+}

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -1,5 +1,7 @@
 from collections.abc import Sequence
 
+def render_bitmap(types_bytes: bytes, coords_bytes: bytes, size: int) -> bytes: ...
+
 class GlyphItem:
     types: bytes
     coords: bytes

--- a/torchfont/transforms.py
+++ b/torchfont/transforms.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 
+from torchfont import _torchfont
 from torchfont.io import CommandType
 
 
@@ -48,4 +49,27 @@ def quad_to_cubic(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     return out_types, out_coords
 
 
-__all__ = ["quad_to_cubic"]
+def render_bitmap(types: Tensor, coords: Tensor, size: int = 64) -> Tensor:
+    """Render a glyph outline to a greyscale bitmap tensor.
+
+    The glyph is auto-scaled and centred to fill the canvas with a fixed
+    4-pixel padding on each side.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)`` holding
+            UPM-normalised coordinate data for each command.
+        size: Output image side length in pixels (square). Must be between 1
+            and 4096.
+
+    Returns:
+        uint8 tensor of shape ``(size, size)`` with values in ``[0, 255]``.
+
+    """
+    types_bytes = bytes(types.cpu().contiguous().numpy().view("uint8"))
+    coords_bytes = bytes(coords.cpu().contiguous().numpy().view("uint8"))
+    raw = _torchfont.render_bitmap(types_bytes, coords_bytes, size)
+    return torch.frombuffer(bytearray(raw), dtype=torch.uint8).view(size, size)
+
+
+__all__ = ["quad_to_cubic", "render_bitmap"]


### PR DESCRIPTION
## Summary

- Add `src/render.rs`: Rust rasterisation module backed by `tiny-skia` (`Mask` + non-zero winding rule). Glyphs are auto-scaled and centred via `compute_tight_bounds`.
- Add `render_bitmap(types, coords, size) -> Tensor` function to `torchfont/transforms.py`.
- Expose `render_bitmap` via PyO3 in `src/lib.rs`; add stub to `_torchfont.pyi`.
- Make `Command` enum `pub(crate)` in `src/pen.rs` to avoid re-defining constants.
- Update `examples/google_fonts.py` to demonstrate using `render_bitmap` as a dataset transform.

## Test plan

- [ ] `mise run check` passes (ruff, ty, cargo fmt, clippy)
- [ ] `mise run test` passes (71 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)