### PR TITLE
Return numpy arrays from GlyphItem instead of raw bytes

### DIFF
--- a/docs/en/guide/glyph-data-format.md
+++ b/docs/en/guide/glyph-data-format.md
@@ -12,19 +12,18 @@ sample = dataset[i]
 | `sample.coords`      | `torch.FloatTensor` | `(seq_len, 6)` | Coordinate sequence              |
 | `sample.style_idx`   | `int`               | scalar         | Style class ID                   |
 | `sample.content_idx` | `int`               | scalar         | Content class ID                 |
-| `sample.metrics`     | `bytes`             | 15 × f32       | Per-glyph and font-level metrics |
+| `sample.metrics`     | `torch.FloatTensor` | `(15,)`        | Per-glyph and font-level metrics |
 | `sample.glyph_name`  | `str`               | —              | PostScript glyph name            |
 
 `GlyphSample` is a dataclass; field access by name is the intended API.
 
-`sample.metrics` is a packed native-endian `f32` byte buffer (60 bytes). Decode with:
+`sample.metrics` is a 1-D `float32` tensor of shape `(15,)`:
 
 ```python
-import torch
-m = torch.frombuffer(bytearray(sample.metrics), dtype=torch.float32)
 # [adv_w, lsb, x_min, y_min, x_max, y_max,
 #  ascent, descent, leading, cap_height, x_height, avg_width,
 #  italic_angle, units_per_em, is_monospace]
+m = sample.metrics
 ```
 
 Values are UPM-normalised where applicable; `nan` when missing.

--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -81,6 +81,8 @@ sample = dataset[idx]
 | `sample.coords`      | `torch.FloatTensor` | `(seq_len, 6)` |
 | `sample.style_idx`   | `int`               | scalar         |
 | `sample.content_idx` | `int`               | scalar         |
+| `sample.metrics`     | `torch.FloatTensor` | `(15,)`        |
+| `sample.glyph_name`  | `str`               | —              |
 
 Without `transform`, `sample` is a `GlyphSample`. With `transform`, the
 dataset item type is inferred from the transform return type.

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -81,7 +81,7 @@ sample = dataset[idx]
 | `sample.coords`      | `torch.FloatTensor` | `(seq_len, 6)` |
 | `sample.style_idx`   | `int`               | スカラー       |
 | `sample.content_idx` | `int`               | スカラー       |
-| `sample.metrics`     | `bytes`             | 15 × f32      |
+| `sample.metrics`     | `torch.FloatTensor` | `(15,)`       |
 | `sample.glyph_name`  | `str`               | —             |
 
 `transform` なしでは `sample` 自体の型は `GlyphSample` です。`transform`

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -7,23 +7,22 @@ use crate::error::py_index_err;
 use entry::FontEntry;
 use index::{DatasetIndex, load_entries_and_index};
 use io::{canonicalize_root, discover_font_files};
+use numpy::{IntoPyArray as _, PyArray1};
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
 use std::path::Path;
 
 #[pyclass(get_all)]
 pub struct GlyphItem {
-    /// Raw native-endian ``i64`` bytes, one per pen command.
-    pub types: Vec<u8>,
-    /// Raw native-endian ``f32`` bytes, six values per pen command.
-    pub coords: Vec<u8>,
+    /// One ``i64`` per pen command.
+    pub types: Py<PyArray1<i64>>,
+    /// Six ``f32`` values per pen command (flat).
+    pub coords: Py<PyArray1<f32>>,
     pub style_idx: usize,
     pub content_idx: usize,
-    /// Raw native-endian ``f32`` bytes for 15 float metrics (in order):
-    /// advance_width, lsb, x_min, y_min, x_max, y_max,
+    /// 15 ``f32`` metrics: advance_width, lsb, x_min, y_min, x_max, y_max,
     /// ascent, descent, leading, cap_height, x_height, average_width,
     /// italic_angle, units_per_em (cast to f32), is_monospace (0.0 or 1.0).
-    pub metrics: Vec<u8>,
+    pub metrics: Py<PyArray1<f32>>,
     pub glyph_name: String,
 }
 
@@ -111,7 +110,7 @@ impl GlyphDataset {
         axes
     }
 
-    pub fn item(&self, idx: usize) -> PyResult<GlyphItem> {
+    pub fn item(&self, py: Python<'_>, idx: usize) -> PyResult<GlyphItem> {
         let (font_idx, inst_idx, codepoint, style_idx, content_idx) = self.locate_parts(idx)?;
         let (
             types,
@@ -133,17 +132,13 @@ impl GlyphDataset {
             italic_angle,
             glyph_name,
         ) = self.entries[font_idx].glyph_complete(codepoint, inst_idx)?;
-        let mut types_bytes = Vec::with_capacity(types.len() * std::mem::size_of::<i64>());
-        for &t in &types {
-            types_bytes.extend_from_slice(&(t as i64).to_ne_bytes());
-        }
-        let coords_bytes: Vec<u8> = {
-            let bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(coords.as_ptr().cast::<u8>(), coords.len() * 4)
-            };
-            bytes.to_vec()
-        };
-        let metrics_f32: [f32; 15] = [
+
+        let types_i64: Vec<i64> = types.iter().map(|&t| t as i64).collect();
+        let types_arr = types_i64.into_pyarray(py).unbind();
+
+        let coords_arr = coords.into_pyarray(py).unbind();
+
+        let metrics: Vec<f32> = vec![
             adv_w,
             lsb,
             x_min,
@@ -160,42 +155,36 @@ impl GlyphDataset {
             upem as f32,
             if is_monospace { 1.0_f32 } else { 0.0_f32 },
         ];
-        let metrics_bytes: Vec<u8> = {
-            let bytes: &[u8] =
-                unsafe { std::slice::from_raw_parts(metrics_f32.as_ptr().cast::<u8>(), 15 * 4) };
-            bytes.to_vec()
-        };
+        let metrics_arr = metrics.into_pyarray(py).unbind();
+
         Ok(GlyphItem {
-            types: types_bytes,
-            coords: coords_bytes,
+            types: types_arr,
+            coords: coords_arr,
             style_idx,
             content_idx,
-            metrics: metrics_bytes,
+            metrics: metrics_arr,
             glyph_name,
         })
     }
 
-    pub fn targets<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+    pub fn targets<'py>(&self, py: Python<'py>) -> PyResult<Py<PyArray1<i64>>> {
         let total = self.sample_count();
-        let capacity = total
-            .checked_mul(2)
-            .and_then(|n| n.checked_mul(std::mem::size_of::<i64>()))
-            .ok_or_else(|| {
-                pyo3::exceptions::PyOverflowError::new_err("target buffer size overflowed usize")
-            })?;
-        let mut bytes = Vec::with_capacity(capacity);
+        let capacity = total.checked_mul(2).ok_or_else(|| {
+            pyo3::exceptions::PyOverflowError::new_err("target buffer size overflowed usize")
+        })?;
+        let mut pairs: Vec<i64> = Vec::with_capacity(capacity);
         for (font_idx, entry) in self.entries.iter().enumerate() {
             let inst_offset = self.index.inst_offsets[font_idx];
             for inst_idx in 0..entry.instance_count() {
                 let style_idx = inst_offset + inst_idx;
                 for &cp in entry.codepoints() {
                     let content_idx = self.index.content_index(cp)?;
-                    bytes.extend_from_slice(&(style_idx as i64).to_ne_bytes());
-                    bytes.extend_from_slice(&(content_idx as i64).to_ne_bytes());
+                    pairs.push(style_idx as i64);
+                    pairs.push(content_idx as i64);
                 }
             }
         }
-        Ok(PyBytes::new(py, &bytes))
+        Ok(pairs.into_pyarray(py).unbind())
     }
 }
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -112,11 +112,10 @@ def test_glyph_dataset_getitem() -> None:
     assert 0 <= sample.style_idx < len(dataset.style_classes)
     assert 0 <= sample.content_idx < len(dataset.content_classes)
 
-    assert isinstance(sample.metrics, bytes)
-    assert len(sample.metrics) == 60  # 15 native-endian f32s
-    metrics = torch.frombuffer(bytearray(sample.metrics), dtype=torch.float32)
-    assert metrics.shape == (15,)
-    assert not torch.isnan(metrics[0])  # advance_width should be present
+    assert isinstance(sample.metrics, torch.Tensor)
+    assert sample.metrics.dtype == torch.float32
+    assert sample.metrics.shape == (15,)
+    assert not torch.isnan(sample.metrics[0])  # advance_width should be present
 
     assert isinstance(sample.glyph_name, str)
     assert len(sample.glyph_name) > 0

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -4,7 +4,7 @@ from torchfont.datasets import GlyphSample
 from torchfont.io import CommandType
 from torchfont.transforms import quad_to_cubic
 
-_ZERO_METRICS = bytes(60)  # 15 x 0.0 as f32, placeholder for transform tests
+_ZERO_METRICS = torch.zeros(15, dtype=torch.float32)  # placeholder for transform tests
 
 
 def test_quad_to_cubic_converts_quadratic_segments() -> None:

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -8,11 +8,11 @@ def quad_to_cubic_inplace(
 ) -> None: ...
 
 class GlyphItem:
-    types: bytes
-    coords: bytes
+    types: np.ndarray
+    coords: np.ndarray
     style_idx: int
     content_idx: int
-    metrics: bytes
+    metrics: np.ndarray
     glyph_name: str
 
 class GlyphDataset:
@@ -31,4 +31,4 @@ class GlyphDataset:
     def style_metadata_rows(self, root: str) -> list[tuple[str, str]]: ...
     style_axes: list[list[tuple[str, float]]]
     def item(self, idx: int) -> GlyphItem: ...
-    def targets(self) -> bytes: ...
+    def targets(self) -> np.ndarray: ...

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -53,15 +53,13 @@ class GlyphSample:
             coordinate data for each command.
         style_idx (int): Index into the dataset's ``style_classes`` list.
         content_idx (int): Index into the dataset's ``content_classes`` list.
-        metrics (bytes): Raw native-endian ``f32`` bytes for 15 metrics.
-            Column order: ``advance_width``, ``lsb``, ``x_min``, ``y_min``,
-            ``x_max``, ``y_max``, ``ascent``, ``descent``, ``leading``,
-            ``cap_height``, ``x_height``, ``average_width``, ``italic_angle``,
-            ``units_per_em`` (cast to f32), ``is_monospace`` (0.0 or 1.0).
-            UPM-normalised where applicable; ``nan`` when missing.
-            Decode with
-            ``torch.frombuffer(bytearray(sample.metrics), dtype=torch.float32)``
-            to obtain a 1-D float tensor of shape ``(15,)``.
+        metrics (Tensor): 1-D float tensor of shape ``(15,)`` holding per-sample
+            metrics. Column order: ``advance_width``, ``lsb``, ``x_min``,
+            ``y_min``, ``x_max``, ``y_max``, ``ascent``, ``descent``,
+            ``leading``, ``cap_height``, ``x_height``, ``average_width``,
+            ``italic_angle``, ``units_per_em`` (cast to f32),
+            ``is_monospace`` (0.0 or 1.0). UPM-normalised where applicable;
+            ``nan`` when missing.
         glyph_name (str): PostScript name of the glyph.
 
     """
@@ -70,7 +68,7 @@ class GlyphSample:
     coords: Tensor
     style_idx: int
     content_idx: int
-    metrics: bytes
+    metrics: Tensor
     glyph_name: str
 
 
@@ -297,16 +295,15 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         """
         idx = self._normalize_index(idx)
         item = self._dataset.item(idx)
-        types = torch.frombuffer(bytearray(item.types), dtype=torch.long)
-        coords = torch.frombuffer(bytearray(item.coords), dtype=torch.float32).view(
-            -1, COORD_DIM
-        )
+        types = torch.from_numpy(item.types)
+        coords = torch.from_numpy(item.coords).view(-1, COORD_DIM)
+        metrics = torch.from_numpy(item.metrics)
         sample = GlyphSample(
             types=types,
             coords=coords,
             style_idx=item.style_idx,
             content_idx=item.content_idx,
-            metrics=item.metrics,
+            metrics=metrics,
             glyph_name=item.glyph_name,
         )
         if self.transform is not None:
@@ -332,10 +329,10 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
             tensor([style_idx, content_idx])
 
         """
-        raw = self._dataset.targets()
-        if not raw:
+        arr = self._dataset.targets()
+        if arr.size == 0:
             return torch.empty(0, 2, dtype=torch.long)
-        return torch.frombuffer(bytearray(raw), dtype=torch.long).view(-1, 2)
+        return torch.from_numpy(arr).view(-1, 2)
 
     @property
     def content_classes(self) -> list[str]:

--- a/torchfont/utils.py
+++ b/torchfont/utils.py
@@ -93,14 +93,7 @@ def collate_fn(
     targets_tensor = torch.tensor(
         [(s.style_idx, s.content_idx) for s in batch], dtype=torch.long, device=device
     )
-    metrics_tensor = (
-        torch.frombuffer(
-            bytearray().join(s.metrics for s in batch),
-            dtype=torch.float32,
-        )
-        .view(len(batch), 15)
-        .to(device)
-    )
+    metrics_tensor = torch.stack([s.metrics for s in batch]).to(device)
 
     return GlyphBatch(
         types=types_tensor,


### PR DESCRIPTION
## Summary

- `GlyphItem.types` / `coords` / `metrics` フィールドを `Vec<u8>` から `Py<PyArray1<i64/f32>>` に変更
- `GlyphDataset.targets()` の戻り値を `PyBytes` から `Py<PyArray1<i64>>` に変更
- Python 側は `torch.frombuffer(bytearray(...))` → `torch.from_numpy()` に置き換え（中間コピー削減）
- `collate_fn` の metrics 集約を `torch.stack()` に簡略化
- スタブ (`.pyi`)、テスト、ドキュメント（EN/JA）を一括更新

## Performance

171k サンプルのテストデータセットで計測（`--release` ビルド）：

| 操作 | bytes 版 | numpy 版 | 差分 |
|---|---|---|---|
| `raw item(0)` | 1.2 µs | 1.5 µs | +25% |
| `ds[0]` (Python `__getitem__`) | 5.2 µs | 5.9 µs | +13% |
| `ds.targets` (171k 件) | 5,414 µs | 3,473 µs | **-36%** |
| `collate_fn` (batch=32) | 132 µs | 136 µs | +3% |

`item()` 単体は numpy 配列確保のオーバーヘッドでわずかに増加するが、`targets` は `bytearray` の二重コピーがなくなり大幅に改善。`collate_fn` は誤差範囲内。

## Test plan

- [x] `mise run check` — ruff / ty / clippy / cargo check 全通過
- [x] `mise run test` — 71 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)