### PR TITLE
fix: rebuild Rust extension as part of setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,7 @@ node = "lts"
 run = ["mise install", { tasks = ["setup-uv", "setup-npm"] }]
 
 [tasks.setup-uv]
-run = "mise exec -- uv sync"
+run = ["mise exec -- uv sync", "mise exec -- uv run maturin develop"]
 
 [tasks.setup-npm]
 run = "mise exec -- npm install"


### PR DESCRIPTION
## Summary

- `setup-uv` now runs `maturin develop` after `uv sync`
- The devcontainer mounts `.venv` as a persistent Docker volume; when Rust source changes between sessions, `uv sync` alone leaves the compiled extension stale because the package version (`0.8.1`) already matches what is installed
- This caused `test_variable_font_style_axes_are_exposed_in_metadata` and `test_targets_variable_fonts` to fail in devcontainer environments where the extension predated named-instance support

## Test plan

- [ ] `mise run setup` in a devcontainer with a stale `.venv` volume now produces a freshly compiled extension
- [ ] All 74 tests pass after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)