### PR TITLE
docs(ja): add missing metrics and glyph_name fields to glyph-data-format

### DIFF
--- a/docs/ja/guide/glyph-data-format.md
+++ b/docs/ja/guide/glyph-data-format.md
@@ -14,8 +14,21 @@ sample = dataset[i]
 | `sample.coords` | `torch.FloatTensor` | `(seq_len, 6)` | 各コマンドの座標 |
 | `sample.style_idx` | `int` | スカラー | 書体スタイルのクラスID |
 | `sample.content_idx` | `int` | スカラー | 文字内容のクラスID |
+| `sample.metrics` | `torch.FloatTensor` | `(15,)` | グリフ・フォント単位のメトリクス |
+| `sample.glyph_name` | `str` | — | PostScript グリフ名 |
 
 `GlyphSample` は dataclass なので、名前付きフィールドでアクセスする使い方が前提です。
+
+`sample.metrics` は形状 `(15,)` の 1-D `float32` テンソルです:
+
+```python
+# [adv_w, lsb, x_min, y_min, x_max, y_max,
+#  ascent, descent, leading, cap_height, x_height, avg_width,
+#  italic_angle, units_per_em, is_monospace]
+m = sample.metrics
+```
+
+値は UPM で正規化済み（該当する場合）。欠損時は `nan`。
 
 ## `types` の定義
 


### PR DESCRIPTION
## Summary

- Japanese glyph data format guide (`docs/ja/guide/glyph-data-format.md`) was missing `sample.metrics` and `sample.glyph_name` rows from the `GlyphSample` field table
- Also missing the metrics column order description block (`# [adv_w, lsb, ...]`) that exists in the English version

## Test plan

- [ ] Confirm the Japanese page renders both new table rows correctly
- [ ] Confirm the metrics code block matches the English version and the Rust source (`src/dataset/mod.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)