### PR TITLE
[codex] Release v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "torchfont"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ignore",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "torchfont"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
+description = "Datasets, Transforms and Models specific to Vector Fonts"
+license = "MIT"
+repository = "https://github.com/torchfont/torchfont"
 
 [lib]
 name = "_torchfont"


### PR DESCRIPTION
## Summary

- Bump TorchFont package version from 0.8.1 to 0.9.0.
- Add Cargo package metadata so `uv build` no longer emits missing manifest metadata warnings.
- Keep Cargo.lock aligned with the release version.

## Validation

- `uv build`
- `mise run check`
- `mise run test`
- `importlib.metadata.version("torchfont")` returns `0.9.0` after reinstalling the editable package.

## Notes

- This is a draft PR for the release prep commit.
- The local `v0.9.0` tag exists but was not pushed, so publishing is not triggered by this PR.
