### PR TITLE
chore: ignore dirty state for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,18 +3,22 @@
 	url = https://github.com/google/fonts.git
 	branch = main
 	shallow = true
+	ignore = dirty
 [submodule "data/fortawesome/font-awesome"]
 	path = data/fortawesome/font-awesome
 	url = https://github.com/FortAwesome/Font-Awesome.git
 	branch = 7.x
 	shallow = true
+	ignore = dirty
 [submodule "data/google/material_design_icons"]
 	path = data/google/material_design_icons
 	url = https://github.com/google/material-design-icons.git
 	branch = main
 	shallow = true
+	ignore = dirty
 [submodule "data/adobe/source-han-code-jp"]
 	path = data/adobe/source-han-code-jp
 	url = https://github.com/adobe-fonts/source-han-code-jp.git
 	branch = release
 	shallow = true
+	ignore = dirty


### PR DESCRIPTION
This change adds dirty-state ignores to .gitmodules for the example submodules, so updating the pinned submodule contents does not leave the worktree looking dirty.\n\nIt keeps the submodule pointer setup from the earlier example-repo conversion while reducing noise in everyday development.