### PR TITLE
Refine mise tasks and docs

### DIFF
--- a/docs/en/examples/index.md
+++ b/docs/en/examples/index.md
@@ -6,7 +6,7 @@ Runnable examples live in the repository `examples/` directory.
 Run from the repository root, e.g. `python examples/local_fonts.py`.
 
 Examples backed by external font repositories use Git submodules. Initialize
-them with `mise run data-setup`.
+them with `mise run data-sync`.
 
 Some scripts use `num_workers=8`. If you set `num_workers=0`, also remove
 `prefetch_factor`.

--- a/docs/ja/examples/index.md
+++ b/docs/ja/examples/index.md
@@ -8,7 +8,7 @@
 リポジトリのルートで実行してください（例: `python examples/local_fonts.py`）。
 
 外部フォントリポジトリを使うサンプルは Git submodule を使います。
-`mise run data-setup` で初期化してください。
+`mise run data-sync` で初期化してください。
 
 一部スクリプトは `num_workers=8` を前提にしています。`num_workers=0` にする場合は `prefetch_factor` も削除してください。
 :::

--- a/mise.toml
+++ b/mise.toml
@@ -5,34 +5,79 @@ npm = "latest"
 node = "lts"
 
 [tasks.setup]
-run = ["mise install", { tasks = ["setup-uv", "setup-npm"] }]
+sources = ["mise.toml"]
+run = "mise install"
 
-[tasks.setup-uv]
-run = "mise exec -- uv sync"
+[tasks.uv-sync]
+sources = ["pyproject.toml", "uv.lock"]
+depends = ["setup"]
+run = "uv sync"
 
-[tasks.setup-npm]
-run = "mise exec -- npm install"
+[tasks.npm-sync]
+sources = ["package.json", "package-lock.json"]
+depends = ["setup"]
+run = "npm ci"
+
+[tasks.sync]
+depends = ["uv-sync", "npm-sync"]
+
+[tasks.rust-format]
+sources = ["src/**/*.rs"]
+run = "cargo fmt --all"
+
+[tasks.python-format]
+sources = ["examples/**/*.py", "tests/**/*.py", "torchfont/**/*.py"]
+depends = ["uv-sync"]
+run = "uv run ruff format"
 
 [tasks.format]
-run = ["mise exec -- uv run ruff format", "mise exec -- cargo fmt --all"]
+depends = ["rust-format", "python-format"]
+
+[tasks.rust-check]
+sources = ["Cargo.toml", "Cargo.lock", "src/**/*.rs"]
+run = [
+  "cargo fmt --all -- --check",
+  "cargo clippy --all-targets --all-features -- -D warnings",
+  "cargo check --all-targets --all-features",
+]
+
+[tasks.python-check]
+sources = [
+  "pyproject.toml",
+  "uv.lock",
+  "examples/**/*.py",
+  "tests/**/*.py",
+  "torchfont/**/*.py",
+]
+depends = ["uv-sync"]
+run = ["uv run ruff format --check", "uv run ruff check", "uv run ty check"]
 
 [tasks.check]
-run = [
-  "mise exec -- uv run ruff format --diff",
-  "mise exec -- uv run ruff check",
-  "mise exec -- uv run ty check",
-  "mise exec -- cargo fmt --all -- --check",
-  "mise exec -- cargo clippy --all-targets --all-features -- -D warnings",
-  "mise exec -- cargo check --all-targets --all-features",
+depends = ["rust-check", "python-check"]
+
+[tasks.build]
+sources = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "pyproject.toml",
+  "uv.lock",
+  "src/**/*.rs",
+  "torchfont/**/*.py",
 ]
+outputs = ["target/wheels/*.whl"]
+depends = ["check"]
+run = "uv run maturin build"
 
 [tasks.test]
-run = [
-  "mise exec -- uv run maturin develop",
-  "mise exec -- uv run pytest tests",
-]
+depends = ["build"]
+run = "uv run pytest tests"
 
-[tasks.data-setup]
+[tasks.docs-build]
+sources = ["docs/**/*", "package.json", "package-lock.json"]
+depends = ["npm-sync"]
+run = "npm run docs:build"
+
+[tasks.data-sync]
 run = [
   "git submodule sync --recursive",
   "git submodule update --init --depth 1 --recursive",
@@ -43,11 +88,3 @@ run = [
   "git submodule sync --recursive",
   "git submodule update --remote --depth 1 --recursive",
 ]
-
-[tasks.bench]
-run = [
-  "mise exec -- uv run pytest tests/benchmarks --benchmark-only --benchmark-sort=mean",
-]
-
-[tasks.docs-build]
-run = "mise exec -- npm run docs:build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ testpaths = ["tests"]
 
 [tool.ruff]
 unsafe-fixes = true
+exclude = ["data"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -88,3 +89,6 @@ module-name = "torchfont._torchfont"
 
 [tool.ty.rules]
 invalid-method-override = "ignore"
+
+[tool.ty.src]
+exclude = ["data"]


### PR DESCRIPTION
## Summary
- restructure mise tasks for sync/format/check/build/test
- exclude data submodule from ruff and ty
- update docs to reference data-sync task

## Testing
- not run (not requested)