### PR TITLE
[codex] Use maturin develop for build task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -64,9 +64,8 @@ sources = [
   "src/**/*.rs",
   "torchfont/**/*.py",
 ]
-outputs = ["target/wheels/*.whl"]
 depends = ["check"]
-run = "uv run maturin build"
+run = "uv run maturin develop --release"
 
 [tasks.test]
 depends = ["build"]


### PR DESCRIPTION
## Summary
- switch the mise `build` task to `uv run maturin develop --release`
- remove the stale `target/wheels/*.whl` output declaration, since `maturin develop` installs from a temporary wheel instead of updating `target/wheels`

## Impact
This keeps the task definition aligned with its editable-install behavior for local testing.

## Validation
- `mise run build`