### PR TITLE
[codex] Make docs workflow independent of mise

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,6 @@ on:
       - 'README.md'
       - 'package.json'
       - 'package-lock.json'
-      - 'mise.toml'
       - '.readthedocs.yaml'
       - '.github/workflows/docs.yml'
   pull_request:
@@ -18,7 +17,6 @@ on:
       - 'README.md'
       - 'package.json'
       - 'package-lock.json'
-      - 'mise.toml'
       - '.readthedocs.yaml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
@@ -32,6 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
-      - run: mise exec -- npm ci
-      - run: mise run docs-build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run docs:build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     nodejs: "22"
   jobs:
     install:
-      - npm install
+      - npm ci
     build:
       html:
         - npx vitepress build docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,6 @@ build:
       - npm ci
     build:
       html:
-        - npm run docs:build
+        - npx vitepress build docs
         - mkdir -p $READTHEDOCS_OUTPUT/
         - mv docs/.vitepress/dist $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     nodejs: "22"
   jobs:
     install:
-      - npm ci
+      - npm install
     build:
       html:
         - npx vitepress build docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,6 @@ build:
       - npm ci
     build:
       html:
-        - npx vitepress build docs
+        - npm run docs:build
         - mkdir -p $READTHEDOCS_OUTPUT/
         - mv docs/.vitepress/dist $READTHEDOCS_OUTPUT/html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,8 @@ uv run pytest tests --runslow --runnetwork
 Docs use VitePress. Build them with:
 
 ```bash
-mise run docs-build
+npm ci
+npm run docs:build
 ```
 
 Keep `docs/en/` and `docs/ja/` aligned when changing user-facing docs.


### PR DESCRIPTION
## Summary
- replace the docs GitHub Actions mise setup with actions/setup-node, npm ci, and npm run docs:build
- remove mise.toml from docs workflow path triggers because the workflow no longer depends on it
- align Read the Docs and contributing docs with lockfile-based npm docs builds

## Validation
- npm ci
- npm run docs:build
- git diff --check

Note: actionlint was not available in the local environment.