### PR TITLE
[codex] Exclude VitePress dist from docs build sources

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -72,7 +72,12 @@ depends = ["build"]
 run = "uv run pytest tests"
 
 [tasks.docs-build]
-sources = ["docs/**/*", "package.json", "package-lock.json"]
+sources = [
+  "docs/**/*",
+  "!docs/.vitepress/dist/**",
+  "package.json",
+  "package-lock.json",
+]
 depends = ["npm-sync"]
 run = "npm run docs:build"
 


### PR DESCRIPTION
## Summary
- Exclude VitePress build output from the `docs-build` source set.
- Keep package lockfiles as docs build inputs.

## Root Cause
`docs/**/*` also matched `docs/.vitepress/dist/**`, so generated VitePress files could make `mise run docs-build` stale.

## Validation
- `mise run docs-build`
- `mise run docs-build` again: skipped as up-to-date
- Added `docs/.vitepress/dist/codex-stale-check.tmp`, then `mise run docs-build`: skipped as up-to-date
