### PR TITLE
chore: release v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "torchfont"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ignore",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
Bumps the package version to v0.9.2.

Validation:
- mise run test