### PR TITLE
Rename internal quad_to_cubic_inplace to quad_to_cubic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ fn render_bitmap(
 }
 
 #[pyfunction]
-fn quad_to_cubic_inplace<'py>(
+fn quad_to_cubic<'py>(
     mut types: PyReadwriteArray1<'py, i64>,
     mut coords: PyReadwriteArray1<'py, f32>,
     seq_len: usize,
@@ -56,6 +56,6 @@ fn _torchfont(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GlyphDataset>()?;
     m.add_class::<GlyphItem>()?;
     m.add_function(wrap_pyfunction!(render_bitmap, &m)?)?;
-    m.add_function(wrap_pyfunction!(quad_to_cubic_inplace, &m)?)?;
+    m.add_function(wrap_pyfunction!(quad_to_cubic, &m)?)?;
     Ok(())
 }

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -8,9 +8,7 @@ _BitmapMode: TypeAlias = Literal["fixed", "bbox", "bbox_square"]
 def render_bitmap(
     types: np.ndarray, coords: np.ndarray, size: int, mode: _BitmapMode
 ) -> tuple[bytes, int, int]: ...
-def quad_to_cubic(
-    types: np.ndarray, coords: np.ndarray, seq_len: int
-) -> None: ...
+def quad_to_cubic(types: np.ndarray, coords: np.ndarray, seq_len: int) -> None: ...
 
 class GlyphItem:
     types: np.ndarray

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -8,7 +8,7 @@ _BitmapMode: TypeAlias = Literal["fixed", "bbox", "bbox_square"]
 def render_bitmap(
     types: np.ndarray, coords: np.ndarray, size: int, mode: _BitmapMode
 ) -> tuple[bytes, int, int]: ...
-def quad_to_cubic_inplace(
+def quad_to_cubic(
     types: np.ndarray, coords: np.ndarray, seq_len: int
 ) -> None: ...
 

--- a/torchfont/transforms.py
+++ b/torchfont/transforms.py
@@ -30,7 +30,7 @@ def quad_to_cubic(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     seq_len = types.size(-1)
     out_types = types.cpu().contiguous().clone()
     out_coords = coords.cpu().contiguous().clone()
-    _torchfont.quad_to_cubic_inplace(
+    _torchfont.quad_to_cubic(
         out_types.reshape(-1).numpy(),
         out_coords.reshape(-1).numpy(),
         seq_len,


### PR DESCRIPTION
## Summary

- `_inplace` suffix was a historical artifact from when a non-mutating variant existed alongside the mutating one
- Now that the in-place implementation is the only one, the suffix is noise
- Renames the private Rust PyO3 function, its `.pyi` stub, and the call site in `transforms.py`

## Test plan

- [ ] Existing `test_quad_to_cubic_*` tests pass without modification (public API is unchanged)
- [ ] Build succeeds (`mise run build` or equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)