### PR TITLE
Add remove_overlaps transform using Skia PathOps

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -30,6 +30,29 @@ endpoint continuity must cross chunk boundaries.
 - input: `types=(...)`, `coords=(..., 6)`
 - output: `types=(...)`, `coords=(..., 6)`
 
+
+## remove_overlaps
+
+```python
+from torchfont.transforms import remove_overlaps
+```
+
+```python
+types, coords = remove_overlaps(types, coords)
+```
+
+Merges overlapping glyph contours with Skia PathOps while preserving winding-based holes.
+
+- accepts one continuous outline sequence
+- removes internal overlap edges and returns a new variable-length outline
+- returns the original outline unchanged when Skia PathOps cannot simplify it
+- output tensors are CPU-backed because PathOps runs in the Rust backend
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(M,)`, `coords=(M, 6)`
+
 ## patchify
 
 ```python

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -30,6 +30,29 @@ types, coords = quad_to_cubic(types, coords)
 - 入力: `types=(...)`, `coords=(..., 6)`
 - 出力: `types=(...)`, `coords=(..., 6)`
 
+
+## remove_overlaps
+
+```python
+from torchfont.transforms import remove_overlaps
+```
+
+```python
+types, coords = remove_overlaps(types, coords)
+```
+
+Skia PathOps を使い、winding に基づく hole を保ったまま重なったグリフ contour を統合します。
+
+- 1 つの連続した outline シーケンスを受け取ります
+- 重なり内部の edge を除去し、新しい可変長 outline を返します
+- Skia PathOps が簡約できない outline は元のまま返します
+- PathOps は Rust backend で動くため、出力 tensor は CPU 上に置かれます
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(M,)`, `coords=(M, 6)`
+
 ## patchify
 
 ```python

--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -5,12 +5,13 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from torchfont.datasets import GlyphDataset, GlyphSample
-from torchfont.transforms import patchify, quad_to_cubic, render_bitmap
+from torchfont.transforms import patchify, quad_to_cubic, remove_overlaps, render_bitmap
 
 
 def transform(sample: GlyphSample) -> tuple[Tensor, Tensor, Tensor]:
     types = sample.types[:512]
     coords = sample.coords[:512]
+    types, coords = remove_overlaps(types, coords)
     types, coords = quad_to_cubic(types, coords)
     bitmap = render_bitmap(types, coords)
     patch_types, patch_coords = patchify(types, coords, patch_size=32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod bounds;
 mod dataset;
 mod error;
 mod outline;
+mod pathops;
 
 use dataset::{GlyphDataset, GlyphItem};
 use numpy::{PyReadonlyArray1, PyReadwriteArray1};
@@ -40,6 +41,17 @@ fn render_bitmap(
 }
 
 #[pyfunction]
+fn remove_overlaps(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    Ok(pathops::remove_overlaps(
+        types.as_slice()?,
+        coords.as_slice()?,
+    ))
+}
+
+#[pyfunction]
 fn quad_to_cubic<'py>(
     mut types: PyReadwriteArray1<'py, i64>,
     mut coords: PyReadwriteArray1<'py, f32>,
@@ -56,6 +68,7 @@ fn _torchfont(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GlyphDataset>()?;
     m.add_class::<GlyphItem>()?;
     m.add_function(wrap_pyfunction!(render_bitmap, &m)?)?;
+    m.add_function(wrap_pyfunction!(remove_overlaps, &m)?)?;
     m.add_function(wrap_pyfunction!(quad_to_cubic, &m)?)?;
     Ok(())
 }

--- a/src/pathops.rs
+++ b/src/pathops.rs
@@ -1,0 +1,103 @@
+use skia_safe::{Path, PathBuilder, PathFillType, PathVerb};
+
+use crate::outline::Command;
+
+pub(crate) fn remove_overlaps(types: &[i64], coords: &[f32]) -> (Vec<i64>, Vec<f32>) {
+    let path = build_path(types, coords);
+    path.simplify().map_or_else(
+        || segments_from_input(types, coords),
+        |simplified| path_to_segments(&simplified),
+    )
+}
+
+fn build_path(types: &[i64], coords: &[f32]) -> Path {
+    let mut builder = PathBuilder::new_with_fill_type(PathFillType::Winding);
+    for (&command, values) in types.iter().zip(coords.chunks_exact(6)) {
+        match command {
+            v if v == Command::MoveTo as i64 => {
+                builder.move_to((values[4], values[5]));
+            }
+            v if v == Command::LineTo as i64 => {
+                builder.line_to((values[4], values[5]));
+            }
+            v if v == Command::QuadTo as i64 => {
+                builder.quad_to((values[0], values[1]), (values[4], values[5]));
+            }
+            v if v == Command::CurveTo as i64 => {
+                builder.cubic_to(
+                    (values[0], values[1]),
+                    (values[2], values[3]),
+                    (values[4], values[5]),
+                );
+            }
+            v if v == Command::Close as i64 => {
+                builder.close();
+            }
+            _ => break,
+        };
+    }
+    builder.detach()
+}
+
+fn segments_from_input(types: &[i64], coords: &[f32]) -> (Vec<i64>, Vec<f32>) {
+    let len = types
+        .iter()
+        .position(|&command| command == Command::End as i64)
+        .map_or(types.len(), |idx| idx + 1);
+    (types[..len].to_vec(), coords[..len * 6].to_vec())
+}
+
+fn path_to_segments(path: &Path) -> (Vec<i64>, Vec<f32>) {
+    let mut types = Vec::with_capacity(path.verbs().len() + 1);
+    let mut coords = Vec::with_capacity((path.verbs().len() + 1) * 6);
+
+    for record in path.iter() {
+        let points = record.points();
+        match record.verb() {
+            PathVerb::Move => push_endpoint(&mut types, &mut coords, Command::MoveTo, points[0]),
+            PathVerb::Line => push_endpoint(&mut types, &mut coords, Command::LineTo, points[1]),
+            PathVerb::Quad => push(
+                &mut types,
+                &mut coords,
+                Command::QuadTo,
+                [points[1].x, points[1].y, 0.0, 0.0, points[2].x, points[2].y],
+            ),
+            PathVerb::Cubic => push(
+                &mut types,
+                &mut coords,
+                Command::CurveTo,
+                [
+                    points[1].x,
+                    points[1].y,
+                    points[2].x,
+                    points[2].y,
+                    points[3].x,
+                    points[3].y,
+                ],
+            ),
+            PathVerb::Close => push(&mut types, &mut coords, Command::Close, [0.0; 6]),
+            PathVerb::Conic => unreachable!("PathOps simplify should not emit conic segments"),
+        }
+    }
+    push(&mut types, &mut coords, Command::End, [0.0; 6]);
+    (types, coords)
+}
+
+fn push_endpoint(
+    types: &mut Vec<i64>,
+    coords: &mut Vec<f32>,
+    command: Command,
+    point: skia_safe::Point,
+) {
+    push(
+        types,
+        coords,
+        command,
+        [0.0, 0.0, 0.0, 0.0, point.x, point.y],
+    );
+}
+
+fn push(types: &mut Vec<i64>, coords: &mut Vec<f32>, command: Command, values: [f32; 6]) {
+    types.push(command as i64);
+    coords.extend_from_slice(&values);
+}

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -3,7 +3,7 @@ import torch
 
 from torchfont.datasets import GlyphSample
 from torchfont.io import CommandType
-from torchfont.transforms import patchify, quad_to_cubic, render_bitmap
+from torchfont.transforms import patchify, quad_to_cubic, remove_overlaps, render_bitmap
 
 _ZERO_METRICS = torch.zeros(15, dtype=torch.float32)  # placeholder for transform tests
 
@@ -155,6 +155,57 @@ def test_quad_to_cubic_keeps_batched_sequences_independent() -> None:
         out_coords[1, 0],
         torch.tensor([0.0, 2.0, 1.0, 3.0, 3.0, 3.0], dtype=torch.float32),
     )
+
+
+def test_remove_overlaps_merges_overlapping_contours() -> None:
+    types = torch.tensor(
+        [
+            CommandType.MOVE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.MOVE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [
+            [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 2.0, 0.0],
+            [0, 0, 0, 0, 2.0, 2.0],
+            [0, 0, 0, 0, 0.0, 2.0],
+            [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 1.0, 0.0],
+            [0, 0, 0, 0, 3.0, 0.0],
+            [0, 0, 0, 0, 3.0, 2.0],
+            [0, 0, 0, 0, 1.0, 2.0],
+            [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    out_types, out_coords = remove_overlaps(types, coords)
+
+    assert out_types[-1].item() == CommandType.END.value
+    assert out_types.tolist().count(CommandType.MOVE_TO.value) == 1
+    assert out_types.tolist().count(CommandType.CLOSE.value) == 1
+    expected = torch.tensor([0.0, 0.0, 3.0, 2.0])
+    actual = torch.tensor(
+        [
+            out_coords[:, 4].min(),
+            out_coords[:, 5].min(),
+            out_coords[:, 4].max(),
+            out_coords[:, 5].max(),
+        ]
+    )
+    assert torch.allclose(actual, expected)
 
 
 def test_patchify_reshapes_exact_multiple() -> None:

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -8,6 +8,9 @@ _BitmapMode: TypeAlias = Literal["fixed", "bbox", "bbox_square"]
 def render_bitmap(
     types: np.ndarray, coords: np.ndarray, size: int, mode: _BitmapMode
 ) -> tuple[bytes, int, int]: ...
+def remove_overlaps(
+    types: np.ndarray, coords: np.ndarray
+) -> tuple[list[int], list[float]]: ...
 def quad_to_cubic(types: np.ndarray, coords: np.ndarray, seq_len: int) -> None: ...
 
 class GlyphItem:

--- a/torchfont/transforms.py
+++ b/torchfont/transforms.py
@@ -38,6 +38,32 @@ def quad_to_cubic(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     return out_types, out_coords
 
 
+def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Merge overlapping contours using Skia PathOps winding simplification.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+
+    Returns:
+        A new variable-length outline tuple ``(types, coords)`` with overlapping
+        contour edges removed when Skia PathOps can resolve the outline. If
+        PathOps cannot simplify an otherwise valid outline, the original outline
+        is returned unchanged. The output is always CPU-backed because PathOps
+        runs in the Rust backend.
+
+    """
+    types_c = types.cpu().contiguous()
+    coords_c = coords.cpu().contiguous()
+    out_types, out_coords = _torchfont.remove_overlaps(
+        types_c.numpy(), coords_c.reshape(-1).numpy()
+    )
+    return (
+        torch.tensor(out_types, dtype=torch.long),
+        torch.tensor(out_coords, dtype=torch.float32).view(-1, 6),
+    )
+
+
 def patchify(types: Tensor, coords: Tensor, patch_size: int) -> tuple[Tensor, Tensor]:
     """Pad and reshape a glyph sequence into uniform, fixed-size patches.
 
@@ -106,4 +132,10 @@ def render_bitmap(
     return torch.frombuffer(bytearray(raw), dtype=torch.uint8).view(height, width)
 
 
-__all__ = ["BitmapMode", "patchify", "quad_to_cubic", "render_bitmap"]
+__all__ = [
+    "BitmapMode",
+    "patchify",
+    "quad_to_cubic",
+    "remove_overlaps",
+    "render_bitmap",
+]


### PR DESCRIPTION
## Summary

- Adds `src/pathops.rs` with Rust implementation using `skia_safe::Path::simplify()`
- Exposes `remove_overlaps` as a PyO3 function in `src/lib.rs`
- Adds `torchfont.transforms.remove_overlaps(types, coords)` Python wrapper
- Updates type stub, docs (EN/JA), and the `google_fonts` example

## Behavior

- Merges overlapping glyph contours while preserving winding-based holes
- Falls back to the original outline unchanged if PathOps cannot simplify
- Open/truncated contours (e.g. after `[:512]` slicing) are handled correctly — Skia auto-closes open subpaths before simplification, so no pre-processing is required on the caller side
- Output is always CPU-backed

## Test plan

- [x] `test_remove_overlaps_merges_overlapping_contours`: two overlapping squares merge into one contour, bounding box correct
- [x] Full test suite passes (`mise run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)