### PR TITLE
chore: release v0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "ignore",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from v0.9.2 to v0.9.3 (`Cargo.toml` / `Cargo.lock`)

## Test plan

- [ ] CI passes
- [ ] `torchfont.__version__` returns `"0.9.3"` after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)