### PR TITLE
Add cubic_to_quad and merge_curves transforms

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -11,6 +11,8 @@ from torchfont.transforms import quad_to_cubic
 
 ```python
 types, coords = quad_to_cubic(types, coords)
+# or, for one continuous outline sequence:
+types, coords = quad_to_cubic(types, coords, merge_curves=True)
 ```
 
 Converts `CommandType.QUAD_TO` commands to `CommandType.CURVE_TO`.
@@ -25,10 +27,61 @@ Converts `CommandType.QUAD_TO` commands to `CommandType.CURVE_TO`.
 Call `quad_to_cubic` before chunking one continuous outline into patches when
 endpoint continuity must cross chunk boundaries.
 
+Set `merge_curves=True` to merge adjacent reconstructable curves and collinear
+lines in the same Rust call immediately after conversion. This mode is useful
+after `cubic_to_quad`, and because merging can shorten the outline it accepts
+one continuous outline sequence rather than batched inputs.
+
 ### I/O Shape
 
 - input: `types=(...)`, `coords=(..., 6)`
 - output: `types=(...)`, `coords=(..., 6)`
+- with `merge_curves=True`: input `types=(N,)`, `coords=(N, 6)`; output
+  `types=(M,)`, `coords=(M, 6)`
+
+## cubic_to_quad
+
+```python
+from torchfont.transforms import cubic_to_quad
+```
+
+```python
+types, coords = cubic_to_quad(types, coords)
+```
+
+Converts `CommandType.CURVE_TO` commands to quadratic splines using the same
+approximation strategy as fonttools cu2qu.
+
+- accepts one continuous outline sequence
+- one cubic may expand into multiple `CommandType.QUAD_TO` commands
+- adjacent quadratic controls imply on-curve points at their midpoints
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(M,)`, `coords=(M, 6)`
+
+## merge_curves
+
+```python
+from torchfont.transforms import merge_curves
+```
+
+```python
+types, coords = merge_curves(types, coords)
+```
+
+Collapses adjacent segments when they can be reconstructed as one parent shape.
+
+- split cubic pieces are merged back into one cubic when the reconstruction fits
+- split quadratic pieces are merged back into one quadratic when the reconstruction fits
+- consecutive collinear `LineTo` commands moving in the same direction are merged
+- contour boundaries are preserved
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(M,)`, `coords=(M, 6)`
 
 
 ## remove_overlaps

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -11,6 +11,8 @@ from torchfont.transforms import quad_to_cubic
 
 ```python
 types, coords = quad_to_cubic(types, coords)
+# 1 つの連続した outline シーケンスでは:
+types, coords = quad_to_cubic(types, coords, merge_curves=True)
 ```
 
 `CommandType.QUAD_TO` を `CommandType.CURVE_TO` へ変換します。
@@ -25,10 +27,60 @@ types, coords = quad_to_cubic(types, coords)
 1 つの連続した outline を patch に分割し、patch 境界をまたいだ終点の連続性が
 必要な場合は、分割前に `quad_to_cubic` を呼び出してください。
 
+`merge_curves=True` を指定すると、変換直後に復元可能な隣接カーブと共線の line を
+同じ Rust 呼び出し内でまとめます。`cubic_to_quad` の後段で特に有用です。
+マージ後は outline が短くなることがあるため、このモードは batched 入力ではなく
+1 つの連続した outline シーケンスを受け取ります。
+
 ### 入出力
 
 - 入力: `types=(...)`, `coords=(..., 6)`
 - 出力: `types=(...)`, `coords=(..., 6)`
+- `merge_curves=True` の場合: 入力 `types=(N,)`, `coords=(N, 6)`、出力
+  `types=(M,)`, `coords=(M, 6)`
+
+## cubic_to_quad
+
+```python
+from torchfont.transforms import cubic_to_quad
+```
+
+```python
+types, coords = cubic_to_quad(types, coords)
+```
+
+fonttools cu2qu と同じ近似方針で、`CommandType.CURVE_TO` を 2 次 spline へ変換します。
+
+- 1 つの連続した outline シーケンスを受け取ります
+- 1 つの cubic が複数の `CommandType.QUAD_TO` に展開されることがあります
+- 隣接する 2 次制御点の中点が暗黙の on-curve 点になります
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(M,)`, `coords=(M, 6)`
+
+## merge_curves
+
+```python
+from torchfont.transforms import merge_curves
+```
+
+```python
+types, coords = merge_curves(types, coords)
+```
+
+隣接セグメントを 1 つの親形状として復元できる場合にまとめます。
+
+- 分割された cubic は、復元誤差が許容範囲内なら 1 つの cubic に戻します
+- 分割された quadratic は、復元誤差が許容範囲内なら 1 つの quadratic に戻します
+- 同方向へ進む連続した共線の `LineTo` は 1 つにまとめます
+- contour 境界は保持します
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(M,)`, `coords=(M, 6)`
 
 
 ## remove_overlaps

--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -12,7 +12,7 @@ def transform(sample: GlyphSample) -> tuple[Tensor, Tensor, Tensor]:
     types = sample.types[:512]
     coords = sample.coords[:512]
     types, coords = remove_overlaps(types, coords)
-    types, coords = quad_to_cubic(types, coords)
+    types, coords = quad_to_cubic(types, coords, merge_curves=True)
     bitmap = render_bitmap(types, coords)
     patch_types, patch_coords = patchify(types, coords, patch_size=32)
     return patch_types, patch_coords, bitmap

--- a/src/cubic_to_quad.rs
+++ b/src/cubic_to_quad.rs
@@ -1,0 +1,212 @@
+use crate::outline::Command;
+
+// Absolute tolerance for quadratic approximation (normalized coords ≈ 1 font-unit in 1000 UPM).
+const TOLERANCE: f32 = 1e-3;
+// Keep this aligned with fonttools.cu2qu.MAX_N.
+const MAX_N: usize = 100;
+
+type Pt = [f32; 2];
+type Cubic = (Pt, Pt, Pt, Pt);
+
+pub(crate) enum CubicToQuadError {
+    ApproximationFailed,
+}
+
+pub(crate) fn cubic_to_quad(
+    types: &[i64],
+    coords: &[f32],
+) -> Result<(Vec<i64>, Vec<f32>), CubicToQuadError> {
+    let n = types.len();
+    let mut out_types: Vec<i64> = Vec::with_capacity(n);
+    let mut out_coords: Vec<f32> = Vec::with_capacity(n * 6);
+    let mut prev = [0f32; 2];
+
+    for (i, &ty) in types.iter().enumerate() {
+        let c = &coords[i * 6..(i + 1) * 6];
+        if ty == Command::CurveTo as i64 {
+            let p3 = [c[4], c[5]];
+            for (qcp, end) in cubic_to_quads(prev, [c[0], c[1]], [c[2], c[3]], p3)? {
+                out_types.push(Command::QuadTo as i64);
+                out_coords.extend_from_slice(&[qcp[0], qcp[1], 0.0, 0.0, end[0], end[1]]);
+            }
+            prev = p3;
+        } else {
+            out_types.push(ty);
+            out_coords.extend_from_slice(c);
+            if ty == Command::MoveTo as i64
+                || ty == Command::LineTo as i64
+                || ty == Command::QuadTo as i64
+            {
+                prev = [c[4], c[5]];
+            }
+        }
+    }
+    Ok((out_types, out_coords))
+}
+
+// Port of fonttools.cu2qu's all_quadratic=True path.  The returned pairs encode
+// the quadratic spline as explicit commands, with implied on-curves materialized
+// at midpoints between adjacent off-curves.
+fn cubic_to_quads(p0: Pt, p1: Pt, p2: Pt, p3: Pt) -> Result<Vec<(Pt, Pt)>, CubicToQuadError> {
+    for n in 1..=MAX_N {
+        if let Some(spline) = cubic_approx_spline(p0, p1, p2, p3, n) {
+            let mut out = Vec::with_capacity(n);
+            for i in 0..n {
+                let end = if i + 1 == n {
+                    p3
+                } else {
+                    midpt(spline[i + 1], spline[i + 2])
+                };
+                out.push((spline[i + 1], end));
+            }
+            return Ok(out);
+        }
+    }
+    Err(CubicToQuadError::ApproximationFailed)
+}
+
+fn cubic_approx_spline(p0: Pt, p1: Pt, p2: Pt, p3: Pt, n: usize) -> Option<Vec<Pt>> {
+    if n == 1 {
+        let q1 = cubic_approx_quadratic(p0, p1, p2, p3)?;
+        return Some(vec![p0, q1, p3]);
+    }
+
+    let cubics = split_cubic_into_n(p0, p1, p2, p3, n);
+    let mut spline = Vec::with_capacity(n + 2);
+    let mut next_q1 = cubic_approx_control(0.0, cubics[0]);
+    let mut q2 = p0;
+    let mut d1 = [0.0, 0.0];
+    spline.push(p0);
+    spline.push(next_q1);
+
+    for i in 1..=n {
+        let (_c0, c1, c2, c3) = cubics[i - 1];
+        let q0 = q2;
+        let q1 = next_q1;
+        if i < n {
+            next_q1 = cubic_approx_control(i as f32 / (n - 1) as f32, cubics[i]);
+            spline.push(next_q1);
+            q2 = midpt(q1, next_q1);
+        } else {
+            q2 = c3;
+        }
+
+        let d0 = d1;
+        d1 = sub2(q2, c3);
+        let e1 = sub2(lerp2(q0, q1, 2.0 / 3.0), c1);
+        let e2 = sub2(lerp2(q2, q1, 2.0 / 3.0), c2);
+        if dist0(d1) > TOLERANCE || !cubic_farthest_fit_inside(d0, e1, e2, d1, TOLERANCE) {
+            return None;
+        }
+    }
+    spline.push(p3);
+    Some(spline)
+}
+
+fn cubic_approx_quadratic(p0: Pt, p1: Pt, p2: Pt, p3: Pt) -> Option<Pt> {
+    // Most reducible cubics recover their quadratic control from the endpoint
+    // tangent intersection. When both tangents are parallel (notably straight
+    // degree-elevated quadratics), the intersection is at infinity, so recover
+    // the same control from each cubic handle and let the fit test below decide.
+    let q1 = line_intersection(p0, p1, p2, p3)
+        .unwrap_or_else(|| midpt(lerp2(p0, p1, 1.5), lerp2(p3, p2, 1.5)));
+    let c1 = lerp2(p0, q1, 2.0 / 3.0);
+    let c2 = lerp2(p3, q1, 2.0 / 3.0);
+    cubic_farthest_fit_inside(
+        [0.0, 0.0],
+        sub2(c1, p1),
+        sub2(c2, p2),
+        [0.0, 0.0],
+        TOLERANCE,
+    )
+    .then_some(q1)
+}
+
+fn cubic_approx_control(t: f32, (p0, p1, p2, p3): Cubic) -> Pt {
+    let a = lerp2(p0, p1, 1.5);
+    let b = lerp2(p3, p2, 1.5);
+    lerp2(a, b, t)
+}
+
+fn line_intersection(a: Pt, b: Pt, c: Pt, d: Pt) -> Option<Pt> {
+    let ab = sub2(b, a);
+    let cd = sub2(d, c);
+    let den = cross(ab, cd);
+    if den.abs() < 1e-15 {
+        return (b == c && (a == b || c == d)).then_some(b);
+    }
+    let h = cross(sub2(c, a), ab) / den;
+    Some(lerp2(c, d, h))
+}
+
+fn split_cubic_into_n(p0: Pt, p1: Pt, p2: Pt, p3: Pt, n: usize) -> Vec<Cubic> {
+    if n == 1 {
+        return vec![(p0, p1, p2, p3)];
+    }
+    let mut result = Vec::with_capacity(n);
+    let mut current = (p0, p1, p2, p3);
+    for k in 0..n - 1 {
+        let (left, right) = split_cubic_at(
+            current.0,
+            current.1,
+            current.2,
+            current.3,
+            1.0 / (n - k) as f32,
+        );
+        result.push(left);
+        current = right;
+    }
+    result.push(current);
+    result
+}
+
+fn split_cubic_at(p0: Pt, p1: Pt, p2: Pt, p3: Pt, t: f32) -> (Cubic, Cubic) {
+    let q0 = lerp2(p0, p1, t);
+    let q1 = lerp2(p1, p2, t);
+    let q2 = lerp2(p2, p3, t);
+    let r0 = lerp2(q0, q1, t);
+    let r1 = lerp2(q1, q2, t);
+    let s = lerp2(r0, r1, t);
+    ((p0, q0, r0, s), (s, r1, q2, p3))
+}
+
+fn cubic_farthest_fit_inside(p0: Pt, p1: Pt, p2: Pt, p3: Pt, tolerance: f32) -> bool {
+    if dist0(p2) <= tolerance && dist0(p1) <= tolerance {
+        return true;
+    }
+    let mid = [
+        (p0[0] + 3.0 * (p1[0] + p2[0]) + p3[0]) * 0.125,
+        (p0[1] + 3.0 * (p1[1] + p2[1]) + p3[1]) * 0.125,
+    ];
+    if dist0(mid) > tolerance {
+        return false;
+    }
+    let deriv3 = [
+        (p3[0] + p2[0] - p1[0] - p0[0]) * 0.125,
+        (p3[1] + p2[1] - p1[1] - p0[1]) * 0.125,
+    ];
+    cubic_farthest_fit_inside(p0, midpt(p0, p1), sub2(mid, deriv3), mid, tolerance)
+        && cubic_farthest_fit_inside(mid, add2(mid, deriv3), midpt(p2, p3), p3, tolerance)
+}
+
+fn lerp2(a: Pt, b: Pt, t: f32) -> Pt {
+    [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t]
+}
+fn midpt(a: Pt, b: Pt) -> Pt {
+    [(a[0] + b[0]) * 0.5, (a[1] + b[1]) * 0.5]
+}
+fn sub2(a: Pt, b: Pt) -> Pt {
+    [a[0] - b[0], a[1] - b[1]]
+}
+fn add2(a: Pt, b: Pt) -> Pt {
+    [a[0] + b[0], a[1] + b[1]]
+}
+fn cross(a: Pt, b: Pt) -> f32 {
+    a[0] * b[1] - a[1] * b[0]
+}
+fn dist0(a: Pt) -> f32 {
+    if !a[0].is_finite() || !a[1].is_finite() {
+        return f32::INFINITY;
+    }
+    (a[0] * a[0] + a[1] * a[1]).sqrt()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
 mod bitmap;
 mod bounds;
+mod cubic_to_quad;
 mod dataset;
 mod error;
+mod merge_curves;
 mod outline;
 mod pathops;
+mod quad_to_cubic;
 
 use dataset::{GlyphDataset, GlyphItem};
 use numpy::{PyReadonlyArray1, PyReadwriteArray1};
@@ -40,6 +43,17 @@ fn render_bitmap(
     Ok((rendered.data, rendered.width, rendered.height))
 }
 
+#[pyfunction(name = "merge_curves")]
+fn py_merge_curves(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    Ok(merge_curves::merge_curves(t, c))
+}
+
 #[pyfunction]
 fn remove_overlaps(
     types: PyReadonlyArray1<'_, i64>,
@@ -51,24 +65,65 @@ fn remove_overlaps(
     ))
 }
 
-#[pyfunction]
-fn quad_to_cubic<'py>(
+#[pyfunction(name = "quad_to_cubic")]
+fn py_quad_to_cubic<'py>(
     mut types: PyReadwriteArray1<'py, i64>,
     mut coords: PyReadwriteArray1<'py, f32>,
     seq_len: usize,
 ) -> PyResult<()> {
     let t = types.as_slice_mut()?;
     let c = coords.as_slice_mut()?;
-    outline::quad_to_cubic(t, c, seq_len);
+    quad_to_cubic::quad_to_cubic(t, c, seq_len);
     Ok(())
+}
+
+#[pyfunction(name = "quad_to_cubic_and_merge")]
+fn py_quad_to_cubic_and_merge(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    Ok(quad_to_cubic::quad_to_cubic_and_merge(t, c))
+}
+
+#[pyfunction(name = "cubic_to_quad")]
+fn py_cubic_to_quad(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    cubic_to_quad::cubic_to_quad(t, c).map_err(|err| match err {
+        cubic_to_quad::CubicToQuadError::ApproximationFailed => {
+            pyo3::exceptions::PyValueError::new_err(
+                "cubic_to_quad could not approximate a curve within MAX_N segments",
+            )
+        }
+    })
+}
+
+fn ensure_flat_coords_len(types_len: usize, coords_len: usize) -> PyResult<()> {
+    if coords_len == types_len * 6 {
+        Ok(())
+    } else {
+        Err(pyo3::exceptions::PyValueError::new_err(
+            "coords length must equal types length times 6",
+        ))
+    }
 }
 
 #[pymodule]
 fn _torchfont(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GlyphDataset>()?;
     m.add_class::<GlyphItem>()?;
+    m.add_function(wrap_pyfunction!(py_cubic_to_quad, &m)?)?;
+    m.add_function(wrap_pyfunction!(py_merge_curves, &m)?)?;
     m.add_function(wrap_pyfunction!(render_bitmap, &m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, &m)?)?;
-    m.add_function(wrap_pyfunction!(quad_to_cubic, &m)?)?;
+    m.add_function(wrap_pyfunction!(py_quad_to_cubic, &m)?)?;
+    m.add_function(wrap_pyfunction!(py_quad_to_cubic_and_merge, &m)?)?;
     Ok(())
 }

--- a/src/merge_curves.rs
+++ b/src/merge_curves.rs
@@ -1,0 +1,520 @@
+use crate::outline::Command;
+
+// Absolute tolerance for merge validation (normalized coords ≈ 1 font-unit in 1000 UPM).
+const TOLERANCE: f32 = 1e-3;
+
+type Pt = [f32; 2];
+type Cubic = (Pt, Pt, Pt, Pt);
+type Quad = (Pt, Pt, Pt);
+
+pub(crate) fn merge_curves(types: &[i64], coords: &[f32]) -> (Vec<i64>, Vec<f32>) {
+    let n = types.len();
+    let mut out_types: Vec<i64> = Vec::with_capacity(n);
+    let mut out_coords: Vec<f32> = Vec::with_capacity(n * 6);
+
+    let mut i = 0;
+    while i < n {
+        let ty = types[i];
+        let c = arr6(coords, i);
+
+        if ty == Command::MoveTo as i64 {
+            let move_x = c[4];
+            let move_y = c[5];
+            i += 1;
+
+            let mut draw: Vec<(i64, [f32; 6])> = Vec::new();
+            while i < n {
+                let st = types[i];
+                if st == Command::Close as i64
+                    || st == Command::End as i64
+                    || st == Command::MoveTo as i64
+                {
+                    break;
+                }
+                draw.push((st, arr6(coords, i)));
+                i += 1;
+            }
+
+            let merged = merge_contour(move_x, move_y, draw);
+
+            out_types.push(Command::MoveTo as i64);
+            out_coords.extend_from_slice(&c);
+            for (mt, mc) in merged {
+                out_types.push(mt);
+                out_coords.extend_from_slice(&mc);
+            }
+        } else if ty == Command::End as i64 {
+            out_types.push(ty);
+            out_coords.extend_from_slice(&c);
+            break;
+        } else {
+            out_types.push(ty);
+            out_coords.extend_from_slice(&c);
+            i += 1;
+        }
+    }
+
+    (out_types, out_coords)
+}
+
+fn merge_contour(
+    start_x: f32,
+    start_y: f32,
+    segments: Vec<(i64, [f32; 6])>,
+) -> Vec<(i64, [f32; 6])> {
+    let n = segments.len();
+    let mut result: Vec<(i64, [f32; 6])> = Vec::with_capacity(n);
+    let mut result_starts: Vec<[f32; 2]> = Vec::with_capacity(n);
+    let mut i = 0;
+
+    while i < n {
+        let (ty, c) = segments[i];
+        let seg_start = match result.last() {
+            Some((_, lc)) => [lc[4], lc[5]],
+            None => [start_x, start_y],
+        };
+
+        let line = Command::LineTo as i64;
+        let quad = Command::QuadTo as i64;
+        let cubic = Command::CurveTo as i64;
+
+        if ty == cubic {
+            let mut run_end = i + 1;
+            while run_end < n && segments[run_end].0 == cubic {
+                run_end += 1;
+            }
+            let run_len = run_end - i;
+
+            let mut merged = None;
+            for merge_len in (2..=run_len).rev() {
+                if let Some(m) = try_merge_cubics_n(seg_start, &segments[i..i + merge_len]) {
+                    merged = Some((m, merge_len));
+                    break;
+                }
+            }
+
+            if let Some((m, len)) = merged {
+                result.push((cubic, m));
+                result_starts.push(seg_start);
+                i += len;
+            } else {
+                result.push((ty, c));
+                result_starts.push(seg_start);
+                i += 1;
+            }
+        } else if ty == quad {
+            let mut run_end = i + 1;
+            while run_end < n && segments[run_end].0 == quad {
+                run_end += 1;
+            }
+            let run_len = run_end - i;
+
+            let mut merged = None;
+            for merge_len in (2..=run_len).rev() {
+                if let Some(m) = try_merge_quads_n(seg_start, &segments[i..i + merge_len]) {
+                    merged = Some((m, merge_len));
+                    break;
+                }
+            }
+
+            if let Some((m, len)) = merged {
+                result.push((quad, m));
+                result_starts.push(seg_start);
+                i += len;
+            } else {
+                result.push((ty, c));
+                result_starts.push(seg_start);
+                i += 1;
+            }
+        } else if ty == line {
+            let merged = if let (Some(&(last_ty, last_c)), Some(&ls)) =
+                (result.last(), result_starts.last())
+            {
+                if last_ty == line {
+                    let (ax, ay) = (last_c[4], last_c[5]);
+                    let (bx, by) = (c[4], c[5]);
+                    if can_merge_lines(ls[0], ls[1], ax, ay, bx, by) {
+                        Some([0.0f32, 0.0, 0.0, 0.0, bx, by])
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            if let Some(new_c) = merged {
+                let saved_start = *result_starts.last().unwrap();
+                result.pop();
+                result_starts.pop();
+                result.push((line, new_c));
+                result_starts.push(saved_start);
+            } else {
+                result.push((ty, c));
+                result_starts.push(seg_start);
+            }
+            i += 1;
+        } else {
+            result.push((ty, c));
+            result_starts.push(seg_start);
+            i += 1;
+        }
+    }
+
+    result
+}
+
+// Attempt to merge n consecutive quadratic segments into one.
+//
+// The split parameters can be recovered from adjacent tangent-length ratios in
+// the same way as cubics. A parent quadratic then has only one outer control
+// point to reconstruct and validate.
+fn try_merge_quads_n(p0: Pt, segs: &[(i64, [f32; 6])]) -> Option<[f32; 6]> {
+    let n = segs.len();
+    debug_assert!(n >= 2);
+
+    let mut prod_ratio = 1.0_f32;
+    let mut sum_ratio = 1.0_f32;
+    let mut ts_unnorm = vec![1.0_f32];
+
+    for k in 1..n {
+        let prev_c = &segs[k - 1].1;
+        let curr_c = &segs[k].1;
+        let prev_end = [prev_c[4], prev_c[5]];
+        let prev_h = [prev_c[0], prev_c[1]];
+        let curr_h = [curr_c[0], curr_c[1]];
+
+        let end_tan = sub2(prev_end, prev_h);
+        let start_tan = sub2(curr_h, prev_end);
+        let len_end = hypot(end_tan[0], end_tan[1]);
+        let len_start = hypot(start_tan[0], start_tan[1]);
+        if len_end < 1e-10 {
+            return None;
+        }
+        if len_start > 1e-10 {
+            let cross = end_tan[0] * start_tan[1] - end_tan[1] * start_tan[0];
+            if cross.abs() > TOLERANCE * len_end * len_start {
+                return None;
+            }
+            if end_tan[0] * start_tan[0] + end_tan[1] * start_tan[1] < 0.0 {
+                return None;
+            }
+        }
+
+        let ratio = len_start / len_end;
+        prod_ratio *= ratio;
+        sum_ratio += prod_ratio;
+        ts_unnorm.push(sum_ratio);
+    }
+
+    ts_unnorm.pop();
+    let ts: Vec<f32> = ts_unnorm.iter().map(|&t| t / sum_ratio).collect();
+    let t1 = ts[0];
+    if !(1e-6..=1.0 - 1e-6).contains(&t1) {
+        return None;
+    }
+
+    let first_h = [segs[0].1[0], segs[0].1[1]];
+    let p1 = [
+        p0[0] + (first_h[0] - p0[0]) / t1,
+        p0[1] + (first_h[1] - p0[1]) / t1,
+    ];
+    let last_c = &segs[n - 1].1;
+    let p2 = [last_c[4], last_c[5]];
+
+    if !validate_quad_merge(p0, p1, p2, segs, &ts) {
+        return None;
+    }
+
+    Some([p1[0], p1[1], 0.0, 0.0, p2[0], p2[1]])
+}
+
+fn validate_quad_merge(p0: Pt, p1: Pt, p2: Pt, segs: &[(i64, [f32; 6])], ts: &[f32]) -> bool {
+    let pieces = split_quad_at_ts(p0, p1, p2, ts);
+    for (k, (_rp0, rp1, rp2)) in pieces.iter().enumerate() {
+        let orig_c = &segs[k].1;
+        let orig_h = [orig_c[0], orig_c[1]];
+        let orig_end = [orig_c[4], orig_c[5]];
+        if hypot(rp1[0] - orig_h[0], rp1[1] - orig_h[1]) > TOLERANCE
+            || hypot(rp2[0] - orig_end[0], rp2[1] - orig_end[1]) > TOLERANCE
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn split_quad_at_ts(p0: Pt, p1: Pt, p2: Pt, ts: &[f32]) -> Vec<Quad> {
+    let mut pieces = Vec::with_capacity(ts.len() + 1);
+    let mut current = (p0, p1, p2);
+    let mut t_prev = 0.0_f32;
+    for &t in ts {
+        let remaining = 1.0 - t_prev;
+        if remaining < 1e-10 {
+            return pieces;
+        }
+        let t_rel = (t - t_prev) / remaining;
+        let (lp0, lp1, lp2, rp0, rp1, rp2) =
+            split_quad_at_t(current.0, current.1, current.2, t_rel);
+        pieces.push((lp0, lp1, lp2));
+        current = (rp0, rp1, rp2);
+        t_prev = t;
+    }
+    pieces.push(current);
+    pieces
+}
+
+fn split_quad_at_t(p0: Pt, p1: Pt, p2: Pt, t: f32) -> (Pt, Pt, Pt, Pt, Pt, Pt) {
+    let q1 = lerp2(p0, p1, t);
+    let q2 = lerp2(p1, p2, t);
+    let s = lerp2(q1, q2, t);
+    (p0, q1, s, s, q2, p2)
+}
+
+// Attempt to merge n consecutive cubic segments into one.
+//
+// Uses the fonttools qu2cu approach: reconstruct t-parameters from cumulative
+// ratios of adjacent junction tangent lengths, then recover the outer control
+// points P1/P2. Validity is confirmed by re-splitting and measuring curve error.
+fn try_merge_cubics_n(p0: [f32; 2], segs: &[(i64, [f32; 6])]) -> Option<[f32; 6]> {
+    let n = segs.len();
+    debug_assert!(n >= 2);
+
+    // Compute cumulative tangent-length ratios at each junction.
+    // ratio_k = |start_tan_k| / |end_tan_{k-1}|
+    // ts_unnorm accumulates partial sums; the last entry is discarded (= total).
+    let mut prod_ratio = 1.0_f32;
+    let mut sum_ratio = 1.0_f32;
+    let mut ts_unnorm = vec![1.0_f32];
+
+    for k in 1..n {
+        let prev_c = &segs[k - 1].1;
+        let curr_c = &segs[k].1;
+
+        let prev_end = [prev_c[4], prev_c[5]];
+        let prev_h2 = [prev_c[2], prev_c[3]];
+        let curr_h1 = [curr_c[0], curr_c[1]];
+
+        let end_tan = sub2(prev_end, prev_h2);
+        let start_tan = sub2(curr_h1, prev_end);
+
+        let len_end = hypot(end_tan[0], end_tan[1]);
+        let len_start = hypot(start_tan[0], start_tan[1]);
+
+        if len_end < 1e-10 {
+            return None;
+        }
+
+        // Tangents at the junction must be parallel and in the same direction.
+        if len_start > 1e-10 {
+            let cross = end_tan[0] * start_tan[1] - end_tan[1] * start_tan[0];
+            if cross.abs() > TOLERANCE * len_end * len_start {
+                return None;
+            }
+            if end_tan[0] * start_tan[0] + end_tan[1] * start_tan[1] < 0.0 {
+                return None; // anti-parallel (cusp)
+            }
+        }
+
+        let ratio = len_start / len_end;
+        prod_ratio *= ratio;
+        sum_ratio += prod_ratio;
+        ts_unnorm.push(sum_ratio);
+    }
+
+    // Normalize: ts has n-1 elements, ts[0] = t1 (first junction), ts[n-2] = t_{n-1} (last).
+    ts_unnorm.pop();
+    let ts: Vec<f32> = ts_unnorm.iter().map(|&t| t / sum_ratio).collect();
+
+    let t1 = ts[0];
+    let t_last = *ts.last().unwrap();
+
+    if !(1e-6..=1.0 - 1e-6).contains(&t1) || !(1e-6..=1.0 - 1e-6).contains(&t_last) {
+        return None;
+    }
+
+    let first_c = &segs[0].1;
+    let last_c = &segs[n - 1].1;
+    let first_h1 = [first_c[0], first_c[1]];
+    let last_h2 = [last_c[2], last_c[3]];
+    let p3 = [last_c[4], last_c[5]];
+
+    // Recover outer control points from the split relationship:
+    //   first_h1 = lerp(P0, P1, t1)  →  P1 = P0 + (first_h1 − P0) / t1
+    //   last_h2  = lerp(P2, P3, t_last)  →  P2 = P3 + (last_h2 − P3) / (1 − t_last)
+    let p1 = [
+        p0[0] + (first_h1[0] - p0[0]) / t1,
+        p0[1] + (first_h1[1] - p0[1]) / t1,
+    ];
+    let p2 = [
+        p3[0] + (last_h2[0] - p3[0]) / (1.0 - t_last),
+        p3[1] + (last_h2[1] - p3[1]) / (1.0 - t_last),
+    ];
+
+    if !validate_cubic_merge(p0, p1, p2, p3, segs, &ts) {
+        return None;
+    }
+
+    Some([p1[0], p1[1], p2[0], p2[1], p3[0], p3[1]])
+}
+
+fn validate_cubic_merge(
+    p0: [f32; 2],
+    p1: [f32; 2],
+    p2: [f32; 2],
+    p3: [f32; 2],
+    segs: &[(i64, [f32; 6])],
+    ts: &[f32],
+) -> bool {
+    let pieces = split_cubic_at_ts(p0, p1, p2, p3, ts);
+    let mut prev_end = p0;
+
+    for (k, (rp0, rp1, rp2, rp3)) in pieces.iter().enumerate() {
+        let orig_c = &segs[k].1;
+        let orig_h1 = [orig_c[0], orig_c[1]];
+        let orig_h2 = [orig_c[2], orig_c[3]];
+        let orig_end = [orig_c[4], orig_c[5]];
+
+        if hypot(rp3[0] - orig_end[0], rp3[1] - orig_end[1]) > TOLERANCE {
+            return false;
+        }
+
+        // Check that the difference cubic lies within TOLERANCE of the origin.
+        let d0 = sub2(*rp0, prev_end);
+        let d1 = sub2(*rp1, orig_h1);
+        let d2 = sub2(*rp2, orig_h2);
+        let d3 = sub2(*rp3, orig_end);
+
+        if !cubic_farthest_fit_inside(d0, d1, d2, d3, TOLERANCE) {
+            return false;
+        }
+
+        prev_end = orig_end;
+    }
+
+    true
+}
+
+// Split cubic (P0,P1,P2,P3) at each t in ts (ascending), returning n+1 pieces.
+// Each subsequent split uses the reparametrized t relative to the remaining curve.
+fn split_cubic_at_ts(p0: Pt, p1: Pt, p2: Pt, p3: Pt, ts: &[f32]) -> Vec<Cubic> {
+    let mut pieces = Vec::with_capacity(ts.len() + 1);
+    let mut current = (p0, p1, p2, p3);
+    let mut t_prev = 0.0_f32;
+
+    for &t in ts {
+        let remaining = 1.0 - t_prev;
+        if remaining < 1e-10 {
+            return pieces;
+        }
+        let t_rel = (t - t_prev) / remaining;
+        let (lp0, lp1, lp2, lp3, rp0, rp1, rp2, rp3) =
+            split_cubic_at_t(current.0, current.1, current.2, current.3, t_rel);
+        pieces.push((lp0, lp1, lp2, lp3));
+        current = (rp0, rp1, rp2, rp3);
+        t_prev = t;
+    }
+    pieces.push(current);
+    pieces
+}
+
+fn split_cubic_at_t(p0: Pt, p1: Pt, p2: Pt, p3: Pt, t: f32) -> (Pt, Pt, Pt, Pt, Pt, Pt, Pt, Pt) {
+    let q1 = lerp2(p0, p1, t);
+    let q2 = lerp2(p1, p2, t);
+    let q3 = lerp2(p2, p3, t);
+    let r1 = lerp2(q1, q2, t);
+    let r2 = lerp2(q2, q3, t);
+    let s = lerp2(r1, r2, t);
+    (p0, q1, r1, s, s, r2, q3, p3)
+}
+
+// Recursive check: does the cubic (as a displacement field relative to the origin)
+// lie entirely within `tolerance` of the origin?  Ported from fonttools qu2cu.
+fn cubic_farthest_fit_inside(
+    p0: [f32; 2],
+    p1: [f32; 2],
+    p2: [f32; 2],
+    p3: [f32; 2],
+    tolerance: f32,
+) -> bool {
+    if hypot(p2[0], p2[1]) <= tolerance && hypot(p1[0], p1[1]) <= tolerance {
+        return true;
+    }
+
+    let mid = [
+        (p0[0] + 3.0 * (p1[0] + p2[0]) + p3[0]) * 0.125,
+        (p0[1] + 3.0 * (p1[1] + p2[1]) + p3[1]) * 0.125,
+    ];
+    if hypot(mid[0], mid[1]) > tolerance {
+        return false;
+    }
+
+    let deriv3 = [
+        (p3[0] + p2[0] - p1[0] - p0[0]) * 0.125,
+        (p3[1] + p2[1] - p1[1] - p0[1]) * 0.125,
+    ];
+
+    let p01 = lerp2(p0, p1, 0.5);
+    let p23 = lerp2(p2, p3, 0.5);
+
+    cubic_farthest_fit_inside(p0, p01, sub2(mid, deriv3), mid, tolerance)
+        && cubic_farthest_fit_inside(mid, add2(mid, deriv3), p23, p3, tolerance)
+}
+
+fn can_merge_lines(px: f32, py: f32, ax: f32, ay: f32, bx: f32, by: f32) -> bool {
+    let (dx1, dy1) = (ax - px, ay - py);
+    let (dx2, dy2) = (bx - ax, by - ay);
+
+    let len1_sq = dx1 * dx1 + dy1 * dy1;
+    let len2_sq = dx2 * dx2 + dy2 * dy2;
+
+    if len1_sq < 1e-12 || len2_sq < 1e-12 {
+        return true;
+    }
+
+    let total_dx = bx - px;
+    let total_dy = by - py;
+    let total_len = hypot(total_dx, total_dy);
+    if total_len < 1e-6 {
+        return false;
+    }
+
+    // Measure the actual geometric deviation of the join from the merged line,
+    // not just its angle. The rest of the module interprets TOLERANCE as an
+    // absolute distance in normalized coordinates.
+    let distance = (dx1 * total_dy - dy1 * total_dx).abs() / total_len;
+    if distance > TOLERANCE {
+        return false;
+    }
+
+    dx1 * dx2 + dy1 * dy2 >= 0.0
+}
+
+#[inline]
+fn lerp2(a: [f32; 2], b: [f32; 2], t: f32) -> [f32; 2] {
+    [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t]
+}
+
+#[inline]
+fn sub2(a: [f32; 2], b: [f32; 2]) -> [f32; 2] {
+    [a[0] - b[0], a[1] - b[1]]
+}
+
+#[inline]
+fn add2(a: [f32; 2], b: [f32; 2]) -> [f32; 2] {
+    [a[0] + b[0], a[1] + b[1]]
+}
+
+#[inline]
+fn arr6(coords: &[f32], i: usize) -> [f32; 6] {
+    let mut a = [0f32; 6];
+    a.copy_from_slice(&coords[i * 6..(i + 1) * 6]);
+    a
+}
+
+#[inline]
+fn hypot(x: f32, y: f32) -> f32 {
+    (x * x + y * y).sqrt()
+}

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -74,36 +74,3 @@ pub(crate) fn extract_glyph_segments<'a>(
     glyph.draw(settings, &mut pen)?;
     Ok(pen.finish())
 }
-
-pub(crate) fn quad_to_cubic(types: &mut [i64], coords: &mut [f32], seq_len: usize) {
-    debug_assert_eq!(types.len() * 6, coords.len());
-    if seq_len == 0 {
-        return;
-    }
-    let quad = Command::QuadTo as i64;
-    let cubic = Command::CurveTo as i64;
-
-    for (t_seq, c_seq) in types
-        .chunks_mut(seq_len)
-        .zip(coords.chunks_mut(seq_len * 6))
-    {
-        let mut prev_x = 0.0f32;
-        let mut prev_y = 0.0f32;
-        for (i, t) in t_seq.iter_mut().enumerate() {
-            let base = i * 6;
-            let end_x = c_seq[base + 4];
-            let end_y = c_seq[base + 5];
-            if *t == quad {
-                let cx0 = c_seq[base];
-                let cy0 = c_seq[base + 1];
-                c_seq[base] = prev_x + (2.0 / 3.0) * (cx0 - prev_x);
-                c_seq[base + 1] = prev_y + (2.0 / 3.0) * (cy0 - prev_y);
-                c_seq[base + 2] = end_x + (2.0 / 3.0) * (cx0 - end_x);
-                c_seq[base + 3] = end_y + (2.0 / 3.0) * (cy0 - end_y);
-                *t = cubic;
-            }
-            prev_x = end_x;
-            prev_y = end_y;
-        }
-    }
-}

--- a/src/quad_to_cubic.rs
+++ b/src/quad_to_cubic.rs
@@ -1,0 +1,42 @@
+use crate::merge_curves;
+use crate::outline::Command;
+
+pub(crate) fn quad_to_cubic(types: &mut [i64], coords: &mut [f32], seq_len: usize) {
+    debug_assert_eq!(types.len() * 6, coords.len());
+    if seq_len == 0 {
+        return;
+    }
+    let quad = Command::QuadTo as i64;
+    let cubic = Command::CurveTo as i64;
+
+    for (t_seq, c_seq) in types
+        .chunks_mut(seq_len)
+        .zip(coords.chunks_mut(seq_len * 6))
+    {
+        let mut prev_x = 0.0f32;
+        let mut prev_y = 0.0f32;
+        for (i, t) in t_seq.iter_mut().enumerate() {
+            let base = i * 6;
+            let end_x = c_seq[base + 4];
+            let end_y = c_seq[base + 5];
+            if *t == quad {
+                let cx0 = c_seq[base];
+                let cy0 = c_seq[base + 1];
+                c_seq[base] = prev_x + (2.0 / 3.0) * (cx0 - prev_x);
+                c_seq[base + 1] = prev_y + (2.0 / 3.0) * (cy0 - prev_y);
+                c_seq[base + 2] = end_x + (2.0 / 3.0) * (cx0 - end_x);
+                c_seq[base + 3] = end_y + (2.0 / 3.0) * (cy0 - end_y);
+                *t = cubic;
+            }
+            prev_x = end_x;
+            prev_y = end_y;
+        }
+    }
+}
+
+pub(crate) fn quad_to_cubic_and_merge(types: &[i64], coords: &[f32]) -> (Vec<i64>, Vec<f32>) {
+    let mut out_types = types.to_vec();
+    let mut out_coords = coords.to_vec();
+    quad_to_cubic(&mut out_types, &mut out_coords, types.len());
+    merge_curves::merge_curves(&out_types, &out_coords)
+}

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,11 +1,347 @@
+import math
+from collections.abc import Callable, Sequence
+
 import pytest
 import torch
 
 from torchfont.datasets import GlyphSample
 from torchfont.io import CommandType
-from torchfont.transforms import patchify, quad_to_cubic, remove_overlaps, render_bitmap
+from torchfont.transforms import (
+    cubic_to_quad,
+    merge_curves,
+    patchify,
+    quad_to_cubic,
+    remove_overlaps,
+    render_bitmap,
+)
 
-_ZERO_METRICS = torch.zeros(15, dtype=torch.float32)  # placeholder for transform tests
+_ZERO_METRICS = torch.zeros(15, dtype=torch.float32)
+_Point = tuple[float, float]
+_CubicSeg = tuple[_Point, _Point, _Point, _Point]
+_QuadSeg = tuple[_Point, _Point, _Point]
+
+
+def _lerp(
+    a: tuple[float, float], b: tuple[float, float], t: float
+) -> tuple[float, float]:
+    return (a[0] * (1.0 - t) + b[0] * t, a[1] * (1.0 - t) + b[1] * t)
+
+
+def _line_path_to_tensors(points: list[_Point]) -> tuple[torch.Tensor, torch.Tensor]:
+    types = torch.tensor(
+        [CommandType.MOVE_TO.value]
+        + [CommandType.LINE_TO.value] * (len(points) - 1)
+        + [CommandType.CLOSE.value, CommandType.END.value],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [[0.0, 0.0, 0.0, 0.0, x, y] for x, y in points] + [[0.0] * 6, [0.0] * 6],
+        dtype=torch.float32,
+    )
+    return types, coords
+
+
+def _quad_split(
+    p0: _Point, p1: _Point, p2: _Point, t: float
+) -> tuple[_QuadSeg, _QuadSeg]:
+    q0, q1 = _lerp(p0, p1, t), _lerp(p1, p2, t)
+    s = _lerp(q0, q1, t)
+    return (p0, q0, s), (s, q1, p2)
+
+
+def _split_quad(curve: _QuadSeg, ts: tuple[float, ...]) -> list[_QuadSeg]:
+    pieces: list[_QuadSeg] = []
+    current = curve
+    previous_t = 0.0
+    for t in ts:
+        local_t = (t - previous_t) / (1.0 - previous_t)
+        left, current = _quad_split(*current, local_t)
+        pieces.append(left)
+        previous_t = t
+    pieces.append(current)
+    return pieces
+
+
+def _quad_segs_to_tensors(
+    segs: Sequence[_QuadSeg],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    types_list = (
+        [CommandType.MOVE_TO.value]
+        + [CommandType.QUAD_TO.value] * len(segs)
+        + [CommandType.CLOSE.value, CommandType.END.value]
+    )
+    p0 = segs[0][0]
+    coords_list: list[list[float]] = [[0.0, 0.0, 0.0, 0.0, p0[0], p0[1]]]
+    coords_list.extend([s[1][0], s[1][1], 0.0, 0.0, s[2][0], s[2][1]] for s in segs)
+    coords_list += [[0.0] * 6, [0.0] * 6]
+    return (
+        torch.tensor(types_list, dtype=torch.long),
+        torch.tensor(coords_list, dtype=torch.float32),
+    )
+
+
+def _casteljau_split(
+    p0: _Point,
+    p1: _Point,
+    p2: _Point,
+    p3: _Point,
+    t: float,
+) -> tuple[_CubicSeg, _CubicSeg]:
+    q0, q1, q2 = _lerp(p0, p1, t), _lerp(p1, p2, t), _lerp(p2, p3, t)
+    r0, r1 = _lerp(q0, q1, t), _lerp(q1, q2, t)
+    s = _lerp(r0, r1, t)
+    return (p0, q0, r0, s), (s, r1, q2, p3)
+
+
+def _cubic_segs_to_tensors(
+    segs: Sequence[_CubicSeg],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    n = len(segs)
+    types_list = (
+        [CommandType.MOVE_TO.value]
+        + [CommandType.CURVE_TO.value] * n
+        + [CommandType.CLOSE.value, CommandType.END.value]
+    )
+    p0 = segs[0][0]
+    coords_list: list[list[float]] = [[0.0, 0.0, 0.0, 0.0, p0[0], p0[1]]]
+    coords_list.extend(
+        [s[1][0], s[1][1], s[2][0], s[2][1], s[3][0], s[3][1]] for s in segs
+    )
+    coords_list += [[0.0] * 6, [0.0] * 6]
+    return (
+        torch.tensor(types_list, dtype=torch.long),
+        torch.tensor(coords_list, dtype=torch.float32),
+    )
+
+
+_CUBIC_CURVES: list[_CubicSeg] = [
+    ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (2.0, 1.0)),
+    ((0.0, 0.0), (0.5, 1.0), (1.5, 1.0), (2.0, 0.0)),
+    ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)),
+    ((0.0, 0.0), (2.0, 0.0), (0.0, 1.0), (2.0, 1.0)),
+]
+
+
+def _split_cubic(curve: _CubicSeg, ts: tuple[float, ...]) -> list[_CubicSeg]:
+    pieces: list[_CubicSeg] = []
+    current = curve
+    previous_t = 0.0
+    for t in ts:
+        local_t = (t - previous_t) / (1.0 - previous_t)
+        left, current = _casteljau_split(*current, local_t)
+        pieces.append(left)
+        previous_t = t
+    pieces.append(current)
+    return pieces
+
+
+def _sub_cubic(curve: _CubicSeg, t1: float, t2: float) -> _CubicSeg:
+    if t1 == 0.0:
+        left, _ = _casteljau_split(*curve, t2)
+        return left
+    _, right = _casteljau_split(*curve, t1)
+    t_adj = (t2 - t1) / (1.0 - t1)
+    left, _ = _casteljau_split(*right, t_adj)
+    return left
+
+
+def _cubic_coords(curve: _CubicSeg) -> torch.Tensor:
+    p1, p2, p3 = curve[1], curve[2], curve[3]
+    return torch.tensor([p1[0], p1[1], p2[0], p2[1], p3[0], p3[1]], dtype=torch.float32)
+
+
+def _assert_single_cubic_matches(
+    types: torch.Tensor,
+    coords: torch.Tensor,
+    curve: _CubicSeg,
+    *,
+    atol: float = 1e-4,
+) -> None:
+    assert types.tolist().count(CommandType.CURVE_TO.value) == 1
+    idx = types.tolist().index(CommandType.CURVE_TO.value)
+    assert torch.allclose(coords[idx], _cubic_coords(curve), atol=atol)
+
+
+def test_merge_curves_collinear_lines_are_merged() -> None:
+    types, coords = _line_path_to_tensors(
+        [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0)]
+    )
+
+    out_types, out_coords = merge_curves(types, coords)
+
+    assert out_types.tolist().count(CommandType.LINE_TO.value) == 1
+    line_idx = out_types.tolist().index(CommandType.LINE_TO.value)
+    assert out_coords[line_idx, 4].item() == pytest.approx(3.0)
+    assert out_coords[line_idx, 5].item() == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        pytest.param([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)], id="corner"),
+        # Tiny angular bend, but far from the merged line in normalized coordinates.
+        pytest.param(
+            [(0.0, 0.0), (1_000.0, 0.0), (2_000.0, 0.5)], id="absolute-tolerance"
+        ),
+        pytest.param([(0.0, 0.0), (1.0, 0.0), (0.5, 0.0)], id="antiparallel"),
+    ],
+)
+def test_merge_curves_non_mergeable_lines_stay_separate(points: list[_Point]) -> None:
+    types, coords = _line_path_to_tensors(points)
+
+    out_types, _out_coords = merge_curves(types, coords)
+
+    assert out_types.tolist().count(CommandType.LINE_TO.value) == 2
+
+
+@pytest.mark.parametrize(
+    "ts",
+    [(0.2,), (0.4,), (0.5,), (0.7,), (0.9,), (0.2, 0.6), (0.3, 0.7), (0.5, 0.8)],
+)
+@pytest.mark.parametrize("curve", _CUBIC_CURVES)
+def test_merge_curves_split_cubics_roundtrip(
+    ts: tuple[float, ...], curve: _CubicSeg
+) -> None:
+    types, coords = _cubic_segs_to_tensors(_split_cubic(curve, ts))
+
+    out_types, out_coords = merge_curves(types, coords)
+
+    _assert_single_cubic_matches(out_types, out_coords, curve)
+
+
+@pytest.mark.parametrize("ts", [(0.2,), (0.5,), (0.8,), (0.2, 0.6), (0.3, 0.7)])
+def test_merge_curves_split_quads_roundtrip(ts: tuple[float, ...]) -> None:
+    curve: _QuadSeg = ((0.0, 0.0), (1.0, 2.0), (3.0, 0.0))
+    types, coords = _quad_segs_to_tensors(_split_quad(curve, ts))
+
+    out_types, out_coords = merge_curves(types, coords)
+
+    assert out_types.tolist().count(CommandType.QUAD_TO.value) == 1
+    idx = out_types.tolist().index(CommandType.QUAD_TO.value)
+    assert torch.allclose(
+        out_coords[idx],
+        torch.tensor([1.0, 2.0, 0.0, 0.0, 3.0, 0.0]),
+        atol=1e-4,
+    )
+
+
+def test_merge_curves_incompatible_quads_are_not_merged() -> None:
+    types = torch.tensor(
+        [
+            CommandType.MOVE_TO.value,
+            CommandType.QUAD_TO.value,
+            CommandType.QUAD_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+            [2.0, 0.0, 0.0, 0.0, 2.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    out_types, _out_coords = merge_curves(types, coords)
+
+    assert out_types.tolist().count(CommandType.QUAD_TO.value) == 2
+
+
+def test_merge_curves_incompatible_cubics_are_not_merged() -> None:
+    types = torch.tensor(
+        [
+            CommandType.MOVE_TO.value,
+            CommandType.CURVE_TO.value,
+            CommandType.CURVE_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
+            [2.0, 0.0, 2.0, 1.0, 2.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    out_types, _out_coords = merge_curves(types, coords)
+
+    assert out_types.tolist().count(CommandType.CURVE_TO.value) == 2
+
+
+def test_merge_curves_preserves_structure_outside_contour() -> None:
+    types = torch.tensor(
+        [
+            CommandType.MOVE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(4, 6, dtype=torch.float32)
+    coords[1, 4] = 1.0
+
+    out_types, _out_coords = merge_curves(types, coords)
+
+    assert out_types[-1].item() == CommandType.END.value
+    assert CommandType.CLOSE.value in out_types.tolist()
+
+
+def test_merge_curves_multiple_contours() -> None:
+    def _contour(ox: float) -> tuple[list[int], list[list[float]]]:
+        t = [
+            CommandType.MOVE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.CLOSE.value,
+        ]
+        c = [
+            [0.0, 0.0, 0.0, 0.0, ox, 0.0],
+            [0.0, 0.0, 0.0, 0.0, ox + 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, ox + 2.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+        return t, c
+
+    t1, c1 = _contour(0.0)
+    t2, c2 = _contour(10.0)
+    end_t = [CommandType.END.value]
+    end_c = [[0.0] * 6]
+
+    types = torch.tensor(t1 + t2 + end_t, dtype=torch.long)
+    coords = torch.tensor(c1 + c2 + end_c, dtype=torch.float32)
+
+    out_types, _out_coords = merge_curves(types, coords)
+
+    assert out_types.tolist().count(CommandType.LINE_TO.value) == 2
+    assert out_types.tolist().count(CommandType.MOVE_TO.value) == 2
+
+
+@pytest.mark.parametrize("transform", [cubic_to_quad, merge_curves])
+def test_variable_length_transforms_reject_mismatched_coords(
+    transform: Callable[
+        [torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]
+    ],
+) -> None:
+    types = torch.tensor(
+        [CommandType.MOVE_TO.value, CommandType.CURVE_TO.value],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(1, 6, dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="coords length"):
+        transform(types, coords)
 
 
 def test_quad_to_cubic_converts_quadratic_segments() -> None:
@@ -22,12 +358,12 @@ def test_quad_to_cubic_converts_quadratic_segments() -> None:
     )
     coords = torch.tensor(
         [
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # moveTo(0, 0)
-            [0.0, 1.0, 0.0, 0.0, 1.0, 1.0],  # quadTo((0, 1), (1, 1))
-            [0.0, 0.0, 0.0, 0.0, 2.0, 1.0],  # lineTo(2, 1)
-            [3.0, 2.0, 0.0, 0.0, 4.0, 1.0],  # quadTo((3, 2), (4, 1))
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # close
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # end
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0, 2.0, 1.0],
+            [3.0, 2.0, 0.0, 0.0, 4.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
         ],
         dtype=torch.float32,
     )
@@ -157,6 +493,183 @@ def test_quad_to_cubic_keeps_batched_sequences_independent() -> None:
         out_coords[1, 0],
         torch.tensor([0.0, 2.0, 1.0, 3.0, 3.0, 3.0], dtype=torch.float32),
     )
+
+
+def test_quad_to_cubic_can_merge_curves_in_same_transform() -> None:
+    curve = _CUBIC_CURVES[0]
+    types, coords = _cubic_segs_to_tensors([curve])
+    q_types, q_coords = cubic_to_quad(types, coords)
+
+    out_types, out_coords = quad_to_cubic(q_types, q_coords, merge_curves=True)
+
+    _assert_single_cubic_matches(out_types, out_coords, curve)
+
+
+def test_quad_to_cubic_merge_curves_runs_even_without_quadratics() -> None:
+    types, coords = _line_path_to_tensors(
+        [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0)]
+    )
+
+    out_types, _out_coords = quad_to_cubic(types, coords, merge_curves=True)
+
+    assert out_types.tolist().count(CommandType.LINE_TO.value) == 1
+
+
+def test_cubic_to_quad_produces_quad_to_commands() -> None:
+    curve = _CUBIC_CURVES[0]
+    types, coords = _cubic_segs_to_tensors([curve])
+
+    out_types, out_coords = cubic_to_quad(types, coords)
+
+    assert CommandType.CURVE_TO.value not in out_types.tolist()
+    assert CommandType.QUAD_TO.value in out_types.tolist()
+    assert out_coords.shape[1] == 6
+
+
+def test_cubic_to_quad_passes_through_non_cubic_commands() -> None:
+    types = torch.tensor(
+        [
+            CommandType.MOVE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    out_types, out_coords = cubic_to_quad(types, coords)
+
+    assert out_types.tolist() == types.tolist()
+    assert torch.equal(out_coords, coords)
+
+
+@pytest.mark.parametrize(
+    "curve",
+    [
+        ((0.0, 0.0), (0.5, 1.0), (1.5, 1.0), (3.0, 0.0)),
+        ((0.0, 0.0), (1.0 / 3.0, 0.0), (2.0 / 3.0, 0.0), (1.0, 0.0)),
+    ],
+)
+def test_cubic_to_quad_exact_quadratics_use_one_segment_and_roundtrip(
+    curve: _CubicSeg,
+) -> None:
+    # Cubics with p0 - 3*p1 + 3*p2 - p3 = 0 are exactly degree-elevated
+    # quadratics; parallel endpoint tangents are covered by the straight case.
+    types, coords = _cubic_segs_to_tensors([curve])
+
+    q_types, q_coords = cubic_to_quad(types, coords)
+
+    assert q_types.tolist().count(CommandType.QUAD_TO.value) == 1
+
+    c_types, c_coords = quad_to_cubic(q_types, q_coords)
+    m_types, m_coords = merge_curves(c_types, c_coords)
+
+    _assert_single_cubic_matches(m_types, m_coords, curve, atol=1e-5)
+
+
+@pytest.mark.parametrize("curve", _CUBIC_CURVES)
+def test_cubic_to_quad_quad_to_cubic_merge_curves_roundtrip(curve: _CubicSeg) -> None:
+    types, coords = _cubic_segs_to_tensors([curve])
+
+    q_types, q_coords = cubic_to_quad(types, coords)
+    c_types, c_coords = quad_to_cubic(q_types, q_coords)
+    m_types, m_coords = merge_curves(c_types, c_coords)
+
+    _assert_single_cubic_matches(m_types, m_coords, curve)
+
+
+def test_cubic_to_quad_reports_unrepresentable_large_curve() -> None:
+    # With normalized input this should be unusual, but public APIs should not
+    # turn malformed/extreme input into a Rust panic.
+    curve: _CubicSeg = (
+        (0.0, 0.0),
+        (0.0, 10_000.0),
+        (10_000.0, 10_000.0),
+        (10_000.0, 0.0),
+    )
+    types, coords = _cubic_segs_to_tensors([curve])
+
+    with pytest.raises(ValueError, match="could not approximate"):
+        cubic_to_quad(types, coords)
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf])
+def test_cubic_to_quad_reports_non_finite_curve(value: float) -> None:
+    curve: _CubicSeg = (
+        (0.0, 0.0),
+        (value, 0.0),
+        (1.0, 1.0),
+        (1.0, 0.0),
+    )
+    types, coords = _cubic_segs_to_tensors([curve])
+
+    with pytest.raises(ValueError, match="could not approximate"):
+        cubic_to_quad(types, coords)
+
+
+@pytest.mark.parametrize("curve", _CUBIC_CURVES)
+def test_cubic_to_quad_quad_to_cubic_endpoints_are_exact(curve: _CubicSeg) -> None:
+    types, coords = _cubic_segs_to_tensors([curve])
+
+    q_types, q_coords = cubic_to_quad(types, coords)
+
+    quad_indices = [
+        i for i, t in enumerate(q_types.tolist()) if t == CommandType.QUAD_TO.value
+    ]
+    assert len(quad_indices) >= 1
+
+    last_idx = quad_indices[-1]
+    orig_end = torch.tensor([curve[3][0], curve[3][1]], dtype=torch.float32)
+    assert torch.allclose(q_coords[last_idx, 4:6], orig_end, atol=1e-5)
+
+    # For multi-segment results, intermediate on-curve points are midpoints of
+    # adjacent off-curve control points (TrueType spline convention).
+    if len(quad_indices) > 1:
+        for k in range(len(quad_indices) - 1):
+            qi = quad_indices[k]
+            qi1 = quad_indices[k + 1]
+            mid = (q_coords[qi, :2] + q_coords[qi1, :2]) / 2.0
+            assert torch.allclose(q_coords[qi, 4:6], mid, atol=1e-5)
+
+
+@pytest.mark.parametrize("curve", _CUBIC_CURVES)
+def test_cubic_to_quad_implied_cubics_close_to_sub_cubics(curve: _CubicSeg) -> None:
+    # cubic_to_quad splits the cubic into N quads at t = i/N.
+    # quad_to_cubic converts each back; the resulting cp1/cp2 must be close to
+    # the De Casteljau sub-cubic's own control points.
+    # This directly validates the algorithm's tolerance guarantee.
+    types, coords = _cubic_segs_to_tensors([curve])
+
+    q_types, q_coords = cubic_to_quad(types, coords)
+    c_types, c_coords = quad_to_cubic(q_types, q_coords)
+
+    quad_count = q_types.tolist().count(CommandType.QUAD_TO.value)
+    curve_indices = [
+        i for i, t in enumerate(c_types.tolist()) if t == CommandType.CURVE_TO.value
+    ]
+    assert len(curve_indices) == quad_count
+
+    for i, ci in enumerate(curve_indices):
+        sub = _sub_cubic(curve, i / quad_count, (i + 1) / quad_count)
+        actual_cp1 = (c_coords[ci, 0].item(), c_coords[ci, 1].item())
+        actual_cp2 = (c_coords[ci, 2].item(), c_coords[ci, 3].item())
+        err1 = math.sqrt(
+            (actual_cp1[0] - sub[1][0]) ** 2 + (actual_cp1[1] - sub[1][1]) ** 2
+        )
+        err2 = math.sqrt(
+            (actual_cp2[0] - sub[2][0]) ** 2 + (actual_cp2[1] - sub[2][1]) ** 2
+        )
+        assert err1 <= 2e-3, f"segment {i}: cp1 error {err1}"
+        assert err2 <= 2e-3, f"segment {i}: cp2 error {err2}"
 
 
 def test_remove_overlaps_merges_overlapping_contours() -> None:

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -5,6 +5,12 @@ import numpy as np
 
 _BitmapMode: TypeAlias = Literal["fixed", "bbox", "bbox_square"]
 
+def cubic_to_quad(
+    types: np.ndarray, coords: np.ndarray
+) -> tuple[list[int], list[float]]: ...
+def merge_curves(
+    types: np.ndarray, coords: np.ndarray
+) -> tuple[list[int], list[float]]: ...
 def render_bitmap(
     types: np.ndarray, coords: np.ndarray, size: int, mode: _BitmapMode
 ) -> tuple[bytes, int, int]: ...
@@ -12,6 +18,9 @@ def remove_overlaps(
     types: np.ndarray, coords: np.ndarray
 ) -> tuple[list[int], list[float]]: ...
 def quad_to_cubic(types: np.ndarray, coords: np.ndarray, seq_len: int) -> None: ...
+def quad_to_cubic_and_merge(
+    types: np.ndarray, coords: np.ndarray
+) -> tuple[list[int], list[float]]: ...
 
 class GlyphItem:
     types: np.ndarray

--- a/torchfont/transforms.py
+++ b/torchfont/transforms.py
@@ -13,19 +13,35 @@ from torchfont.io import CommandType
 BitmapMode = Literal["fixed", "bbox", "bbox_square"]
 
 
-def quad_to_cubic(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+def quad_to_cubic(
+    types: Tensor, coords: Tensor, *, merge_curves: bool = False
+) -> tuple[Tensor, Tensor]:
     """Convert ``CommandType.QUAD_TO`` entries to ``CommandType.CURVE_TO``.
 
     The command and coordinate shapes are preserved. Coordinate rows use the
     ``[cx0, cy0, cx1, cy1, x, y]`` layout, with quadratic control points read
     from ``[cx0, cy0]`` and endpoints from ``[x, y]``.
 
-    The last dimension of ``types`` is treated as the sequence dimension. Any
-    leading dimensions are independent sequences, so call this before chunking a
-    continuous outline if endpoint continuity must cross chunk boundaries.
+    By default, the last dimension of ``types`` is treated as the sequence
+    dimension. Any leading dimensions are independent sequences, so call this
+    before chunking a continuous outline if endpoint continuity must cross chunk
+    boundaries.
+
+    When ``merge_curves=True``, adjacent mergeable curves and lines are merged
+    in the same Rust call after conversion. This variable-length mode accepts
+    one continuous outline sequence and returns ``types=(M,)`` and
+    ``coords=(M, 6)``.
     """
     types = types.cpu().contiguous()
     coords = coords.cpu().contiguous()
+    if merge_curves:
+        out_types, out_coords = _torchfont.quad_to_cubic_and_merge(
+            types.numpy(), coords.reshape(-1).numpy()
+        )
+        return (
+            torch.tensor(out_types, dtype=torch.long),
+            torch.tensor(out_coords, dtype=torch.float32).view(-1, 6),
+        )
     if not torch.any(types == CommandType.QUAD_TO.value):
         return types, coords
 
@@ -38,6 +54,72 @@ def quad_to_cubic(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
         seq_len,
     )
     return out_types, out_coords
+
+
+def cubic_to_quad(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Convert ``CommandType.CURVE_TO`` entries to ``CommandType.QUAD_TO`` sequences.
+
+    Each cubic Bezier segment is replaced by the minimum number of quadratic
+    Bezier segments needed to approximate it within ~1e-3 normalised UPM units
+    (roughly 1 font-unit in a 1000-UPM font), following the fonttools cu2qu
+    approach. Consecutive quadratics share implicit on-curve points at the
+    midpoints of adjacent off-curve control points (TrueType spline).
+
+    Unlike ``quad_to_cubic``, the output length may differ from the input
+    because a single cubic can expand into multiple quadratics.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+
+    Returns:
+        A new variable-length outline tuple ``(types, coords)`` where each
+        ``CurveTo`` has been replaced by one or more ``QuadTo`` commands.
+        Non-cubic commands are passed through unchanged.
+
+    """
+    types = types.cpu().contiguous()
+    coords = coords.cpu().contiguous()
+    out_types, out_coords = _torchfont.cubic_to_quad(
+        types.numpy(), coords.reshape(-1).numpy()
+    )
+    return (
+        torch.tensor(out_types, dtype=torch.long),
+        torch.tensor(out_coords, dtype=torch.float32).view(-1, 6),
+    )
+
+
+def merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Merge adjacent segments that belong to the same parent curve or line.
+
+    Adjacent cubic and quadratic Bezier segments are merged when they are pieces
+    of a single parent curve (i.e. joined at smooth split points determined via
+    de Casteljau). Adjacent ``LineTo`` segments are merged when the three points are
+    collinear and the segments run in the same direction. Unlike the fonttools
+    ``merge_curves`` helper this transform also handles line segments.
+
+    The comparison tolerance is ~1e-3 in normalised UPM coordinates (roughly
+    1 font-unit in a 1000-UPM font), matching the precision typically used by
+    fonttools.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+
+    Returns:
+        A new variable-length outline tuple ``(types, coords)`` with mergeable
+        adjacent segments collapsed.
+
+    """
+    types = types.cpu().contiguous()
+    coords = coords.cpu().contiguous()
+    out_types, out_coords = _torchfont.merge_curves(
+        types.numpy(), coords.reshape(-1).numpy()
+    )
+    return (
+        torch.tensor(out_types, dtype=torch.long),
+        torch.tensor(out_coords, dtype=torch.float32).view(-1, 6),
+    )
 
 
 def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
@@ -135,6 +217,8 @@ def render_bitmap(
 
 __all__ = [
     "BitmapMode",
+    "cubic_to_quad",
+    "merge_curves",
     "patchify",
     "quad_to_cubic",
     "remove_overlaps",


### PR DESCRIPTION
## Summary

- Add `cubic_to_quad` transform: converts `CurveTo` commands to `QuadTo` sequences using a cu2qu-style approximation (minimum segments within ~1e-3 normalised UPM tolerance)
- Add `merge_curves` transform: merges adjacent split cubics/quads back into parent curves, and collinear `LineTo` segments in the same direction
- Add `merge_curves=True` option to `quad_to_cubic` for a single combined convert-and-merge Rust call
- Refactor `quad_to_cubic` out of `outline.rs` into its own `src/quad_to_cubic.rs` module
- Add EN/JA documentation and comprehensive test coverage

## Test plan

- [ ] `mise run test` passes (unit tests for all new transforms including roundtrip, edge cases, and error paths)
- [ ] `mise run lint` / `mise run fmt` pass
- [ ] Docs build cleanly (`docs/en/` and `docs/ja/` aligned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)