### PR TITLE
refactor: unify #[pyfunction] style and reorder GlyphDataset methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,68 @@ use numpy::{PyReadonlyArray1, PyReadwriteArray1};
 use pyo3::{Bound, prelude::*, types::PyModule};
 
 #[pyfunction]
+fn quad_to_cubic<'py>(
+    mut types: PyReadwriteArray1<'py, i64>,
+    mut coords: PyReadwriteArray1<'py, f32>,
+    seq_len: usize,
+) -> PyResult<()> {
+    let t = types.as_slice_mut()?;
+    let c = coords.as_slice_mut()?;
+    transform::quad_to_cubic::quad_to_cubic(t, c, seq_len);
+    Ok(())
+}
+
+#[pyfunction]
+fn quad_to_cubic_and_merge(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    Ok(transform::quad_to_cubic::quad_to_cubic_and_merge(t, c))
+}
+
+#[pyfunction]
+fn cubic_to_quad(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    transform::cubic_to_quad::cubic_to_quad(t, c).map_err(|err| match err {
+        transform::cubic_to_quad::CubicToQuadError::ApproximationFailed => {
+            pyo3::exceptions::PyValueError::new_err(
+                "cubic_to_quad could not approximate a curve within MAX_N segments",
+            )
+        }
+    })
+}
+
+#[pyfunction]
+fn merge_curves(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    Ok(transform::merge_curves::merge_curves(t, c))
+}
+
+#[pyfunction]
+fn remove_overlaps(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    Ok(transform::remove_overlaps::remove_overlaps(
+        types.as_slice()?,
+        coords.as_slice()?,
+    ))
+}
+
+#[pyfunction]
 fn render_bitmap(
     types: PyReadonlyArray1<'_, i64>,
     coords: PyReadonlyArray1<'_, f32>,
@@ -42,68 +104,6 @@ fn render_bitmap(
     Ok((rendered.data, rendered.width, rendered.height))
 }
 
-#[pyfunction(name = "merge_curves")]
-fn py_merge_curves(
-    types: PyReadonlyArray1<'_, i64>,
-    coords: PyReadonlyArray1<'_, f32>,
-) -> PyResult<(Vec<i64>, Vec<f32>)> {
-    let t = types.as_slice()?;
-    let c = coords.as_slice()?;
-    ensure_flat_coords_len(t.len(), c.len())?;
-    Ok(transform::merge_curves::merge_curves(t, c))
-}
-
-#[pyfunction]
-fn remove_overlaps(
-    types: PyReadonlyArray1<'_, i64>,
-    coords: PyReadonlyArray1<'_, f32>,
-) -> PyResult<(Vec<i64>, Vec<f32>)> {
-    Ok(transform::remove_overlaps::remove_overlaps(
-        types.as_slice()?,
-        coords.as_slice()?,
-    ))
-}
-
-#[pyfunction(name = "quad_to_cubic")]
-fn py_quad_to_cubic<'py>(
-    mut types: PyReadwriteArray1<'py, i64>,
-    mut coords: PyReadwriteArray1<'py, f32>,
-    seq_len: usize,
-) -> PyResult<()> {
-    let t = types.as_slice_mut()?;
-    let c = coords.as_slice_mut()?;
-    transform::quad_to_cubic::quad_to_cubic(t, c, seq_len);
-    Ok(())
-}
-
-#[pyfunction(name = "quad_to_cubic_and_merge")]
-fn py_quad_to_cubic_and_merge(
-    types: PyReadonlyArray1<'_, i64>,
-    coords: PyReadonlyArray1<'_, f32>,
-) -> PyResult<(Vec<i64>, Vec<f32>)> {
-    let t = types.as_slice()?;
-    let c = coords.as_slice()?;
-    ensure_flat_coords_len(t.len(), c.len())?;
-    Ok(transform::quad_to_cubic::quad_to_cubic_and_merge(t, c))
-}
-
-#[pyfunction(name = "cubic_to_quad")]
-fn py_cubic_to_quad(
-    types: PyReadonlyArray1<'_, i64>,
-    coords: PyReadonlyArray1<'_, f32>,
-) -> PyResult<(Vec<i64>, Vec<f32>)> {
-    let t = types.as_slice()?;
-    let c = coords.as_slice()?;
-    ensure_flat_coords_len(t.len(), c.len())?;
-    transform::cubic_to_quad::cubic_to_quad(t, c).map_err(|err| match err {
-        transform::cubic_to_quad::CubicToQuadError::ApproximationFailed => {
-            pyo3::exceptions::PyValueError::new_err(
-                "cubic_to_quad could not approximate a curve within MAX_N segments",
-            )
-        }
-    })
-}
-
 fn ensure_flat_coords_len(types_len: usize, coords_len: usize) -> PyResult<()> {
     if coords_len == types_len * 6 {
         Ok(())
@@ -118,11 +118,11 @@ fn ensure_flat_coords_len(types_len: usize, coords_len: usize) -> PyResult<()> {
 fn _torchfont(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GlyphDataset>()?;
     m.add_class::<GlyphItem>()?;
-    m.add_function(wrap_pyfunction!(py_cubic_to_quad, &m)?)?;
-    m.add_function(wrap_pyfunction!(py_merge_curves, &m)?)?;
-    m.add_function(wrap_pyfunction!(render_bitmap, &m)?)?;
+    m.add_function(wrap_pyfunction!(quad_to_cubic, &m)?)?;
+    m.add_function(wrap_pyfunction!(quad_to_cubic_and_merge, &m)?)?;
+    m.add_function(wrap_pyfunction!(cubic_to_quad, &m)?)?;
+    m.add_function(wrap_pyfunction!(merge_curves, &m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, &m)?)?;
-    m.add_function(wrap_pyfunction!(py_quad_to_cubic, &m)?)?;
-    m.add_function(wrap_pyfunction!(py_quad_to_cubic_and_merge, &m)?)?;
+    m.add_function(wrap_pyfunction!(render_bitmap, &m)?)?;
     Ok(())
 }

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -201,54 +201,6 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
             f"content_classes={self._dataset.content_class_count})"
         )
 
-    def __getstate__(self) -> dict[str, object]:
-        """Return state without the native backend for worker reconstruction."""
-        state = self.__dict__.copy()
-        state.pop("_dataset", None)
-        return state
-
-    def __setstate__(self, state: dict[str, object]) -> None:
-        """Restore state and recreate the native backend after unpickling."""
-        state.pop("_metadata", None)
-        self.__dict__.update(state)
-        self._validate_root_dir(self.root)
-        self._dataset = _torchfont.GlyphDataset(
-            str(self.root),
-            self.codepoints,
-            self.patterns,
-        )
-
-    @staticmethod
-    def _validate_root_dir(root: Path) -> None:
-        """Raise ValueError if *root* exists but is not a directory."""
-        if root.exists() and not root.is_dir():
-            msg = f"root must be a directory: {root}"
-            raise ValueError(msg)
-
-    @staticmethod
-    def _normalize_codepoints(
-        codepoints: Sequence[SupportsIndex] | None,
-    ) -> tuple[int, ...] | None:
-        """Convert an optional codepoint filter into a canonical tuple."""
-        if codepoints is None:
-            return None
-        return tuple(sorted({index(cp) for cp in codepoints}))
-
-    def _normalize_index(self, idx: SupportsIndex) -> int:
-        """Resolve one dataset index, including negative indices."""
-        resolved_idx = index(idx)
-        original_idx = resolved_idx
-        dataset_len = len(self)
-        if resolved_idx < 0:
-            resolved_idx += dataset_len
-        if resolved_idx < 0 or resolved_idx >= dataset_len:
-            msg = (
-                f"index {original_idx} is out of range for dataset of length "
-                f"{dataset_len}"
-            )
-            raise IndexError(msg)
-        return resolved_idx
-
     def __len__(self) -> int:
         """Return the total number of glyph samples discoverable in the dataset.
 
@@ -307,6 +259,61 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         if self.transform is not None:
             return self.transform(sample)
         return cast("_T", sample)
+
+    def __getstate__(self) -> dict[str, object]:
+        """Return state without the native backend for worker reconstruction."""
+        state = self.__dict__.copy()
+        state.pop("_dataset", None)
+        return state
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        """Restore state and recreate the native backend after unpickling."""
+        state.pop("_metadata", None)
+        self.__dict__.update(state)
+        self._validate_root_dir(self.root)
+        self._dataset = _torchfont.GlyphDataset(
+            str(self.root),
+            self.codepoints,
+            self.patterns,
+        )
+
+    @staticmethod
+    def _validate_root_dir(root: Path) -> None:
+        """Raise ValueError if *root* exists but is not a directory."""
+        if root.exists() and not root.is_dir():
+            msg = f"root must be a directory: {root}"
+            raise ValueError(msg)
+
+    @staticmethod
+    def _normalize_codepoints(
+        codepoints: Sequence[SupportsIndex] | None,
+    ) -> tuple[int, ...] | None:
+        """Convert an optional codepoint filter into a canonical tuple."""
+        if codepoints is None:
+            return None
+        return tuple(sorted({index(cp) for cp in codepoints}))
+
+    def _normalize_index(self, idx: SupportsIndex) -> int:
+        """Resolve one dataset index, including negative indices."""
+        resolved_idx = index(idx)
+        original_idx = resolved_idx
+        dataset_len = len(self)
+        if resolved_idx < 0:
+            resolved_idx += dataset_len
+        if resolved_idx < 0 or resolved_idx >= dataset_len:
+            msg = (
+                f"index {original_idx} is out of range for dataset of length "
+                f"{dataset_len}"
+            )
+            raise IndexError(msg)
+        return resolved_idx
+
+    def _style_axes(self) -> list[tuple[StyleAxis, ...]]:
+        """Return style axis metadata aligned with ``style_classes`` order."""
+        return [
+            tuple(StyleAxis(tag=tag, value=float(value)) for tag, value in axes)
+            for axes in self._dataset.style_axes
+        ]
 
     @property
     def targets(self) -> Tensor:
@@ -369,13 +376,6 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
             char: idx
             for idx, (_, char, _) in enumerate(self._dataset.content_metadata_rows())
         }
-
-    def _style_axes(self) -> list[tuple[StyleAxis, ...]]:
-        """Return style axis metadata aligned with ``style_classes`` order."""
-        return [
-            tuple(StyleAxis(tag=tag, value=float(value)) for tag, value in axes)
-            for axes in self._dataset.style_axes
-        ]
 
     @property
     def metadata(self) -> DatasetMetadata:


### PR DESCRIPTION
## Summary

- `src/lib.rs`: `quad_to_cubic` / `quad_to_cubic_and_merge` / `cubic_to_quad` / `merge_curves` から `py_` プレフィックスと `name = "..."` 属性を除去し、`remove_overlaps` / `render_bitmap` と同じ `#[pyfunction]` スタイルに統一。Python 側のシンボル名に変更なし。
- `torchfont/datasets.py`: `GlyphDataset` のメソッドを論理的なグループ順に並び替え。

## Test plan

- [ ] `mise run check` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)