### PR TITLE
fix: add input validation to remove_overlaps and remove stale __setstate__ pop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,10 @@ fn remove_overlaps(
     types: PyReadonlyArray1<'_, i64>,
     coords: PyReadonlyArray1<'_, f32>,
 ) -> PyResult<(Vec<i64>, Vec<f32>)> {
-    Ok(transform::remove_overlaps::remove_overlaps(
-        types.as_slice()?,
-        coords.as_slice()?,
-    ))
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    Ok(transform::remove_overlaps::remove_overlaps(t, c))
 }
 
 #[pyfunction]

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -268,7 +268,6 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
 
     def __setstate__(self, state: dict[str, object]) -> None:
         """Restore state and recreate the native backend after unpickling."""
-        state.pop("_metadata", None)
         self.__dict__.update(state)
         self._validate_root_dir(self.root)
         self._dataset = _torchfont.GlyphDataset(


### PR DESCRIPTION
## Summary

- `remove_overlaps` now calls `ensure_flat_coords_len` before dispatching to Rust, consistent with all other transform functions (`quad_to_cubic_and_merge`, `cubic_to_quad`, `merge_curves`). Previously, passing mismatched `types`/`coords` lengths would silently produce incorrect results or panic.
- Removed `state.pop("_metadata", None)` from `GlyphDataset.__setstate__`. The `_metadata` field does not exist in the current codebase and is not excluded by `__getstate__`, so this line was dead code left over from a prior refactor.

## Test plan

- [ ] Existing tests pass: `uv run pytest`
- [ ] Rust build succeeds: `maturin develop` (or `mise run build`)
- [ ] `remove_overlaps` with mismatched lengths raises `ValueError` instead of silently misbehaving

🤖 Generated with [Claude Code](https://claude.com/claude-code)