### PR TITLE
fix: eliminate double-copy in render_bitmap and restore __setstate__ cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod outline;
 mod transform;
 
 use dataset::{GlyphDataset, GlyphItem};
-use numpy::{PyReadonlyArray1, PyReadwriteArray1};
+use numpy::{IntoPyArray as _, PyArray1, PyReadonlyArray1, PyReadwriteArray1};
 use pyo3::{Bound, prelude::*, types::PyModule};
 
 #[pyfunction]
@@ -72,11 +72,12 @@ fn remove_overlaps(
 
 #[pyfunction]
 fn render_bitmap(
+    py: Python<'_>,
     types: PyReadonlyArray1<'_, i64>,
     coords: PyReadonlyArray1<'_, f32>,
     size: u32,
     mode: &str,
-) -> PyResult<(Vec<u8>, u32, u32)> {
+) -> PyResult<(Py<PyArray1<u8>>, u32, u32)> {
     if size == 0 || size > 4096 {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "size must be between 1 and 4096",
@@ -101,7 +102,11 @@ fn render_bitmap(
                     )
                 }
             })?;
-    Ok((rendered.data, rendered.width, rendered.height))
+    Ok((
+        rendered.data.into_pyarray(py).unbind(),
+        rendered.width,
+        rendered.height,
+    ))
 }
 
 fn ensure_flat_coords_len(types_len: usize, coords_len: usize) -> PyResult<()> {

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -268,6 +268,7 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
 
     def __setstate__(self, state: dict[str, object]) -> None:
         """Restore state and recreate the native backend after unpickling."""
+        state.pop("_metadata", None)
         self.__dict__.update(state)
         self._validate_root_dir(self.root)
         self._dataset = _torchfont.GlyphDataset(

--- a/torchfont/transforms.py
+++ b/torchfont/transforms.py
@@ -212,7 +212,7 @@ def render_bitmap(
     )
     if width == 0 or height == 0:
         return torch.empty((height, width), dtype=torch.uint8)
-    return torch.frombuffer(bytearray(raw), dtype=torch.uint8).view(height, width)
+    return torch.from_numpy(raw).view(height, width)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- `render_bitmap` が Rust から `Vec<u8>`（Python `list`）を返していたため、`list → bytearray → tensor` と 2 回コピーが発生していた。Rust 側の戻り値を `Py<PyArray1<u8>>` に変更し、Python 側で `torch.from_numpy` を使うゼロコピー実装に切り替えた。
- `4af73cd` で誤って削除された `__setstate__` 内の `state.pop("_metadata", None)` を復元した。古いピクルオブジェクトに `_metadata` が含まれていても除去されるようになる。

## Test plan

- [ ] `mise run test` で全テストがパスすること（141 passed, 4 skipped）
- [ ] `test_unpickling_drops_legacy_metadata_cache_state` が PASS すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)