### PR TITLE
docs: replace mise.toml workflow note with uv instruction in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 - Prefer the Dev Container when available.
 - Prefer existing `mise` tasks over ad hoc commands.
-- Add new repeatable project-wide workflows to `mise.toml`.
+- Use `uv` for all Python operations; never invoke `python` or `pip` directly.
 - Run formatting, checks, and relevant tests after code changes.
 - Docs use VitePress. Keep `docs/en/` and `docs/ja/` aligned.
 


### PR DESCRIPTION
## Summary

- `AGENTS.md` の Workflow セクションから `mise.toml` への追記を促す指示を削除
- `python` や `pip` を直接呼び出さず `uv` を使う旨の指示を追加

## Test plan

- ドキュメント変更のみのため、テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)