### PR TITLE
chore: switch npm backend in mise.lock from npm:npm to aqua:npm/cli

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -34,7 +34,7 @@ url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-win-x64.zip"
 
 [[tools.npm]]
 version = "11.14.1"
-backend = "npm:npm"
+backend = "aqua:npm/cli"
 
 [[tools.rust]]
 version = "stable"


### PR DESCRIPTION
## Summary

- `mise.lock` の npm ツールのバックエンドを `npm:npm` から `aqua:npm/cli` に変更

## Test plan

- [ ] `mise install` が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)