### PR TITLE
feat: add geometric transforms and expose tight_bbox from Rust

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -128,6 +128,167 @@ then splits it into contiguous patches.
 - input: `types=(N,)`, `coords=(N, 6)`
 - output: `types=(num_patches, patch_size)`, `coords=(num_patches, patch_size, 6)`
 
+## horizontal_flip
+
+```python
+from torchfont.transforms import horizontal_flip
+```
+
+```python
+types, coords = horizontal_flip(types, coords)
+```
+
+Flips a glyph outline horizontally around its tight bounding-box centre.
+
+- both on-curve endpoints and off-curve control points are transformed
+- padding entries (CLOSE, END, PAD) are not modified
+- flipping reverses contour winding order
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(N,)` (unchanged), `coords=(N, 6)`
+
+## vertical_flip
+
+```python
+from torchfont.transforms import vertical_flip
+```
+
+```python
+types, coords = vertical_flip(types, coords)
+```
+
+Flips a glyph outline vertically around its tight bounding-box centre.
+
+- both on-curve endpoints and off-curve control points are transformed
+- padding entries (CLOSE, END, PAD) are not modified
+- flipping reverses contour winding order
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(N,)` (unchanged), `coords=(N, 6)`
+
+## affine
+
+```python
+from torchfont.transforms import affine
+```
+
+```python
+types, coords = affine(types, coords, angle=15.0, translate=(0.05, 0.0), scale=0.9, shear=5.0)
+```
+
+Applies a deterministic affine transformation to a glyph outline.
+
+Composes uniform scale, x-shear, and rotation around the tight bounding-box
+centre, then applies `translate`. All active control points and endpoints are
+transformed; padding entries are not modified.
+
+- `angle`: counter-clockwise rotation in degrees (default: `0.0`)
+- `translate`: translation `(tx, ty)` in UPM-normalised units (default: `(0.0, 0.0)`)
+- `scale`: uniform scale factor, must be positive (default: `1.0`)
+- `shear`: x-shear angle in degrees (default: `0.0`)
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(N,)` (unchanged), `coords=(N, 6)`
+
+## random_horizontal_flip
+
+```python
+from torchfont.transforms import random_horizontal_flip
+```
+
+```python
+types, coords = random_horizontal_flip(types, coords, p=0.5)
+```
+
+Randomly applies `horizontal_flip` with probability `p`.
+
+- `p`: flip probability (default: `0.5`)
+- `generator`: optional `torch.Generator` for reproducibility
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(N,)`, `coords=(N, 6)`
+
+## random_vertical_flip
+
+```python
+from torchfont.transforms import random_vertical_flip
+```
+
+```python
+types, coords = random_vertical_flip(types, coords, p=0.5)
+```
+
+Randomly applies `vertical_flip` with probability `p`.
+
+- `p`: flip probability (default: `0.5`)
+- `generator`: optional `torch.Generator` for reproducibility
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(N,)`, `coords=(N, 6)`
+
+## random_affine
+
+```python
+from torchfont.transforms import random_affine
+```
+
+```python
+types, coords = random_affine(
+    types, coords,
+    degrees=15.0,
+    translate=(0.05, 0.05),
+    scale=(0.9, 1.1),
+    shear=5.0,
+)
+```
+
+Applies a random affine transformation sampled uniformly from the given ranges.
+
+- `degrees`: rotation range in degrees; a single float `d` gives `[-d, d]`
+- `translate`: maximum absolute translation `(max_dx, max_dy)` in UPM-normalised
+  units; each axis is sampled from `[-max_d, max_d]` (default: no translation)
+- `scale`: scale range `(min, max)`; both values must be positive (default: no scaling)
+- `shear`: x-shear range in degrees; same format as `degrees` (default: `0.0`)
+- `generator`: optional `torch.Generator` for reproducibility
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(N,)` (unchanged), `coords=(N, 6)`
+
+## random_coord_jitter
+
+```python
+from torchfont.transforms import random_coord_jitter
+```
+
+```python
+types, coords = random_coord_jitter(types, coords, std=0.005)
+```
+
+Adds independent Gaussian noise to each active outline coordinate.
+
+- `std`: standard deviation in UPM-normalised units; `0.005` ≈ 5 font-units in
+  a 1000-UPM font
+- only active coordinate columns are perturbed (unused columns, CLOSE, END, PAD
+  are left unchanged)
+- `generator`: optional `torch.Generator` for reproducibility
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(N,)` (unchanged), `coords=(N, 6)`
+
 ## render_bitmap
 
 ```python

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -127,6 +127,166 @@ patch_types, patch_coords = patchify(types, coords, patch_size=32)
 - 入力: `types=(N,)`, `coords=(N, 6)`
 - 出力: `types=(num_patches, patch_size)`, `coords=(num_patches, patch_size, 6)`
 
+## horizontal_flip
+
+```python
+from torchfont.transforms import horizontal_flip
+```
+
+```python
+types, coords = horizontal_flip(types, coords)
+```
+
+グリフアウトラインを tight bounding-box の中心を軸に水平反転します。
+
+- on-curve 終点と off-curve 制御点の両方を変換します
+- パディングエントリ（CLOSE、END、PAD）は変更しません
+- 反転により contour の巻き順が逆転します
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(N,)` (変更なし), `coords=(N, 6)`
+
+## vertical_flip
+
+```python
+from torchfont.transforms import vertical_flip
+```
+
+```python
+types, coords = vertical_flip(types, coords)
+```
+
+グリフアウトラインを tight bounding-box の中心を軸に垂直反転します。
+
+- on-curve 終点と off-curve 制御点の両方を変換します
+- パディングエントリ（CLOSE、END、PAD）は変更しません
+- 反転により contour の巻き順が逆転します
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(N,)` (変更なし), `coords=(N, 6)`
+
+## affine
+
+```python
+from torchfont.transforms import affine
+```
+
+```python
+types, coords = affine(types, coords, angle=15.0, translate=(0.05, 0.0), scale=0.9, shear=5.0)
+```
+
+グリフアウトラインに決定論的なアフィン変換を適用します。
+
+tight bounding-box の中心を基準に一様スケール・x-shear・回転を合成し、
+`translate` を適用します。すべてのアクティブな制御点と終点を変換します。
+パディングエントリは変更しません。
+
+- `angle`: 反時計回りの回転角度（単位: 度、デフォルト: `0.0`）
+- `translate`: UPM 正規化単位での平行移動 `(tx, ty)`（デフォルト: `(0.0, 0.0)`）
+- `scale`: 一様スケール係数（正数必須、デフォルト: `1.0`）
+- `shear`: x-shear 角度（単位: 度、デフォルト: `0.0`）
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(N,)` (変更なし), `coords=(N, 6)`
+
+## random_horizontal_flip
+
+```python
+from torchfont.transforms import random_horizontal_flip
+```
+
+```python
+types, coords = random_horizontal_flip(types, coords, p=0.5)
+```
+
+確率 `p` で `horizontal_flip` をランダムに適用します。
+
+- `p`: 反転確率（デフォルト: `0.5`）
+- `generator`: 再現性のためのオプション `torch.Generator`
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(N,)`, `coords=(N, 6)`
+
+## random_vertical_flip
+
+```python
+from torchfont.transforms import random_vertical_flip
+```
+
+```python
+types, coords = random_vertical_flip(types, coords, p=0.5)
+```
+
+確率 `p` で `vertical_flip` をランダムに適用します。
+
+- `p`: 反転確率（デフォルト: `0.5`）
+- `generator`: 再現性のためのオプション `torch.Generator`
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(N,)`, `coords=(N, 6)`
+
+## random_affine
+
+```python
+from torchfont.transforms import random_affine
+```
+
+```python
+types, coords = random_affine(
+    types, coords,
+    degrees=15.0,
+    translate=(0.05, 0.05),
+    scale=(0.9, 1.1),
+    shear=5.0,
+)
+```
+
+指定した範囲から一様サンプリングしたランダムなアフィン変換を適用します。
+
+- `degrees`: 回転範囲（度）。単一の float `d` を指定すると `[-d, d]` になります
+- `translate`: UPM 正規化単位での最大絶対平行移動 `(max_dx, max_dy)`。
+  各軸を `[-max_d, max_d]` からサンプリングします（デフォルト: 平行移動なし）
+- `scale`: スケール範囲 `(min, max)`。両値は正数必須（デフォルト: スケールなし）
+- `shear`: x-shear 範囲（度）。`degrees` と同じ書式（デフォルト: `0.0`）
+- `generator`: 再現性のためのオプション `torch.Generator`
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(N,)` (変更なし), `coords=(N, 6)`
+
+## random_coord_jitter
+
+```python
+from torchfont.transforms import random_coord_jitter
+```
+
+```python
+types, coords = random_coord_jitter(types, coords, std=0.005)
+```
+
+各アクティブな outline 座標に独立したガウスノイズを加算します。
+
+- `std`: UPM 正規化単位での標準偏差。`0.005` は 1000-UPM フォントで
+  約 5 フォントユニットに相当します
+- 未使用の座標列（CLOSE、END、PAD）は変更しません
+- `generator`: 再現性のためのオプション `torch.Generator`
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(N,)` (変更なし), `coords=(N, 6)`
+
 ## render_bitmap
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ignore = ["COM812", "D203", "D213", "EXE002"]
 
 [tool.ruff.lint.per-file-ignores]
 "examples/**/*.py" = ["D", "T201"]
+"torchfont/transforms/geometric.py" = ["PLR0913"]
 "torchfont/datasets/*.py" = ["PLR0913"]
 "tests/**/*.py" = ["D", "PLR2004", "S101"]
 

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -114,8 +114,8 @@ impl BoundsPen {
     }
 }
 
-pub(crate) fn bounds_from_i32_segments(types: &[i32], coords: &[f32]) -> Option<Bounds> {
-    bounds_from_segments(types.iter().copied().map(i64::from), coords)
+pub(crate) fn bounds_from_i64_segments(types: &[i64], coords: &[f32]) -> Option<Bounds> {
+    bounds_from_segments(types.iter().copied(), coords)
 }
 
 fn bounds_from_segments(types: impl Iterator<Item = i64>, coords: &[f32]) -> Option<Bounds> {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -133,8 +133,7 @@ impl GlyphDataset {
             glyph_name,
         ) = self.entries[font_idx].glyph_complete(codepoint, inst_idx)?;
 
-        let types_i64: Vec<i64> = types.iter().map(|&t| t as i64).collect();
-        let types_arr = types_i64.into_pyarray(py).unbind();
+        let types_arr = types.into_pyarray(py).unbind();
 
         let coords_arr = coords.into_pyarray(py).unbind();
 

--- a/src/dataset/reader.rs
+++ b/src/dataset/reader.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 pub(super) type GlyphItemData = (
-    Vec<i32>,
+    Vec<i64>,
     Vec<f32>,
     f32,
     f32,
@@ -95,7 +95,7 @@ impl GlyphReader {
                 .map(|v| v * inv_upem)
                 .unwrap_or(f32::NAN);
             let (x_min, y_min, x_max, y_max) = if metrics_bounds_are_outline_based(&font) {
-                bounds::bounds_from_i32_segments(&types, &coords)
+                bounds::bounds_from_i64_segments(&types, &coords)
                     .map_or((f32::NAN, f32::NAN, f32::NAN, f32::NAN), |bb| {
                         (bb.x_min, bb.y_min, bb.x_max, bb.y_max)
                     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,17 @@ fn remove_overlaps(
 }
 
 #[pyfunction]
+fn tight_bbox(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<Option<(f32, f32, f32, f32)>> {
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    Ok(bounds::bounds_from_i64_segments(t, c).map(|b| (b.x_min, b.y_min, b.x_max, b.y_max)))
+}
+
+#[pyfunction]
 fn render_bitmap(
     py: Python<'_>,
     types: PyReadonlyArray1<'_, i64>,
@@ -128,6 +139,7 @@ fn _torchfont(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cubic_to_quad, &m)?)?;
     m.add_function(wrap_pyfunction!(merge_curves, &m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, &m)?)?;
+    m.add_function(wrap_pyfunction!(tight_bbox, &m)?)?;
     m.add_function(wrap_pyfunction!(render_bitmap, &m)?)?;
     Ok(())
 }

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -12,7 +12,7 @@ pub(crate) enum Command {
 }
 
 struct SegmentPen {
-    commands: Vec<i32>,
+    commands: Vec<i64>,
     coords: Vec<f32>,
     scale: f32,
 }
@@ -27,13 +27,13 @@ impl SegmentPen {
         }
     }
 
-    fn finish(mut self) -> (Vec<i32>, Vec<f32>) {
+    fn finish(mut self) -> (Vec<i64>, Vec<f32>) {
         self.push(Command::End, [0.0; 6]);
         (self.commands, self.coords)
     }
 
     fn push(&mut self, command: Command, values: [f32; 6]) {
-        self.commands.push(command as i32);
+        self.commands.push(command as i64);
         let scaled = values.map(|v| v * self.scale);
         self.coords.extend_from_slice(&scaled);
     }
@@ -69,7 +69,7 @@ pub(crate) fn extract_glyph_segments<'a>(
     glyph: &OutlineGlyph<'a>,
     settings: DrawSettings<'a>,
     units_per_em: f32,
-) -> Result<(Vec<i32>, Vec<f32>), DrawError> {
+) -> Result<(Vec<i64>, Vec<f32>), DrawError> {
     let mut pen = SegmentPen::new(units_per_em);
     glyph.draw(settings, &mut pen)?;
     Ok(pen.finish())

--- a/tests/transforms/geometric/_helpers.py
+++ b/tests/transforms/geometric/_helpers.py
@@ -1,0 +1,85 @@
+import torch
+
+from torchfont.io import CommandType
+
+
+def _simple_outline() -> tuple[torch.Tensor, torch.Tensor]:
+    types = torch.tensor(
+        [
+            CommandType.MOVE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.LINE_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    return types, coords
+
+
+def _cubic_outline() -> tuple[torch.Tensor, torch.Tensor]:
+    types = torch.tensor(
+        [
+            CommandType.MOVE_TO.value,
+            CommandType.CURVE_TO.value,
+            CommandType.CURVE_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.2, 0.8, 0.8, 0.8, 1.0, 0.0],
+            [0.8, 0.2, 0.2, 0.2, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    return types, coords
+
+
+def _quad_outline() -> tuple[torch.Tensor, torch.Tensor]:
+    types = torch.tensor(
+        [
+            CommandType.MOVE_TO.value,
+            CommandType.QUAD_TO.value,
+            CommandType.QUAD_TO.value,
+            CommandType.CLOSE.value,
+            CommandType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0, 0.0, 1.0, 0.0],
+            [0.5, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    return types, coords
+
+
+def _close_end_zeros(types: torch.Tensor, coords: torch.Tensor) -> bool:
+    for cmd in (CommandType.CLOSE.value, CommandType.END.value):
+        idx = types.tolist().index(cmd)
+        if not torch.all(coords[idx] == 0.0):
+            return False
+    return True

--- a/tests/transforms/geometric/test_affine.py
+++ b/tests/transforms/geometric/test_affine.py
@@ -1,0 +1,92 @@
+import pytest
+import torch
+
+from torchfont.io import CommandType
+from torchfont.transforms import affine
+
+from ._helpers import (
+    _close_end_zeros,
+    _cubic_outline,
+    _quad_outline,
+    _simple_outline,
+)
+
+
+def test_affine_identity_leaves_coords_unchanged() -> None:
+    types, coords = _simple_outline()
+    _, out = affine(types, coords, angle=0.0, scale=1.0, shear=0.0)
+    assert torch.allclose(out, coords, atol=1e-6)
+
+
+def test_affine_does_not_modify_types() -> None:
+    types, coords = _simple_outline()
+    out_types, _ = affine(types, coords, angle=10.0)
+    assert torch.equal(out_types, types)
+
+
+def test_affine_preserves_padding_zeros() -> None:
+    types, coords = _simple_outline()
+    _, out = affine(types, coords, angle=45.0, scale=1.2, shear=5.0)
+    assert _close_end_zeros(types, out)
+
+
+def test_affine_90_degree_rotation() -> None:
+    types, coords = _simple_outline()
+    _, out = affine(types, coords, angle=90.0)
+
+    line_idx = types.tolist().index(CommandType.LINE_TO.value)
+    ox, oy = coords[line_idx, 4].item(), coords[line_idx, 5].item()
+    nx, ny = out[line_idx, 4].item(), out[line_idx, 5].item()
+    assert nx == pytest.approx(1.0 - oy, abs=1e-5)
+    assert ny == pytest.approx(ox, abs=1e-5)
+
+
+def test_affine_scale_multiplies_coordinates() -> None:
+    types, coords = _simple_outline()
+    _, out = affine(types, coords, scale=2.0)
+
+    line_idx = types.tolist().index(CommandType.LINE_TO.value)
+    assert out[line_idx, 4].item() == pytest.approx(
+        coords[line_idx, 4].item() * 2.0 - 0.5, abs=1e-5
+    )
+    assert out[line_idx, 5].item() == pytest.approx(
+        coords[line_idx, 5].item() * 2.0 - 0.5, abs=1e-5
+    )
+
+
+def test_affine_translate_shifts_endpoints() -> None:
+    types, coords = _simple_outline()
+    _, out = affine(types, coords, translate=(0.1, 0.2))
+
+    move_idx = types.tolist().index(CommandType.MOVE_TO.value)
+    assert out[move_idx, 4].item() == pytest.approx(
+        coords[move_idx, 4].item() + 0.1, abs=1e-5
+    )
+    assert out[move_idx, 5].item() == pytest.approx(
+        coords[move_idx, 5].item() + 0.2, abs=1e-5
+    )
+
+
+def test_affine_transforms_all_cubic_pairs() -> None:
+    types, coords = _cubic_outline()
+    _, out = affine(types, coords, angle=90.0)
+
+    curve_idx = types.tolist().index(CommandType.CURVE_TO.value)
+    assert not torch.allclose(out[curve_idx, 0:2], coords[curve_idx, 0:2])
+    assert not torch.allclose(out[curve_idx, 2:4], coords[curve_idx, 2:4])
+    assert not torch.allclose(out[curve_idx, 4:6], coords[curve_idx, 4:6])
+
+
+def test_affine_quad_pair1_stays_zero() -> None:
+    types, coords = _quad_outline()
+    _, out = affine(types, coords, angle=45.0, translate=(0.05, 0.05))
+
+    quad_idx = types.tolist().index(CommandType.QUAD_TO.value)
+    assert out[quad_idx, 2].item() == pytest.approx(0.0)
+    assert out[quad_idx, 3].item() == pytest.approx(0.0)
+
+
+def test_affine_non_positive_scale_raises() -> None:
+    types, coords = _simple_outline()
+    with pytest.raises(ValueError, match="scale must be positive"):
+        affine(types, coords, scale=0.0)

--- a/tests/transforms/geometric/test_horizontal_flip.py
+++ b/tests/transforms/geometric/test_horizontal_flip.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+
+from torchfont.io import CommandType
+from torchfont.transforms import horizontal_flip
+
+from ._helpers import (
+    _close_end_zeros,
+    _cubic_outline,
+    _quad_outline,
+    _simple_outline,
+)
+
+
+def test_horizontal_flip_mirrors_x_around_bbox_center() -> None:
+    types, coords = _simple_outline()
+    _, out = horizontal_flip(types, coords)
+
+    line_idx = types.tolist().index(CommandType.LINE_TO.value)
+    assert out[line_idx, 4].item() == pytest.approx(1.0 - coords[line_idx, 4].item())
+
+
+def test_horizontal_flip_twice_is_identity() -> None:
+    types, coords = _simple_outline()
+    _, once = horizontal_flip(types, coords)
+    _, twice = horizontal_flip(types, once)
+    assert torch.allclose(twice, coords)
+
+
+def test_horizontal_flip_does_not_modify_types() -> None:
+    types, coords = _simple_outline()
+    out_types, _ = horizontal_flip(types, coords)
+    assert torch.equal(out_types, types)
+
+
+def test_horizontal_flip_preserves_padding_zeros() -> None:
+    types, coords = _simple_outline()
+    _, out = horizontal_flip(types, coords)
+    assert _close_end_zeros(types, out)
+
+
+def test_horizontal_flip_transforms_cubic_control_points() -> None:
+    types, coords = _cubic_outline()
+    _, out = horizontal_flip(types, coords)
+
+    curve_idx = types.tolist().index(CommandType.CURVE_TO.value)
+    assert out[curve_idx, 0].item() == pytest.approx(1.0 - coords[curve_idx, 0].item())
+    assert out[curve_idx, 2].item() == pytest.approx(1.0 - coords[curve_idx, 2].item())
+
+
+def test_horizontal_flip_quad_pair1_stays_zero() -> None:
+    types, coords = _quad_outline()
+    _, out = horizontal_flip(types, coords)
+
+    quad_idx = types.tolist().index(CommandType.QUAD_TO.value)
+    assert out[quad_idx, 2].item() == pytest.approx(0.0)
+    assert out[quad_idx, 3].item() == pytest.approx(0.0)
+
+
+def test_horizontal_flip_does_not_alter_y_coordinates() -> None:
+    types, coords = _simple_outline()
+    _, out = horizontal_flip(types, coords)
+    assert torch.allclose(out[:, 1], coords[:, 1])
+    assert torch.allclose(out[:, 3], coords[:, 3])
+    assert torch.allclose(out[:, 5], coords[:, 5])

--- a/tests/transforms/geometric/test_random_affine.py
+++ b/tests/transforms/geometric/test_random_affine.py
@@ -1,0 +1,71 @@
+import pytest
+import torch
+
+from torchfont.io import CommandType
+from torchfont.transforms import random_affine
+
+from ._helpers import _close_end_zeros, _quad_outline, _simple_outline
+
+
+def test_random_affine_deterministic_with_generator() -> None:
+    types, coords = _simple_outline()
+    g1 = torch.Generator().manual_seed(7)
+    g2 = torch.Generator().manual_seed(7)
+    _, out1 = random_affine(types, coords, degrees=30.0, generator=g1)
+    _, out2 = random_affine(types, coords, degrees=30.0, generator=g2)
+    assert torch.allclose(out1, out2)
+
+
+def test_random_affine_preserves_padding_zeros() -> None:
+    types, coords = _simple_outline()
+    g = torch.Generator().manual_seed(1)
+    _, out = random_affine(
+        types,
+        coords,
+        degrees=15.0,
+        translate=(0.05, 0.05),
+        scale=(0.9, 1.1),
+        generator=g,
+    )
+    assert _close_end_zeros(types, out)
+
+
+def test_random_affine_does_not_modify_types() -> None:
+    types, coords = _simple_outline()
+    out_types, _ = random_affine(types, coords, degrees=10.0)
+    assert torch.equal(out_types, types)
+
+
+def test_random_affine_translation_within_bounds() -> None:
+    types, coords = _simple_outline()
+    g = torch.Generator().manual_seed(3)
+    move_idx = types.tolist().index(CommandType.MOVE_TO.value)
+    _, out = random_affine(types, coords, translate=(0.1, 0.2), generator=g)
+    dx = abs(out[move_idx, 4].item() - coords[move_idx, 4].item())
+    dy = abs(out[move_idx, 5].item() - coords[move_idx, 5].item())
+    assert dx <= 0.1 + 1e-6
+    assert dy <= 0.2 + 1e-6
+
+
+def test_random_affine_invalid_scale_raises() -> None:
+    types, coords = _simple_outline()
+    with pytest.raises(ValueError, match="positive"):
+        random_affine(types, coords, scale=(-1.0, 1.0))
+
+
+def test_random_affine_reversed_scale_range_raises() -> None:
+    types, coords = _simple_outline()
+    with pytest.raises(ValueError, match="min <= max"):
+        random_affine(types, coords, scale=(2.0, 1.0))
+
+
+def test_random_affine_quad_pair1_stays_zero() -> None:
+    types, coords = _quad_outline()
+    g = torch.Generator().manual_seed(5)
+    _, out = random_affine(
+        types, coords, degrees=45.0, translate=(0.05, 0.05), generator=g
+    )
+
+    quad_idx = types.tolist().index(CommandType.QUAD_TO.value)
+    assert out[quad_idx, 2].item() == pytest.approx(0.0)
+    assert out[quad_idx, 3].item() == pytest.approx(0.0)

--- a/tests/transforms/geometric/test_random_coord_jitter.py
+++ b/tests/transforms/geometric/test_random_coord_jitter.py
@@ -1,0 +1,77 @@
+import pytest
+import torch
+
+from torchfont.io import CommandType
+from torchfont.transforms import random_coord_jitter
+
+from ._helpers import (
+    _close_end_zeros,
+    _cubic_outline,
+    _quad_outline,
+    _simple_outline,
+)
+
+
+def test_random_coord_jitter_changes_active_coords() -> None:
+    types, coords = _simple_outline()
+    g = torch.Generator().manual_seed(42)
+    _, out = random_coord_jitter(types, coords, std=0.1, generator=g)
+
+    line_idx = types.tolist().index(CommandType.LINE_TO.value)
+    assert not torch.equal(out[line_idx, 4:6], coords[line_idx, 4:6])
+
+
+def test_random_coord_jitter_zero_std_is_identity() -> None:
+    types, coords = _simple_outline()
+    _, out = random_coord_jitter(types, coords, std=0.0)
+    assert torch.equal(out, coords)
+
+
+def test_random_coord_jitter_preserves_padding_zeros() -> None:
+    types, coords = _simple_outline()
+    g = torch.Generator().manual_seed(1)
+    _, out = random_coord_jitter(types, coords, std=1.0, generator=g)
+    assert _close_end_zeros(types, out)
+
+
+def test_random_coord_jitter_quad_pair1_stays_zero() -> None:
+    types, coords = _quad_outline()
+    g = torch.Generator().manual_seed(2)
+    _, out = random_coord_jitter(types, coords, std=1.0, generator=g)
+
+    quad_idx = types.tolist().index(CommandType.QUAD_TO.value)
+    assert out[quad_idx, 2].item() == pytest.approx(0.0)
+    assert out[quad_idx, 3].item() == pytest.approx(0.0)
+
+
+def test_random_coord_jitter_jitters_all_cubic_pairs() -> None:
+    types, coords = _cubic_outline()
+    g = torch.Generator().manual_seed(7)
+    _, out = random_coord_jitter(types, coords, std=0.5, generator=g)
+
+    curve_idx = types.tolist().index(CommandType.CURVE_TO.value)
+    assert not torch.equal(out[curve_idx, 0:2], coords[curve_idx, 0:2])
+    assert not torch.equal(out[curve_idx, 2:4], coords[curve_idx, 2:4])
+    assert not torch.equal(out[curve_idx, 4:6], coords[curve_idx, 4:6])
+
+
+def test_random_coord_jitter_does_not_modify_types() -> None:
+    types, coords = _simple_outline()
+    g = torch.Generator().manual_seed(0)
+    out_types, _ = random_coord_jitter(types, coords, std=0.1, generator=g)
+    assert torch.equal(out_types, types)
+
+
+def test_random_coord_jitter_negative_std_raises() -> None:
+    types, coords = _simple_outline()
+    with pytest.raises(ValueError, match="std must be non-negative"):
+        random_coord_jitter(types, coords, std=-0.1)
+
+
+def test_random_coord_jitter_deterministic_with_generator() -> None:
+    types, coords = _simple_outline()
+    g1 = torch.Generator().manual_seed(99)
+    g2 = torch.Generator().manual_seed(99)
+    _, out1 = random_coord_jitter(types, coords, std=0.05, generator=g1)
+    _, out2 = random_coord_jitter(types, coords, std=0.05, generator=g2)
+    assert torch.equal(out1, out2)

--- a/tests/transforms/geometric/test_random_horizontal_flip.py
+++ b/tests/transforms/geometric/test_random_horizontal_flip.py
@@ -1,0 +1,27 @@
+import torch
+
+from torchfont.transforms import random_horizontal_flip
+
+from ._helpers import _simple_outline
+
+
+def test_random_horizontal_flip_applies_with_p1() -> None:
+    types, coords = _simple_outline()
+    g = torch.Generator().manual_seed(0)
+    _, out = random_horizontal_flip(types, coords, p=1.0, generator=g)
+    assert not torch.equal(out, coords)
+
+
+def test_random_horizontal_flip_skips_with_p0() -> None:
+    types, coords = _simple_outline()
+    _, out = random_horizontal_flip(types, coords, p=0.0)
+    assert torch.equal(out, coords)
+
+
+def test_random_horizontal_flip_deterministic_with_generator() -> None:
+    types, coords = _simple_outline()
+    g1 = torch.Generator().manual_seed(42)
+    g2 = torch.Generator().manual_seed(42)
+    _, out1 = random_horizontal_flip(types, coords, generator=g1)
+    _, out2 = random_horizontal_flip(types, coords, generator=g2)
+    assert torch.equal(out1, out2)

--- a/tests/transforms/geometric/test_random_vertical_flip.py
+++ b/tests/transforms/geometric/test_random_vertical_flip.py
@@ -1,0 +1,18 @@
+import torch
+
+from torchfont.transforms import random_vertical_flip
+
+from ._helpers import _simple_outline
+
+
+def test_random_vertical_flip_applies_with_p1() -> None:
+    types, coords = _simple_outline()
+    g = torch.Generator().manual_seed(0)
+    _, out = random_vertical_flip(types, coords, p=1.0, generator=g)
+    assert not torch.equal(out, coords)
+
+
+def test_random_vertical_flip_skips_with_p0() -> None:
+    types, coords = _simple_outline()
+    _, out = random_vertical_flip(types, coords, p=0.0)
+    assert torch.equal(out, coords)

--- a/tests/transforms/geometric/test_vertical_flip.py
+++ b/tests/transforms/geometric/test_vertical_flip.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+
+from torchfont.io import CommandType
+from torchfont.transforms import vertical_flip
+
+from ._helpers import _close_end_zeros, _simple_outline
+
+
+def test_vertical_flip_mirrors_y_around_bbox_center() -> None:
+    types, coords = _simple_outline()
+    _, out = vertical_flip(types, coords)
+
+    line_idx = types.tolist().index(CommandType.LINE_TO.value)
+    assert out[line_idx, 5].item() == pytest.approx(1.0 - coords[line_idx, 5].item())
+
+
+def test_vertical_flip_twice_is_identity() -> None:
+    types, coords = _simple_outline()
+    _, once = vertical_flip(types, coords)
+    _, twice = vertical_flip(types, once)
+    assert torch.allclose(twice, coords)
+
+
+def test_vertical_flip_does_not_alter_x_coordinates() -> None:
+    types, coords = _simple_outline()
+    _, out = vertical_flip(types, coords)
+    assert torch.allclose(out[:, 0], coords[:, 0])
+    assert torch.allclose(out[:, 2], coords[:, 2])
+    assert torch.allclose(out[:, 4], coords[:, 4])
+
+
+def test_vertical_flip_preserves_padding_zeros() -> None:
+    types, coords = _simple_outline()
+    _, out = vertical_flip(types, coords)
+    assert _close_end_zeros(types, out)

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -21,6 +21,9 @@ def quad_to_cubic(types: np.ndarray, coords: np.ndarray, seq_len: int) -> None: 
 def quad_to_cubic_and_merge(
     types: np.ndarray, coords: np.ndarray
 ) -> tuple[list[int], list[float]]: ...
+def tight_bbox(
+    types: np.ndarray, coords: np.ndarray
+) -> tuple[float, float, float, float] | None: ...
 
 class GlyphItem:
     types: np.ndarray

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -11,14 +11,30 @@ from torchfont.transforms.curves import (
     quad_to_cubic,
     remove_overlaps,
 )
+from torchfont.transforms.geometric import (
+    affine,
+    horizontal_flip,
+    random_affine,
+    random_coord_jitter,
+    random_horizontal_flip,
+    random_vertical_flip,
+    vertical_flip,
+)
 from torchfont.transforms.patch import patchify
 
 __all__ = [
     "BitmapMode",
+    "affine",
     "cubic_to_quad",
+    "horizontal_flip",
     "merge_curves",
     "patchify",
     "quad_to_cubic",
+    "random_affine",
+    "random_coord_jitter",
+    "random_horizontal_flip",
+    "random_vertical_flip",
     "remove_overlaps",
     "render_bitmap",
+    "vertical_flip",
 ]

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -1,0 +1,360 @@
+"""Geometric transformation functions for glyph outline tensors.
+
+All functions follow the same convention as :mod:`torchfont.transforms`:
+they accept ``(types, coords)`` and return a transformed ``(types, coords)``
+pair without modifying the inputs.
+
+Coordinate layout (``coords`` shape ``(N, 6)``)::
+
+    [cx0, cy0, cx1, cy1, x, y]
+
+    Pair 0 (cx0, cy0): off-curve control point 1 — active for QUAD_TO / CURVE_TO
+    Pair 1 (cx1, cy1): off-curve control point 2 — active for CURVE_TO only
+    Pair 2 (x,   y  ): on-curve endpoint        — active for all drawing commands
+
+All coordinates are UPM-normalised. The glyph body typically occupies
+``[0, 1] x [0, 1]`` inside the full canvas ``[-0.25, 1.25] x [-0.25, 1.25]``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+from torchfont import _torchfont
+from torchfont.io import CommandType
+
+
+def _active_pairs(types: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+    pair0 = (types == CommandType.QUAD_TO.value) | (types == CommandType.CURVE_TO.value)
+    pair1 = types == CommandType.CURVE_TO.value
+    pair2 = (
+        (types == CommandType.MOVE_TO.value)
+        | (types == CommandType.LINE_TO.value)
+        | (types == CommandType.QUAD_TO.value)
+        | (types == CommandType.CURVE_TO.value)
+    )
+    return pair0, pair1, pair2
+
+
+def _bbox_center(types: Tensor, coords: Tensor) -> Tensor:
+    """Return the tight bounding-box centre via the Rust ``tight_bbox`` implementation.
+
+    Delegates to :func:`torchfont._torchfont.tight_bbox`, which evaluates true
+    curve extrema for QUAD_TO and CURVE_TO segments rather than bounding the
+    control-point hull.
+    """
+    result = _torchfont.tight_bbox(
+        types.cpu().contiguous().numpy(),
+        coords.cpu().contiguous().reshape(-1).numpy(),
+    )
+    if result is None:
+        return coords.new_zeros(2)
+    x_min, y_min, x_max, y_max = result
+    return coords.new_tensor([(x_min + x_max) / 2.0, (y_min + y_max) / 2.0])
+
+
+def _apply_matrix(
+    types: Tensor,
+    coords: Tensor,
+    matrix: Tensor,
+    center: Tensor,
+    translate: tuple[float, float],
+) -> Tensor:
+    """Apply ``p' = (p - center) @ matrix.T + center + translate`` to active pairs."""
+    c = center
+    t = coords.new_tensor(translate)
+    active = torch.stack(list(_active_pairs(types)), dim=1).unsqueeze(-1)
+    pts = coords.reshape(-1, 3, 2)
+    transformed = (pts - c) @ matrix.T + c + t
+    return torch.where(active, transformed, pts).reshape_as(coords)
+
+
+def _rotation_scale_shear_matrix(
+    angle_deg: float,
+    scale: float,
+    shear_deg: float,
+) -> Tensor:
+    """Return a 2x2 matrix for scale * x-shear * rotation (all applied in place)."""
+    a = math.radians(angle_deg)
+    s = math.radians(shear_deg)
+    cos_a, sin_a, tan_s = math.cos(a), math.sin(a), math.tan(s)
+    return torch.tensor(
+        [
+            [scale * (cos_a + sin_a * tan_s), scale * (-sin_a + cos_a * tan_s)],
+            [scale * sin_a, scale * cos_a],
+        ],
+        dtype=torch.float32,
+    )
+
+
+def horizontal_flip(
+    types: Tensor,
+    coords: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Flip a glyph outline horizontally around the bounding-box centre.
+
+    Both on-curve endpoints and off-curve control points are transformed.
+    Zero-padded entries (CLOSE, END, PAD) are left unchanged.
+
+    Note:
+        Flipping reverses contour winding order. For most sequence models
+        this is acceptable; take care when consistent winding is required.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+
+    Returns:
+        A new ``(types, coords)`` pair with coordinates reflected around the
+        bounding-box centre. ``types`` is returned unchanged (same object).
+
+    """
+    matrix = torch.tensor([[-1.0, 0.0], [0.0, 1.0]])
+    center = _bbox_center(types, coords)
+    return types, _apply_matrix(types, coords, matrix, center, (0.0, 0.0))
+
+
+def vertical_flip(
+    types: Tensor,
+    coords: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Flip a glyph outline vertically around the bounding-box centre.
+
+    Note:
+        Flipping reverses contour winding order. For most sequence models
+        this is acceptable; take care when consistent winding is required.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+
+    Returns:
+        A new ``(types, coords)`` pair with coordinates reflected around the
+        bounding-box centre. ``types`` is returned unchanged (same object).
+
+    """
+    matrix = torch.tensor([[1.0, 0.0], [0.0, -1.0]])
+    center = _bbox_center(types, coords)
+    return types, _apply_matrix(types, coords, matrix, center, (0.0, 0.0))
+
+
+def affine(
+    types: Tensor,
+    coords: Tensor,
+    *,
+    angle: float = 0.0,
+    translate: tuple[float, float] = (0.0, 0.0),
+    scale: float = 1.0,
+    shear: float = 0.0,
+) -> tuple[Tensor, Tensor]:
+    """Apply a deterministic affine transformation to a glyph outline.
+
+    The transform composes **uniform scale**, **x-shear**, and **rotation**
+    around the bounding-box centre, then applies ``translate``. Control points
+    and endpoints are all transformed consistently; padding entries (CLOSE, END,
+    PAD) are not modified.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        angle: Counter-clockwise rotation in degrees.
+        translate: Translation ``(tx, ty)`` in UPM-normalised units applied
+            after rotation and scaling.
+        scale: Uniform scale factor (must be positive).
+        shear: x-shear angle in degrees.
+
+    Returns:
+        A new ``(types, coords)`` pair with the affine transform applied.
+        ``types`` is returned unchanged (same object).
+
+    """
+    if scale <= 0:
+        msg = "scale must be positive"
+        raise ValueError(msg)
+    matrix = _rotation_scale_shear_matrix(angle, scale, shear)
+    center = _bbox_center(types, coords)
+    return types, _apply_matrix(types, coords, matrix, center, translate)
+
+
+def random_horizontal_flip(
+    types: Tensor,
+    coords: Tensor,
+    *,
+    p: float = 0.5,
+    generator: torch.Generator | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Randomly flip a glyph outline horizontally with probability ``p``.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        p: Probability of applying the flip. Default: ``0.5``.
+        generator: Optional ``torch.Generator`` for reproducible sampling.
+
+    Returns:
+        Either the original ``(types, coords)`` unchanged, or a flipped copy.
+
+    """
+    if torch.rand(1, generator=generator).item() < p:
+        return horizontal_flip(types, coords)
+    return types, coords
+
+
+def random_vertical_flip(
+    types: Tensor,
+    coords: Tensor,
+    *,
+    p: float = 0.5,
+    generator: torch.Generator | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Randomly flip a glyph outline vertically with probability ``p``.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        p: Probability of applying the flip. Default: ``0.5``.
+        generator: Optional ``torch.Generator`` for reproducible sampling.
+
+    Returns:
+        Either the original ``(types, coords)`` unchanged, or a flipped copy.
+
+    """
+    if torch.rand(1, generator=generator).item() < p:
+        return vertical_flip(types, coords)
+    return types, coords
+
+
+def _sym_range(value: float | tuple[float, float]) -> tuple[float, float]:
+    if isinstance(value, (int, float)):
+        return (-abs(float(value)), abs(float(value)))
+    lo, hi = float(value[0]), float(value[1])
+    if lo > hi:
+        msg = "range must satisfy min <= max"
+        raise ValueError(msg)
+    return (lo, hi)
+
+
+def _validate_scale_range(scale: tuple[float, float]) -> tuple[float, float]:
+    lo, hi = float(scale[0]), float(scale[1])
+    if lo <= 0 or hi <= 0:
+        msg = "scale values must be positive"
+        raise ValueError(msg)
+    if lo > hi:
+        msg = "scale range must satisfy min <= max"
+        raise ValueError(msg)
+    return (lo, hi)
+
+
+def random_affine(
+    types: Tensor,
+    coords: Tensor,
+    *,
+    degrees: float | tuple[float, float] = 0.0,
+    translate: tuple[float, float] | None = None,
+    scale: tuple[float, float] | None = None,
+    shear: float | tuple[float, float] = 0.0,
+    generator: torch.Generator | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Apply a random affine transformation to a glyph outline.
+
+    Each parameter is sampled independently and uniformly from its range.
+    The transform composes **uniform scale**, **x-shear**, **rotation**, and
+    **translation** around the bounding-box centre. Control points and endpoints
+    are all transformed consistently; padding entries (CLOSE, END, PAD) are not
+    modified.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        degrees: Rotation range in degrees. A single float ``d`` gives
+            ``[-d, d]``; a ``(min, max)`` tuple is used directly.
+        translate: Maximum absolute translation ``(max_dx, max_dy)`` in
+            UPM-normalised units. Each axis is sampled uniformly from
+            ``[-max_d, max_d]``. Default: no translation.
+        scale: Scale range ``(min, max)``. Values must be positive and
+            satisfy ``min <= max``. Default: no scaling.
+        shear: x-shear range in degrees. Same format as ``degrees``.
+        generator: Optional ``torch.Generator`` for reproducible sampling.
+
+    Returns:
+        A new ``(types, coords)`` pair with the sampled affine applied.
+        ``types`` is returned unchanged (same object).
+
+    """
+    deg_lo, deg_hi = _sym_range(degrees)
+    shear_lo, shear_hi = _sym_range(shear)
+
+    r = torch.rand(5, generator=generator)
+
+    def _u(lo: float, hi: float, i: int) -> float:
+        return lo + (hi - lo) * r[i].item()
+
+    angle = _u(deg_lo, deg_hi, 0)
+    tx = _u(-translate[0], translate[0], 1) if translate is not None else 0.0
+    ty = _u(-translate[1], translate[1], 2) if translate is not None else 0.0
+    sc = _u(*_validate_scale_range(scale), 3) if scale is not None else 1.0
+    sh = _u(shear_lo, shear_hi, 4)
+
+    return affine(
+        types,
+        coords,
+        angle=angle,
+        translate=(tx, ty),
+        scale=sc,
+        shear=sh,
+    )
+
+
+def random_coord_jitter(
+    types: Tensor,
+    coords: Tensor,
+    *,
+    std: float,
+    generator: torch.Generator | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Add independent Gaussian noise to each active outline coordinate.
+
+    Noise is sampled per scalar coordinate value with standard deviation
+    ``std`` in UPM-normalised units. Non-active padding entries (CLOSE, END,
+    PAD) and unused zero-padding columns (e.g. ``cx1, cy1`` for QUAD_TO) are
+    not perturbed.
+
+    A value of ``std=0.005`` corresponds to roughly 5 font-units in a
+    1000-UPM font — a subtle perturbation that rarely changes the perceived
+    glyph shape.
+
+    Args:
+        types: 1-D ``torch.int64`` tensor of pen command types.
+        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        std: Standard deviation of the Gaussian noise in UPM-normalised units.
+            Must be non-negative.
+        generator: Optional ``torch.Generator`` for reproducible sampling.
+
+    Returns:
+        A new ``(types, coords)`` pair with noise added to active coordinates.
+        ``types`` is returned unchanged (same object).
+
+    """
+    if std < 0:
+        msg = "std must be non-negative"
+        raise ValueError(msg)
+    if std == 0.0:
+        return types, coords
+    active = torch.stack(list(_active_pairs(types)), dim=1).unsqueeze(-1)
+    pts = coords.reshape(-1, 3, 2)
+    noise = torch.empty_like(pts).normal_(std=std, generator=generator)
+    return types, torch.where(active, pts + noise, pts).reshape_as(coords)
+
+
+__all__ = [
+    "affine",
+    "horizontal_flip",
+    "random_affine",
+    "random_coord_jitter",
+    "random_horizontal_flip",
+    "random_vertical_flip",
+    "vertical_flip",
+]


### PR DESCRIPTION
## Summary

- Change segment command type from `i32` to `i64` throughout the Rust layer so the Python tensor dtype (`torch.long` / `int64`) matches without an explicit cast
- Expose `tight_bbox` as a Python-callable Rust function; evaluates true curve extrema for quad/cubic segments instead of bounding the control-point hull
- Add `torchfont.transforms.geometric` module with seven transforms: `Affine`, `HorizontalFlip`, `VerticalFlip`, `RandomAffine`, `RandomHorizontalFlip`, `RandomVerticalFlip`, `RandomCoordJitter`
- Add reference documentation in `docs/en/` and `docs/ja/`

## Test plan

- [x] `mise run format` — no changes
- [x] `mise run check` — Rust clippy, Python ruff, ty all pass
- [x] `mise run test` — 181 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)