### PR TITLE
refactor: remove __all__ and future annotations from modules

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -133,14 +133,6 @@ def test_glyph_dataset_getitem() -> None:
 
 
 def test_datasets_public_api_is_glyphdataset_centered() -> None:
-    assert datasets_module.__all__ == [
-        "ContentLabel",
-        "DatasetMetadata",
-        "GlyphDataset",
-        "GlyphSample",
-        "StyleAxis",
-        "StyleLabel",
-    ]
     assert datasets_module.DatasetMetadata is DatasetMetadata
     assert datasets_module.GlyphDataset is GlyphDataset
     assert datasets_module.GlyphSample is GlyphSample

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -31,10 +31,8 @@ from torch.utils.data import Dataset
 from torchfont import _torchfont
 from torchfont.io import COORD_DIM
 from torchfont.metadata import (
-    ContentLabel,
     DatasetMetadata,
     StyleAxis,
-    StyleLabel,
     build_dataset_metadata,
 )
 
@@ -408,13 +406,3 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
 
         """
         return [name for name, _ in self._dataset.style_metadata_rows(str(self.root))]
-
-
-__all__ = [
-    "ContentLabel",
-    "DatasetMetadata",
-    "GlyphDataset",
-    "GlyphSample",
-    "StyleAxis",
-    "StyleLabel",
-]

--- a/torchfont/io.py
+++ b/torchfont/io.py
@@ -17,5 +17,3 @@ class CommandType(IntEnum):
 
 TYPE_DIM: int = len(CommandType)
 COORD_DIM: int = 6
-
-__all__ = ["COORD_DIM", "TYPE_DIM", "CommandType"]

--- a/torchfont/transforms/bitmap.py
+++ b/torchfont/transforms/bitmap.py
@@ -1,7 +1,5 @@
 """Glyph outline rasterization."""
 
-from __future__ import annotations
-
 from typing import Literal
 
 import torch
@@ -47,9 +45,3 @@ def render_bitmap(
     if width == 0 or height == 0:
         return torch.empty((height, width), dtype=torch.uint8)
     return torch.from_numpy(raw).view(height, width)
-
-
-__all__ = [
-    "BitmapMode",
-    "render_bitmap",
-]

--- a/torchfont/transforms/curves.py
+++ b/torchfont/transforms/curves.py
@@ -1,7 +1,5 @@
 """Bezier curve format conversion, segment merging, and outline simplification."""
 
-from __future__ import annotations
-
 import torch
 from torch import Tensor
 
@@ -141,11 +139,3 @@ def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
         torch.tensor(out_types, dtype=torch.long),
         torch.tensor(out_coords, dtype=torch.float32).view(-1, 6),
     )
-
-
-__all__ = [
-    "cubic_to_quad",
-    "merge_curves",
-    "quad_to_cubic",
-    "remove_overlaps",
-]

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -16,8 +16,6 @@ All coordinates are UPM-normalised. The glyph body typically occupies
 ``[0, 1] x [0, 1]`` inside the full canvas ``[-0.25, 1.25] x [-0.25, 1.25]``.
 """
 
-from __future__ import annotations
-
 import math
 
 import torch
@@ -347,14 +345,3 @@ def random_coord_jitter(
     pts = coords.reshape(-1, 3, 2)
     noise = torch.empty_like(pts).normal_(std=std, generator=generator)
     return types, torch.where(active, pts + noise, pts).reshape_as(coords)
-
-
-__all__ = [
-    "affine",
-    "horizontal_flip",
-    "random_affine",
-    "random_coord_jitter",
-    "random_horizontal_flip",
-    "random_vertical_flip",
-    "vertical_flip",
-]

--- a/torchfont/transforms/patch.py
+++ b/torchfont/transforms/patch.py
@@ -1,7 +1,5 @@
 """Sequence patching for transformer-style model inputs."""
 
-from __future__ import annotations
-
 import torch
 from torch import Tensor
 
@@ -35,8 +33,3 @@ def patchify(types: Tensor, coords: Tensor, patch_size: int) -> tuple[Tensor, Te
     return pad_types.view(num_patches, patch_size), pad_coords.view(
         num_patches, patch_size, coords.size(1)
     )
-
-
-__all__ = [
-    "patchify",
-]


### PR DESCRIPTION
## Summary

- `datasets.py`, `io.py`, `transforms/bitmap.py`, `transforms/curves.py`, `transforms/geometric.py`, `transforms/patch.py` から `__all__` 定義を削除
- 同 transform モジュールから `from __future__ import annotations` を削除
- `datasets.py` から未使用の `ContentLabel` / `StyleLabel` インポートを削除
- `test_dataset.py` の `__all__` 検査テストを削除

## Test plan

- [ ] `mise run test` でテストが通ることを確認
- [ ] `mise run lint` で lint エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)