### PR TITLE
[codex] guard maturin build against hardlink truncation

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -65,10 +65,12 @@ sources = [
   "pyproject.toml",
   "uv.lock",
   "src/**/*.rs",
-  "torchfont/**/*.py",
 ]
 depends = ["check"]
-run = "uv run maturin develop --release"
+run = [
+  "rm -f target/maturin/lib_torchfont.so",
+  "uv run maturin develop --release",
+]
 
 [tasks.test]
 depends = ["build"]


### PR DESCRIPTION
## Summary

- remove `torchfont/**/*.py` from the native build task inputs so Python-only edits do not rerun `maturin develop`
- delete `target/maturin/lib_torchfont.so` immediately before `maturin develop --release`

## Why

`maturin develop --release` can fail on a subsequent run with:

```text
Failed to parse ELF file at 'target/maturin/lib_torchfont.so': Malformed entity: Object is too small.
```

Local tracing showed that the second run can make `target/release/lib_torchfont.so` and `target/maturin/lib_torchfont.so` aliases of the same inode; maturin later truncates one path while copying, which truncates the shared file and leaves a 0-byte ELF candidate. Removing the stale `target/maturin` artifact before the build avoids that aliasing path.

Python-only edits also do not need to rebuild the Rust extension, so narrowing the build inputs reduces unnecessary exposure to the maturin bug.

## Validation

- `rm -rf target/* && mise run build`
- `mise run build` again: skipped safely when inputs were unchanged
- `touch src/lib.rs && mise run build`: forced rebuild succeeded
- `mise run test`: 181 passed, 4 skipped

Closes #227
