### PR TITLE
[codex] track native build output in mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -65,10 +65,12 @@ sources = [
   "pyproject.toml",
   "uv.lock",
   "src/**/*.rs",
-  "torchfont/**/*.py",
 ]
 depends = ["check"]
-run = "uv run maturin develop --release"
+run = [
+  "rm -f target/maturin/lib_torchfont.so",
+  "uv run maturin develop --release",
+]
 
 [tasks.test]
 depends = ["build"]

--- a/mise.toml
+++ b/mise.toml
@@ -66,6 +66,7 @@ sources = [
   "uv.lock",
   "src/**/*.rs",
 ]
+outputs = ["target/maturin/lib_torchfont.so"]
 depends = ["check"]
 run = [
   "rm -f target/maturin/lib_torchfont.so",


### PR DESCRIPTION
## Summary

- declare `target/maturin/lib_torchfont.so` as the output of the native build task

## Why

While verifying the hardlink-truncation workaround from #228, I found that deleting `target/*` alone still let `mise run build` skip the build because the task only tracked inputs. Declaring the native artifact as an output makes `mise` rebuild when that artifact is missing, which keeps the recovery path honest after a target cleanup.

## Validation

- `rm -rf target/* && mise run build`: rebuilt the native extension because the output was missing
- `mise run build`: skipped once the output existed and inputs were unchanged
- `touch src/lib.rs && mise run build`: rebuilt successfully
- `uv run maturin develop --release`: still reproduced the upstream maturin bug directly
- `touch src/lib.rs && mise run build`: recovered successfully through the guarded task
- `mise run test`: 181 passed, 4 skipped
