### PR TITLE
deduplicate build_skia_path and merge run logic across transforms

### DIFF
--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -4,6 +4,8 @@ use crate::outline::ElementType;
 const TOLERANCE: f32 = 1e-3;
 
 type Pt = [f32; 2];
+type PathElement = (i64, [f32; 6]);
+
 type Cubic = (Pt, Pt, Pt, Pt);
 type Quad = (Pt, Pt, Pt);
 
@@ -22,7 +24,7 @@ pub(crate) fn merge_curves(types: &[i64], coords: &[f32]) -> (Vec<i64>, Vec<f32>
             let move_y = c[5];
             i += 1;
 
-            let mut elements: Vec<(i64, [f32; 6])> = Vec::new();
+            let mut elements: Vec<PathElement> = Vec::new();
             while i < n {
                 let st = types[i];
                 if st == ElementType::Close as i64
@@ -60,10 +62,10 @@ pub(crate) fn merge_curves(types: &[i64], coords: &[f32]) -> (Vec<i64>, Vec<f32>
 fn merge_subpath_elements(
     start_x: f32,
     start_y: f32,
-    elements: Vec<(i64, [f32; 6])>,
-) -> Vec<(i64, [f32; 6])> {
+    elements: Vec<PathElement>,
+) -> Vec<PathElement> {
     let n = elements.len();
-    let mut result: Vec<(i64, [f32; 6])> = Vec::with_capacity(n);
+    let mut result: Vec<PathElement> = Vec::with_capacity(n);
     let mut result_starts: Vec<[f32; 2]> = Vec::with_capacity(n);
     let mut i = 0;
 
@@ -78,47 +80,14 @@ fn merge_subpath_elements(
         let quad = ElementType::QuadTo as i64;
         let cubic = ElementType::CurveTo as i64;
 
-        if ty == cubic {
-            let mut run_end = i + 1;
-            while run_end < n && elements[run_end].0 == cubic {
-                run_end += 1;
-            }
-            let run_len = run_end - i;
-
-            let mut merged = None;
-            for merge_len in (2..=run_len).rev() {
-                if let Some(m) = try_merge_cubics_n(seg_start, &elements[i..i + merge_len]) {
-                    merged = Some((m, merge_len));
-                    break;
-                }
-            }
-
-            if let Some((m, len)) = merged {
-                result.push((cubic, m));
-                result_starts.push(seg_start);
-                i += len;
+        if ty == cubic || ty == quad {
+            let try_merge_fn: fn(Pt, &[PathElement]) -> Option<[f32; 6]> = if ty == cubic {
+                try_merge_cubics_n
             } else {
-                result.push((ty, c));
-                result_starts.push(seg_start);
-                i += 1;
-            }
-        } else if ty == quad {
-            let mut run_end = i + 1;
-            while run_end < n && elements[run_end].0 == quad {
-                run_end += 1;
-            }
-            let run_len = run_end - i;
-
-            let mut merged = None;
-            for merge_len in (2..=run_len).rev() {
-                if let Some(m) = try_merge_quads_n(seg_start, &elements[i..i + merge_len]) {
-                    merged = Some((m, merge_len));
-                    break;
-                }
-            }
-
-            if let Some((m, len)) = merged {
-                result.push((quad, m));
+                try_merge_quads_n
+            };
+            if let Some((m, len)) = try_merge_run(ty, seg_start, i, n, &elements, try_merge_fn) {
+                result.push((ty, m));
                 result_starts.push(seg_start);
                 i += len;
             } else {
@@ -171,7 +140,7 @@ fn merge_subpath_elements(
 // The split parameters can be recovered from adjacent tangent-length ratios in
 // the same way as cubics. A parent quadratic then has only one outer control
 // point to reconstruct and validate.
-fn try_merge_quads_n(p0: Pt, segs: &[(i64, [f32; 6])]) -> Option<[f32; 6]> {
+fn try_merge_quads_n(p0: Pt, segs: &[PathElement]) -> Option<[f32; 6]> {
     let n = segs.len();
     debug_assert!(n >= 2);
 
@@ -231,7 +200,7 @@ fn try_merge_quads_n(p0: Pt, segs: &[(i64, [f32; 6])]) -> Option<[f32; 6]> {
     Some([p1[0], p1[1], 0.0, 0.0, p2[0], p2[1]])
 }
 
-fn validate_quad_merge(p0: Pt, p1: Pt, p2: Pt, segs: &[(i64, [f32; 6])], ts: &[f32]) -> bool {
+fn validate_quad_merge(p0: Pt, p1: Pt, p2: Pt, segs: &[PathElement], ts: &[f32]) -> bool {
     let pieces = split_quad_at_ts(p0, p1, p2, ts);
     for (k, (_rp0, rp1, rp2)) in pieces.iter().enumerate() {
         let orig_c = &segs[k].1;
@@ -278,7 +247,7 @@ fn split_quad_at_t(p0: Pt, p1: Pt, p2: Pt, t: f32) -> (Pt, Pt, Pt, Pt, Pt, Pt) {
 // Uses the fonttools qu2cu approach: reconstruct t-parameters from cumulative
 // ratios of adjacent junction tangent lengths, then recover the outer control
 // points P1/P2. Validity is confirmed by re-splitting and measuring curve error.
-fn try_merge_cubics_n(p0: [f32; 2], segs: &[(i64, [f32; 6])]) -> Option<[f32; 6]> {
+fn try_merge_cubics_n(p0: [f32; 2], segs: &[PathElement]) -> Option<[f32; 6]> {
     let n = segs.len();
     debug_assert!(n >= 2);
 
@@ -365,7 +334,7 @@ fn validate_cubic_merge(
     p1: [f32; 2],
     p2: [f32; 2],
     p3: [f32; 2],
-    segs: &[(i64, [f32; 6])],
+    segs: &[PathElement],
     ts: &[f32],
 ) -> bool {
     let pieces = split_cubic_at_ts(p0, p1, p2, p3, ts);
@@ -505,6 +474,27 @@ fn sub2(a: [f32; 2], b: [f32; 2]) -> [f32; 2] {
 #[inline]
 fn add2(a: [f32; 2], b: [f32; 2]) -> [f32; 2] {
     [a[0] + b[0], a[1] + b[1]]
+}
+
+fn try_merge_run(
+    ty: i64,
+    seg_start: Pt,
+    i: usize,
+    n: usize,
+    elements: &[PathElement],
+    try_merge: fn(Pt, &[PathElement]) -> Option<[f32; 6]>,
+) -> Option<([f32; 6], usize)> {
+    let mut run_end = i + 1;
+    while run_end < n && elements[run_end].0 == ty {
+        run_end += 1;
+    }
+    let run_len = run_end - i;
+    for merge_len in (2..=run_len).rev() {
+        if let Some(m) = try_merge(seg_start, &elements[i..i + merge_len]) {
+            return Some((m, merge_len));
+        }
+    }
+    None
 }
 
 #[inline]

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -1,6 +1,62 @@
+use skia_safe::{Path, PathBuilder, PathFillType};
+
+use crate::bounds::{Bounds, BoundsPen};
+use crate::outline::ElementType;
+
 pub(crate) mod cubic_to_quad;
 pub(crate) mod merge_curves;
 pub(crate) mod quad_to_cubic;
 pub(crate) mod remove_overlaps;
 pub(crate) mod render_bitmap;
 pub(crate) mod subpath;
+
+pub(crate) fn build_skia_path(
+    types: &[i64],
+    coords: &[f32],
+    track_bounds: bool,
+) -> Option<(Path, Option<Bounds>)> {
+    let mut builder = PathBuilder::new_with_fill_type(PathFillType::Winding);
+    let mut bounds = track_bounds.then(BoundsPen::default);
+    for (&element_type, values) in types.iter().zip(coords.chunks_exact(6)) {
+        match element_type {
+            v if v == ElementType::MoveTo as i64 => {
+                if let Some(b) = &mut bounds {
+                    b.move_to(values[4], values[5]);
+                }
+                builder.move_to((values[4], values[5]));
+            }
+            v if v == ElementType::LineTo as i64 => {
+                if let Some(b) = &mut bounds {
+                    b.line_to(values[4], values[5]);
+                }
+                builder.line_to((values[4], values[5]));
+            }
+            v if v == ElementType::QuadTo as i64 => {
+                if let Some(b) = &mut bounds {
+                    b.quad_to(values[0], values[1], values[4], values[5]);
+                }
+                builder.quad_to((values[0], values[1]), (values[4], values[5]));
+            }
+            v if v == ElementType::CurveTo as i64 => {
+                if let Some(b) = &mut bounds {
+                    b.curve_to(
+                        values[0], values[1], values[2], values[3], values[4], values[5],
+                    );
+                }
+                builder.cubic_to(
+                    (values[0], values[1]),
+                    (values[2], values[3]),
+                    (values[4], values[5]),
+                );
+            }
+            v if v == ElementType::Close as i64 => {
+                if let Some(b) = &mut bounds {
+                    b.close();
+                }
+                builder.close();
+            }
+            _ => break,
+        }
+    }
+    (!builder.is_empty()).then(|| (builder.detach(), bounds.and_then(BoundsPen::finish)))
+}

--- a/src/transform/remove_overlaps.rs
+++ b/src/transform/remove_overlaps.rs
@@ -1,42 +1,15 @@
-use skia_safe::{Path, PathBuilder, PathFillType, PathVerb};
+use skia_safe::{Path, PathVerb};
 
 use crate::outline::ElementType;
 
 pub(crate) fn remove_overlaps(types: &[i64], coords: &[f32]) -> (Vec<i64>, Vec<f32>) {
-    let path = build_path(types, coords);
+    let Some((path, _)) = super::build_skia_path(types, coords, false) else {
+        return outline_from_input(types, coords);
+    };
     path.simplify().map_or_else(
         || outline_from_input(types, coords),
         |simplified| outline_from_path(&simplified),
     )
-}
-
-fn build_path(types: &[i64], coords: &[f32]) -> Path {
-    let mut builder = PathBuilder::new_with_fill_type(PathFillType::Winding);
-    for (&element_type, values) in types.iter().zip(coords.chunks_exact(6)) {
-        match element_type {
-            v if v == ElementType::MoveTo as i64 => {
-                builder.move_to((values[4], values[5]));
-            }
-            v if v == ElementType::LineTo as i64 => {
-                builder.line_to((values[4], values[5]));
-            }
-            v if v == ElementType::QuadTo as i64 => {
-                builder.quad_to((values[0], values[1]), (values[4], values[5]));
-            }
-            v if v == ElementType::CurveTo as i64 => {
-                builder.cubic_to(
-                    (values[0], values[1]),
-                    (values[2], values[3]),
-                    (values[4], values[5]),
-                );
-            }
-            v if v == ElementType::Close as i64 => {
-                builder.close();
-            }
-            _ => break,
-        };
-    }
-    builder.detach()
 }
 
 fn outline_from_input(types: &[i64], coords: &[f32]) -> (Vec<i64>, Vec<f32>) {

--- a/src/transform/render_bitmap.rs
+++ b/src/transform/render_bitmap.rs
@@ -1,10 +1,6 @@
-use skia_safe::{
-    AlphaType, Color, ColorType, ImageInfo, Matrix, Paint, Path, PathBuilder, PathFillType,
-    surfaces,
-};
+use skia_safe::{AlphaType, Color, ColorType, ImageInfo, Matrix, Paint, surfaces};
 
-use crate::bounds::{Bounds, BoundsPen};
-use crate::outline::ElementType;
+use crate::bounds::Bounds;
 
 const FIXED_MIN: f32 = -0.25;
 const FIXED_MAX: f32 = 1.25;
@@ -41,7 +37,9 @@ pub(crate) fn render_bitmap(
     size: u32,
     mode: RenderMode,
 ) -> Result<RenderedBitmap, RenderBitmapError> {
-    let Some((path, bounds)) = build_path(types, coords, !matches!(mode, RenderMode::Fixed)) else {
+    let Some((path, bounds)) =
+        super::build_skia_path(types, coords, !matches!(mode, RenderMode::Fixed))
+    else {
         return Ok(blank_for_mode(size, mode));
     };
 
@@ -144,53 +142,6 @@ fn render_target(
             Ok(Some((bitmap_size as u32, bitmap_size as u32, transform)))
         }
     }
-}
-
-fn build_path(types: &[i64], coords: &[f32], track_bounds: bool) -> Option<(Path, Option<Bounds>)> {
-    let mut builder = PathBuilder::new_with_fill_type(PathFillType::Winding);
-    let mut bounds = track_bounds.then(BoundsPen::default);
-    for (&element_type, values) in types.iter().zip(coords.chunks_exact(6)) {
-        match element_type {
-            v if v == ElementType::MoveTo as i64 => {
-                if let Some(bounds) = &mut bounds {
-                    bounds.move_to(values[4], values[5]);
-                }
-                builder.move_to((values[4], values[5]));
-            }
-            v if v == ElementType::LineTo as i64 => {
-                if let Some(bounds) = &mut bounds {
-                    bounds.line_to(values[4], values[5]);
-                }
-                builder.line_to((values[4], values[5]));
-            }
-            v if v == ElementType::QuadTo as i64 => {
-                if let Some(bounds) = &mut bounds {
-                    bounds.quad_to(values[0], values[1], values[4], values[5]);
-                }
-                builder.quad_to((values[0], values[1]), (values[4], values[5]));
-            }
-            v if v == ElementType::CurveTo as i64 => {
-                if let Some(bounds) = &mut bounds {
-                    bounds.curve_to(
-                        values[0], values[1], values[2], values[3], values[4], values[5],
-                    );
-                }
-                builder.cubic_to(
-                    (values[0], values[1]),
-                    (values[2], values[3]),
-                    (values[4], values[5]),
-                );
-            }
-            v if v == ElementType::Close as i64 => {
-                if let Some(bounds) = &mut bounds {
-                    bounds.close();
-                }
-                builder.close();
-            }
-            _ => break,
-        }
-    }
-    (!builder.is_empty()).then(|| (builder.detach(), bounds.and_then(BoundsPen::finish)))
 }
 
 impl RenderTransform {


### PR DESCRIPTION
## Summary

- Move the shared outline-to-Skia-path conversion into `transform::build_skia_path`, removing the duplicate `build_path` implementations in `remove_overlaps` and `render_bitmap`. A new `ElementType` added in future now only needs one edit instead of two.
- Extract `try_merge_run` in `merge_curves` to collapse the structurally identical cubic and quad run-merge arms into a single branch, using a `PathElement` type alias and a function pointer parameter.

## Test plan

- [ ] `mise run check` passes (fmt, clippy, ty check)
- [ ] `cargo test` passes
- [ ] `uv run pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)