### PR TITLE
[codex] preserve winding in flip transforms

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -184,12 +184,14 @@ Flips a glyph outline horizontally around its tight bounding-box centre.
 
 - both on-curve endpoints and off-curve control points are transformed
 - zero-coordinate element types (CLOSE, END, PAD) are not modified
-- flipping reverses subpath winding order
+- closed subpath winding is preserved by default
+- pass `preserve_winding=False` to keep the reflected winding order instead
+- open subpaths are reflected but not reversed
 
 ### I/O Shape
 
 - input: `types=(N,)`, `coords=(N, 6)`
-- output: `types=(N,)` (unchanged), `coords=(N, 6)`
+- output: `types=(N,)`, `coords=(N, 6)`
 
 ## vertical_flip
 
@@ -205,12 +207,14 @@ Flips a glyph outline vertically around its tight bounding-box centre.
 
 - both on-curve endpoints and off-curve control points are transformed
 - zero-coordinate element types (CLOSE, END, PAD) are not modified
-- flipping reverses subpath winding order
+- closed subpath winding is preserved by default
+- pass `preserve_winding=False` to keep the reflected winding order instead
+- open subpaths are reflected but not reversed
 
 ### I/O Shape
 
 - input: `types=(N,)`, `coords=(N, 6)`
-- output: `types=(N,)` (unchanged), `coords=(N, 6)`
+- output: `types=(N,)`, `coords=(N, 6)`
 
 ## affine
 
@@ -251,6 +255,7 @@ types, coords = random_horizontal_flip(types, coords, p=0.5)
 Randomly applies `horizontal_flip` with probability `p`.
 
 - `p`: flip probability (default: `0.5`)
+- `preserve_winding`: preserve closed subpath winding after reflection (default: `True`)
 - `generator`: optional `torch.Generator` for reproducibility
 
 ### I/O Shape
@@ -271,6 +276,7 @@ types, coords = random_vertical_flip(types, coords, p=0.5)
 Randomly applies `vertical_flip` with probability `p`.
 
 - `p`: flip probability (default: `0.5`)
+- `preserve_winding`: preserve closed subpath winding after reflection (default: `True`)
 - `generator`: optional `torch.Generator` for reproducibility
 
 ### I/O Shape

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -183,12 +183,14 @@ types, coords = horizontal_flip(types, coords)
 
 - on-curve 終点と off-curve 制御点の両方を変換します
 - 座標が 0 の element type（CLOSE、END、PAD）は変更しません
-- 反転により subpath の巻き順が逆転します
+- 閉じた subpath の巻き順はデフォルトで保持します
+- 反転後の巻き順をそのまま使うには `preserve_winding=False` を指定します
+- 開いた subpath は反転しますが、走査方向は反転しません
 
 ### 入出力
 
 - 入力: `types=(N,)`, `coords=(N, 6)`
-- 出力: `types=(N,)` (変更なし), `coords=(N, 6)`
+- 出力: `types=(N,)`, `coords=(N, 6)`
 
 ## vertical_flip
 
@@ -204,12 +206,14 @@ types, coords = vertical_flip(types, coords)
 
 - on-curve 終点と off-curve 制御点の両方を変換します
 - 座標が 0 の element type（CLOSE、END、PAD）は変更しません
-- 反転により subpath の巻き順が逆転します
+- 閉じた subpath の巻き順はデフォルトで保持します
+- 反転後の巻き順をそのまま使うには `preserve_winding=False` を指定します
+- 開いた subpath は反転しますが、走査方向は反転しません
 
 ### 入出力
 
 - 入力: `types=(N,)`, `coords=(N, 6)`
-- 出力: `types=(N,)` (変更なし), `coords=(N, 6)`
+- 出力: `types=(N,)`, `coords=(N, 6)`
 
 ## affine
 
@@ -250,6 +254,7 @@ types, coords = random_horizontal_flip(types, coords, p=0.5)
 確率 `p` で `horizontal_flip` をランダムに適用します。
 
 - `p`: 反転確率（デフォルト: `0.5`）
+- `preserve_winding`: 反転後も閉じた subpath の巻き順を保持します（デフォルト: `True`）
 - `generator`: 再現性のためのオプション `torch.Generator`
 
 ### 入出力
@@ -270,6 +275,7 @@ types, coords = random_vertical_flip(types, coords, p=0.5)
 確率 `p` で `vertical_flip` をランダムに適用します。
 
 - `p`: 反転確率（デフォルト: `0.5`）
+- `preserve_winding`: 反転後も閉じた subpath の巻き順を保持します（デフォルト: `True`）
 - `generator`: 再現性のためのオプション `torch.Generator`
 
 ### 入出力

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,18 @@ fn randomize_subpath_start_points(
 }
 
 #[pyfunction]
+fn reverse_closed_subpaths(
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+) -> PyResult<(Vec<i64>, Vec<f32>)> {
+    let t = types.as_slice()?;
+    let c = coords.as_slice()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
+    let outline = outline::Outline::decode(t, c);
+    Ok(transform::subpath::reverse_closed_subpaths(&outline).encode())
+}
+
+#[pyfunction]
 fn remove_overlaps(
     types: PyReadonlyArray1<'_, i64>,
     coords: PyReadonlyArray1<'_, f32>,
@@ -189,6 +201,7 @@ fn _torchfont(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(remove_overlaps, &m)?)?;
     m.add_function(wrap_pyfunction!(normalize_subpath_start_points, &m)?)?;
     m.add_function(wrap_pyfunction!(randomize_subpath_start_points, &m)?)?;
+    m.add_function(wrap_pyfunction!(reverse_closed_subpaths, &m)?)?;
     m.add_function(wrap_pyfunction!(tight_bbox, &m)?)?;
     m.add_function(wrap_pyfunction!(render_bitmap, &m)?)?;
     Ok(())

--- a/src/outline/model.rs
+++ b/src/outline/model.rs
@@ -65,6 +65,20 @@ impl PathElement {
             Self::LineTo(end) | Self::QuadTo { end, .. } | Self::CurveTo { end, .. } => end,
         }
     }
+
+    pub(crate) fn reversed_to(self, end: Point) -> Self {
+        match self {
+            Self::LineTo(_) => Self::LineTo(end),
+            Self::QuadTo { control, .. } => Self::QuadTo { control, end },
+            Self::CurveTo {
+                control0, control1, ..
+            } => Self::CurveTo {
+                control0: control1,
+                control1: control0,
+                end,
+            },
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -80,23 +80,9 @@ fn reverse_closed_subpath(subpath: &Subpath) -> Subpath {
         .iter()
         .enumerate()
         .rev()
-        .map(|(idx, element)| reverse_element(*element, nodes[idx]))
+        .map(|(idx, element)| element.reversed_to(nodes[idx]))
         .collect();
     Subpath::new(last.end(), elements, true)
-}
-
-fn reverse_element(element: PathElement, end: Point) -> PathElement {
-    match element {
-        PathElement::LineTo(_) => PathElement::LineTo(end),
-        PathElement::QuadTo { control, .. } => PathElement::QuadTo { control, end },
-        PathElement::CurveTo {
-            control0, control1, ..
-        } => PathElement::CurveTo {
-            control0: control1,
-            control1: control0,
-            end,
-        },
-    }
 }
 
 fn subpath_nodes(subpath: &Subpath) -> Vec<Point> {

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -18,6 +18,21 @@ pub(crate) fn randomize_subpath_start_points(outline: &Outline, random_values: &
     })
 }
 
+pub(crate) fn reverse_closed_subpaths(outline: &Outline) -> Outline {
+    let subpaths = outline
+        .subpaths()
+        .iter()
+        .map(|subpath| {
+            if subpath.is_closed() {
+                reverse_closed_subpath(subpath)
+            } else {
+                subpath.clone()
+            }
+        })
+        .collect();
+    outline.with_subpaths(subpaths)
+}
+
 fn transform_start_points(
     outline: &Outline,
     choose_start: impl Fn(&Subpath, usize) -> usize,
@@ -52,6 +67,36 @@ fn rotate_closed_subpath(subpath: &Subpath, start_idx: usize) -> Subpath {
     }
     elements.extend_from_slice(&subpath.elements()[..split]);
     Subpath::new(start, elements, true)
+}
+
+fn reverse_closed_subpath(subpath: &Subpath) -> Subpath {
+    let Some(last) = subpath.elements().last() else {
+        return subpath.clone();
+    };
+
+    let nodes = subpath_nodes(subpath);
+    let elements = subpath
+        .elements()
+        .iter()
+        .enumerate()
+        .rev()
+        .map(|(idx, element)| reverse_element(*element, nodes[idx]))
+        .collect();
+    Subpath::new(last.end(), elements, true)
+}
+
+fn reverse_element(element: PathElement, end: Point) -> PathElement {
+    match element {
+        PathElement::LineTo(_) => PathElement::LineTo(end),
+        PathElement::QuadTo { control, .. } => PathElement::QuadTo { control, end },
+        PathElement::CurveTo {
+            control0, control1, ..
+        } => PathElement::CurveTo {
+            control0: control1,
+            control1: control0,
+            end,
+        },
+    }
 }
 
 fn subpath_nodes(subpath: &Subpath) -> Vec<Point> {

--- a/tests/transforms/geometric/test_horizontal_flip.py
+++ b/tests/transforms/geometric/test_horizontal_flip.py
@@ -64,6 +64,15 @@ def test_horizontal_flip_transforms_cubic_control_points(
     assert out[curve_idx, 2].item() == pytest.approx(1.0 - coords[curve_idx, 2].item())
 
 
+def test_horizontal_flip_reverses_cubic_segments_when_preserving_winding(
+    cubic_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = cubic_outline
+    _, out = horizontal_flip(types, coords)
+    assert out[1, 0].item() == pytest.approx(1.0 - coords[2, 2].item())
+    assert out[1, 2].item() == pytest.approx(1.0 - coords[2, 0].item())
+
+
 def test_horizontal_flip_quad_pair1_stays_zero(
     quad_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:

--- a/tests/transforms/geometric/test_horizontal_flip.py
+++ b/tests/transforms/geometric/test_horizontal_flip.py
@@ -7,6 +7,16 @@ from torchfont.io import ElementType
 from torchfont.transforms import horizontal_flip
 
 
+def _signed_area(types: torch.Tensor, coords: torch.Tensor) -> float:
+    points = coords[
+        (types == ElementType.MOVE_TO.value) | (types == ElementType.LINE_TO.value), 4:
+    ]
+    shifted = torch.roll(points, shifts=-1, dims=0)
+    return float(
+        (points[:, 0] * shifted[:, 1] - shifted[:, 0] * points[:, 1]).sum() / 2
+    )
+
+
 def test_horizontal_flip_mirrors_x_around_bbox_center(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
@@ -47,7 +57,7 @@ def test_horizontal_flip_transforms_cubic_control_points(
     cubic_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = cubic_outline
-    _, out = horizontal_flip(types, coords)
+    _, out = horizontal_flip(types, coords, preserve_winding=False)
 
     curve_idx = types.tolist().index(ElementType.CURVE_TO.value)
     assert out[curve_idx, 0].item() == pytest.approx(1.0 - coords[curve_idx, 0].item())
@@ -69,7 +79,33 @@ def test_horizontal_flip_does_not_alter_y_coordinates(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = simple_outline
-    _, out = horizontal_flip(types, coords)
+    _, out = horizontal_flip(types, coords, preserve_winding=False)
     assert torch.allclose(out[:, 1], coords[:, 1])
     assert torch.allclose(out[:, 3], coords[:, 3])
     assert torch.allclose(out[:, 5], coords[:, 5])
+
+
+def test_horizontal_flip_preserves_closed_subpath_winding_by_default(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    out_types, out = horizontal_flip(types, coords)
+    assert _signed_area(out_types, out) == pytest.approx(_signed_area(types, coords))
+
+
+def test_horizontal_flip_can_leave_reflected_winding(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    out_types, out = horizontal_flip(types, coords, preserve_winding=False)
+    assert _signed_area(out_types, out) == pytest.approx(-_signed_area(types, coords))
+
+
+def test_horizontal_flip_does_not_reverse_open_subpaths(
+    open_subpath: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = open_subpath
+    out_types, out = horizontal_flip(types, coords)
+    assert torch.equal(out_types, types)
+    assert out[0, 4].item() == pytest.approx(1.0)
+    assert out[1, 4].item() == pytest.approx(2.0)

--- a/tests/transforms/geometric/test_random_vertical_flip.py
+++ b/tests/transforms/geometric/test_random_vertical_flip.py
@@ -8,7 +8,13 @@ def test_random_vertical_flip_applies_with_p1(
 ) -> None:
     types, coords = simple_outline
     g = torch.Generator().manual_seed(0)
-    _, out = random_vertical_flip(types, coords, p=1.0, generator=g)
+    _, out = random_vertical_flip(
+        types,
+        coords,
+        p=1.0,
+        preserve_winding=False,
+        generator=g,
+    )
     assert not torch.equal(out, coords)
 
 

--- a/tests/transforms/geometric/test_vertical_flip.py
+++ b/tests/transforms/geometric/test_vertical_flip.py
@@ -7,11 +7,21 @@ from torchfont.io import ElementType
 from torchfont.transforms import vertical_flip
 
 
+def _signed_area(types: torch.Tensor, coords: torch.Tensor) -> float:
+    points = coords[
+        (types == ElementType.MOVE_TO.value) | (types == ElementType.LINE_TO.value), 4:
+    ]
+    shifted = torch.roll(points, shifts=-1, dims=0)
+    return float(
+        (points[:, 0] * shifted[:, 1] - shifted[:, 0] * points[:, 1]).sum() / 2
+    )
+
+
 def test_vertical_flip_mirrors_y_around_bbox_center(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = simple_outline
-    _, out = vertical_flip(types, coords)
+    _, out = vertical_flip(types, coords, preserve_winding=False)
 
     line_idx = types.tolist().index(ElementType.LINE_TO.value)
     assert out[line_idx, 5].item() == pytest.approx(1.0 - coords[line_idx, 5].item())
@@ -43,3 +53,19 @@ def test_vertical_flip_preserves_padding_zeros(
     types, coords = simple_outline
     _, out = vertical_flip(types, coords)
     assert close_end_zeros(types, out)
+
+
+def test_vertical_flip_preserves_closed_subpath_winding_by_default(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    out_types, out = vertical_flip(types, coords)
+    assert _signed_area(out_types, out) == pytest.approx(_signed_area(types, coords))
+
+
+def test_vertical_flip_can_leave_reflected_winding(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = simple_outline
+    out_types, out = vertical_flip(types, coords, preserve_winding=False)
+    assert _signed_area(out_types, out) == pytest.approx(-_signed_area(types, coords))

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -20,6 +20,9 @@ def normalize_subpath_start_points(
 def randomize_subpath_start_points(
     types: np.ndarray, coords: np.ndarray, random_values: np.ndarray
 ) -> tuple[list[int], list[float]]: ...
+def reverse_closed_subpaths(
+    types: np.ndarray, coords: np.ndarray
+) -> tuple[list[int], list[float]]: ...
 def remove_overlaps(
     types: np.ndarray, coords: np.ndarray
 ) -> tuple[list[int], list[float]]: ...

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -88,55 +88,77 @@ def _rotation_scale_shear_matrix(
     )
 
 
+def _preserve_closed_subpath_winding(
+    types: Tensor,
+    coords: Tensor,
+) -> tuple[Tensor, Tensor]:
+    out_types, out_coords = _torchfont.reverse_closed_subpaths(
+        types.cpu().contiguous().numpy(),
+        coords.cpu().contiguous().reshape(-1).numpy(),
+    )
+    return (
+        torch.tensor(out_types, dtype=torch.long, device=types.device),
+        torch.tensor(out_coords, dtype=torch.float32, device=coords.device).view(-1, 6),
+    )
+
+
 def horizontal_flip(
     types: Tensor,
     coords: Tensor,
+    *,
+    preserve_winding: bool = True,
 ) -> tuple[Tensor, Tensor]:
     """Flip a glyph outline horizontally around the bounding-box centre.
 
     Both on-curve endpoints and off-curve control points are transformed.
     Zero-coordinate element types (CLOSE, END, PAD) are left unchanged.
 
-    Note:
-        Flipping reverses subpath winding order. For most sequence models
-        this is acceptable; take care when consistent winding is required.
-
     Args:
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        preserve_winding: Reverse closed subpaths after reflection so their
+            winding direction matches the input. Default: ``True``.
 
     Returns:
         A new ``(types, coords)`` pair with coordinates reflected around the
-        bounding-box centre. ``types`` is returned unchanged (same object).
+        bounding-box centre. Closed subpaths are re-encoded when
+        ``preserve_winding`` is enabled.
 
     """
     matrix = torch.tensor([[-1.0, 0.0], [0.0, 1.0]])
     center = _bbox_center(types, coords)
-    return types, _apply_matrix(types, coords, matrix, center, (0.0, 0.0))
+    out_coords = _apply_matrix(types, coords, matrix, center, (0.0, 0.0))
+    if preserve_winding:
+        return _preserve_closed_subpath_winding(types, out_coords)
+    return types, out_coords
 
 
 def vertical_flip(
     types: Tensor,
     coords: Tensor,
+    *,
+    preserve_winding: bool = True,
 ) -> tuple[Tensor, Tensor]:
     """Flip a glyph outline vertically around the bounding-box centre.
-
-    Note:
-        Flipping reverses subpath winding order. For most sequence models
-        this is acceptable; take care when consistent winding is required.
 
     Args:
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        preserve_winding: Reverse closed subpaths after reflection so their
+            winding direction matches the input. Default: ``True``.
 
     Returns:
         A new ``(types, coords)`` pair with coordinates reflected around the
-        bounding-box centre. ``types`` is returned unchanged (same object).
+        bounding-box centre. Closed subpaths are re-encoded when
+        ``preserve_winding`` is enabled.
 
     """
     matrix = torch.tensor([[1.0, 0.0], [0.0, -1.0]])
     center = _bbox_center(types, coords)
-    return types, _apply_matrix(types, coords, matrix, center, (0.0, 0.0))
+    out_coords = _apply_matrix(types, coords, matrix, center, (0.0, 0.0))
+    if preserve_winding:
+        return _preserve_closed_subpath_winding(types, out_coords)
+    return types, out_coords
 
 
 def affine(
@@ -182,6 +204,7 @@ def random_horizontal_flip(
     coords: Tensor,
     *,
     p: float = 0.5,
+    preserve_winding: bool = True,
     generator: torch.Generator | None = None,
 ) -> tuple[Tensor, Tensor]:
     """Randomly flip a glyph outline horizontally with probability ``p``.
@@ -190,6 +213,8 @@ def random_horizontal_flip(
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
         p: Probability of applying the flip. Default: ``0.5``.
+        preserve_winding: Reverse closed subpaths after reflection so their
+            winding direction matches the input. Default: ``True``.
         generator: Optional ``torch.Generator`` for reproducible sampling.
 
     Returns:
@@ -197,7 +222,7 @@ def random_horizontal_flip(
 
     """
     if torch.rand(1, generator=generator).item() < p:
-        return horizontal_flip(types, coords)
+        return horizontal_flip(types, coords, preserve_winding=preserve_winding)
     return types, coords
 
 
@@ -206,6 +231,7 @@ def random_vertical_flip(
     coords: Tensor,
     *,
     p: float = 0.5,
+    preserve_winding: bool = True,
     generator: torch.Generator | None = None,
 ) -> tuple[Tensor, Tensor]:
     """Randomly flip a glyph outline vertically with probability ``p``.
@@ -214,6 +240,8 @@ def random_vertical_flip(
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
         p: Probability of applying the flip. Default: ``0.5``.
+        preserve_winding: Reverse closed subpaths after reflection so their
+            winding direction matches the input. Default: ``True``.
         generator: Optional ``torch.Generator`` for reproducible sampling.
 
     Returns:
@@ -221,7 +249,7 @@ def random_vertical_flip(
 
     """
     if torch.rand(1, generator=generator).item() < p:
-        return vertical_flip(types, coords)
+        return vertical_flip(types, coords, preserve_winding=preserve_winding)
     return types, coords
 
 


### PR DESCRIPTION
## Summary
- preserve closed-subpath winding by default when applying horizontal or vertical flips
- keep open subpaths reflected without reversing their traversal direction
- document the new `preserve_winding` option in both English and Japanese transform references

## Why
Reflections invert winding when only coordinates are transformed. For outline-sequence workflows, that silently changes contour semantics even when the rendered glyph still looks correct.

## Impact
`horizontal_flip`, `vertical_flip`, and their random variants now preserve winding by default. Callers that want the previous reflected-winding behavior can pass `preserve_winding=False`.

## Validation
- `mise run test`
- `mise run docs-build`
