### PR TITLE
[codex] bump version to 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ignore",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump the package version from `0.9.4` to `0.9.5`
- keep the Cargo manifest and lockfile aligned

## Why
Prepare the next patch release after `v0.9.4`.

## Impact
Release metadata advances to `0.9.5`; runtime behavior is unchanged.

## Validation
- `mise run check`
