### PR TITLE
remove terminated field from Outline

### DIFF
--- a/src/outline/encoding.rs
+++ b/src/outline/encoding.rs
@@ -7,7 +7,6 @@ impl Outline {
         let mut subpaths = Vec::new();
         let mut current: Option<SubpathBuilder> = None;
 
-        let mut terminated = false;
         for (&ty, values) in types.iter().zip(coords.chunks_exact(6)) {
             match ty {
                 v if v == ElementType::MoveTo as i64 => {
@@ -45,20 +44,13 @@ impl Outline {
                         subpaths.push(builder.finish(true));
                     }
                 }
-                v if v == ElementType::End as i64 => {
-                    terminated = true;
-                    break;
-                }
                 _ => break,
             }
         }
         if let Some(builder) = current {
             subpaths.push(builder.finish(false));
         }
-        Self {
-            subpaths,
-            terminated,
-        }
+        Self { subpaths }
     }
 
     pub(crate) fn encode(&self) -> (Vec<i64>, Vec<f32>) {
@@ -98,9 +90,7 @@ impl Outline {
                 push(&mut types, &mut coords, ElementType::Close, [0.0; 6]);
             }
         }
-        if self.terminated {
-            push(&mut types, &mut coords, ElementType::End, [0.0; 6]);
-        }
+        push(&mut types, &mut coords, ElementType::End, [0.0; 6]);
         (types, coords)
     }
 }

--- a/src/outline/model.rs
+++ b/src/outline/model.rs
@@ -111,15 +111,11 @@ impl Subpath {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct Outline {
     pub(super) subpaths: Vec<Subpath>,
-    pub(super) terminated: bool,
 }
 
 impl Outline {
     pub(crate) fn new(subpaths: Vec<Subpath>) -> Self {
-        Self {
-            subpaths,
-            terminated: true,
-        }
+        Self { subpaths }
     }
 
     pub(crate) fn subpaths(&self) -> &[Subpath] {
@@ -127,10 +123,7 @@ impl Outline {
     }
 
     pub(crate) fn with_subpaths(&self, subpaths: Vec<Subpath>) -> Self {
-        Self {
-            subpaths,
-            terminated: self.terminated,
-        }
+        Self { subpaths }
     }
 }
 

--- a/tests/transforms/subpath/test_normalize_subpath_start_points.py
+++ b/tests/transforms/subpath/test_normalize_subpath_start_points.py
@@ -36,6 +36,7 @@ def test_normalize_subpath_start_points_preserves_incoming_curve() -> None:
             ElementType.CURVE_TO.value,
             ElementType.LINE_TO.value,
             ElementType.CLOSE.value,
+            ElementType.END.value,
         ],
         dtype=torch.long,
     )
@@ -45,14 +46,15 @@ def test_normalize_subpath_start_points_preserves_incoming_curve() -> None:
             [0.7, 0.0, 0.3, 0.0, 0.0, 0.0],
             [0, 0, 0, 0, 1.0, 1.0],
             [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 0.0, 0.0],
         ],
         dtype=torch.float32,
     )
 
     out_types, out_coords = normalize_subpath_start_points(types, coords)
 
-    assert out_types[-2].item() == ElementType.CURVE_TO.value
-    assert torch.equal(out_coords[-2], coords[1])
+    assert out_types[-3].item() == ElementType.CURVE_TO.value
+    assert torch.equal(out_coords[-3], coords[1])
 
 
 def test_normalize_subpath_start_points_leaves_open_subpaths_unchanged(


### PR DESCRIPTION
## Summary

- `Outline.terminated: bool` を削除。`terminated` は `End` を emit するためだけに存在していたが、`End` 自体も `decode` の `_` アームで代替できる循環構造だった
- `decode` の `End` アームを削除。値 6（`End`）は `_ => break` で正しく停止する
- `encode` の `if self.terminated` 条件を削除し、常に `End` を emit するよう変更
- `ElementType::End = 6` 自体は encode 側で値を参照するため残す

## Test plan

- [ ] `mise run build` でビルド成功を確認
- [ ] `mise run test` で全テスト通過を確認（195 passed, 4 skipped）

🤖 Generated with [Claude Code](https://claude.com/claude-code)