### PR TITLE
refactor: reduce verbosity in Rust backend

### DIFF
--- a/src/outline/encoding.rs
+++ b/src/outline/encoding.rs
@@ -8,21 +8,21 @@ impl Outline {
         let mut current: Option<SubpathBuilder> = None;
 
         for (&ty, values) in types.iter().zip(coords.chunks_exact(6)) {
-            match ty {
-                v if v == ElementType::MoveTo as i64 => {
+            match ElementType::try_from(ty) {
+                Ok(ElementType::MoveTo) => {
                     if let Some(builder) = current.take() {
                         subpaths.push(builder.finish(false));
                     }
                     current = Some(SubpathBuilder::new(Point::new(values[4], values[5])));
                 }
-                v if v == ElementType::LineTo as i64 => {
+                Ok(ElementType::LineTo) => {
                     if let Some(builder) = &mut current {
                         builder
                             .elements
                             .push(PathElement::LineTo(Point::new(values[4], values[5])));
                     }
                 }
-                v if v == ElementType::QuadTo as i64 => {
+                Ok(ElementType::QuadTo) => {
                     if let Some(builder) = &mut current {
                         builder.elements.push(PathElement::QuadTo {
                             control: Point::new(values[0], values[1]),
@@ -30,7 +30,7 @@ impl Outline {
                         });
                     }
                 }
-                v if v == ElementType::CurveTo as i64 => {
+                Ok(ElementType::CurveTo) => {
                     if let Some(builder) = &mut current {
                         builder.elements.push(PathElement::CurveTo {
                             control0: Point::new(values[0], values[1]),
@@ -39,12 +39,12 @@ impl Outline {
                         });
                     }
                 }
-                v if v == ElementType::Close as i64 => {
+                Ok(ElementType::Close) => {
                     if let Some(builder) = current.take() {
                         subpaths.push(builder.finish(true));
                     }
                 }
-                _ => break,
+                Ok(ElementType::End) | Err(_) => break,
             }
         }
         if let Some(builder) = current {
@@ -104,6 +104,21 @@ pub(crate) enum ElementType {
     CurveTo = 4,
     Close = 5,
     End = 6,
+}
+
+impl TryFrom<i64> for ElementType {
+    type Error = ();
+    fn try_from(v: i64) -> Result<Self, Self::Error> {
+        Ok(match v {
+            1 => Self::MoveTo,
+            2 => Self::LineTo,
+            3 => Self::QuadTo,
+            4 => Self::CurveTo,
+            5 => Self::Close,
+            6 => Self::End,
+            _ => return Err(()),
+        })
+    }
 }
 
 fn push_endpoint(types: &mut Vec<i64>, coords: &mut Vec<f32>, ty: ElementType, point: Point) {

--- a/src/outline/model.rs
+++ b/src/outline/model.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub(crate) struct Point {
     pub(crate) x: f32,
     pub(crate) y: f32,
@@ -7,10 +7,6 @@ pub(crate) struct Point {
 impl Point {
     pub(crate) fn new(x: f32, y: f32) -> Self {
         Self { x, y }
-    }
-
-    pub(crate) fn zero() -> Self {
-        Self::new(0.0, 0.0)
     }
 
     pub(crate) fn lerp(self, other: Self, t: f32) -> Self {
@@ -24,14 +20,6 @@ impl Point {
         self.lerp(other, 0.5)
     }
 
-    pub(crate) fn sub(self, other: Self) -> Self {
-        Self::new(self.x - other.x, self.y - other.y)
-    }
-
-    pub(crate) fn add(self, other: Self) -> Self {
-        Self::new(self.x + other.x, self.y + other.y)
-    }
-
     pub(crate) fn cross(self, other: Self) -> f32 {
         self.x * other.y - self.y * other.x
     }
@@ -41,6 +29,20 @@ impl Point {
             return f32::INFINITY;
         }
         (self.x * self.x + self.y * self.y).sqrt()
+    }
+}
+
+impl std::ops::Add for Point {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        Self::new(self.x + other.x, self.y + other.y)
+    }
+}
+
+impl std::ops::Sub for Point {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        Self::new(self.x - other.x, self.y - other.y)
     }
 }
 
@@ -120,10 +122,6 @@ impl Outline {
 
     pub(crate) fn subpaths(&self) -> &[Subpath] {
         &self.subpaths
-    }
-
-    pub(crate) fn with_subpaths(&self, subpaths: Vec<Subpath>) -> Self {
-        Self { subpaths }
     }
 }
 

--- a/src/transform/cubic_to_quad.rs
+++ b/src/transform/cubic_to_quad.rs
@@ -38,7 +38,7 @@ pub(crate) fn cubic_to_quad(outline: &Outline) -> Result<Outline, CubicToQuadErr
         }
         subpaths.push(Subpath::new(subpath.start(), elements, subpath.is_closed()));
     }
-    Ok(outline.with_subpaths(subpaths))
+    Ok(Outline::new(subpaths))
 }
 
 // Port of fonttools.cu2qu's all_quadratic=True path.  The returned pairs encode
@@ -57,7 +57,7 @@ fn cubic_to_quads(
                 let end = if i + 1 == n {
                     p3
                 } else {
-                    midpoint(spline[i + 1], spline[i + 2])
+                    spline[i + 1].midpoint(spline[i + 2])
                 };
                 out.push((spline[i + 1], end));
             }
@@ -77,7 +77,7 @@ fn cubic_approx_spline(p0: Point, p1: Point, p2: Point, p3: Point, n: usize) -> 
     let mut spline = Vec::with_capacity(n + 2);
     let mut next_q1 = cubic_approx_control(0.0, cubics[0]);
     let mut q2 = p0;
-    let mut d1 = Point::zero();
+    let mut d1 = Point::default();
     spline.push(p0);
     spline.push(next_q1);
 
@@ -88,16 +88,16 @@ fn cubic_approx_spline(p0: Point, p1: Point, p2: Point, p3: Point, n: usize) -> 
         if i < n {
             next_q1 = cubic_approx_control(i as f32 / (n - 1) as f32, cubics[i]);
             spline.push(next_q1);
-            q2 = midpoint(q1, next_q1);
+            q2 = q1.midpoint(next_q1);
         } else {
             q2 = c3;
         }
 
         let d0 = d1;
-        d1 = sub(q2, c3);
-        let e1 = sub(lerp(q0, q1, 2.0 / 3.0), c1);
-        let e2 = sub(lerp(q2, q1, 2.0 / 3.0), c2);
-        if norm(d1) > TOLERANCE || !cubic_farthest_fit_inside(d0, e1, e2, d1, TOLERANCE) {
+        d1 = q2 - c3;
+        let e1 = q0.lerp(q1, 2.0 / 3.0) - c1;
+        let e2 = q2.lerp(q1, 2.0 / 3.0) - c2;
+        if d1.norm() > TOLERANCE || !cubic_farthest_fit_inside(d0, e1, e2, d1, TOLERANCE) {
             return None;
         }
     }
@@ -111,34 +111,34 @@ fn cubic_approx_quadratic(p0: Point, p1: Point, p2: Point, p3: Point) -> Option<
     // degree-elevated quadratics), the intersection is at infinity, so recover
     // the same control from each cubic handle and let the fit test below decide.
     let q1 = line_intersection(p0, p1, p2, p3)
-        .unwrap_or_else(|| midpoint(lerp(p0, p1, 1.5), lerp(p3, p2, 1.5)));
-    let c1 = lerp(p0, q1, 2.0 / 3.0);
-    let c2 = lerp(p3, q1, 2.0 / 3.0);
+        .unwrap_or_else(|| p0.lerp(p1, 1.5).midpoint(p3.lerp(p2, 1.5)));
+    let c1 = p0.lerp(q1, 2.0 / 3.0);
+    let c2 = p3.lerp(q1, 2.0 / 3.0);
     cubic_farthest_fit_inside(
-        Point::zero(),
-        sub(c1, p1),
-        sub(c2, p2),
-        Point::zero(),
+        Point::default(),
+        c1 - p1,
+        c2 - p2,
+        Point::default(),
         TOLERANCE,
     )
     .then_some(q1)
 }
 
 fn cubic_approx_control(t: f32, (p0, p1, p2, p3): Cubic) -> Point {
-    let a = lerp(p0, p1, 1.5);
-    let b = lerp(p3, p2, 1.5);
-    lerp(a, b, t)
+    let a = p0.lerp(p1, 1.5);
+    let b = p3.lerp(p2, 1.5);
+    a.lerp(b, t)
 }
 
 fn line_intersection(a: Point, b: Point, c: Point, d: Point) -> Option<Point> {
-    let ab = sub(b, a);
-    let cd = sub(d, c);
-    let den = cross(ab, cd);
+    let ab = b - a;
+    let cd = d - c;
+    let den = ab.cross(cd);
     if den.abs() < 1e-15 {
         return (b == c && (a == b || c == d)).then_some(b);
     }
-    let h = cross(sub(c, a), ab) / den;
-    Some(lerp(c, d, h))
+    let h = (c - a).cross(ab) / den;
+    Some(c.lerp(d, h))
 }
 
 fn split_cubic_into_n(p0: Point, p1: Point, p2: Point, p3: Point, n: usize) -> Vec<Cubic> {
@@ -163,49 +163,30 @@ fn split_cubic_into_n(p0: Point, p1: Point, p2: Point, p3: Point, n: usize) -> V
 }
 
 fn split_cubic_at(p0: Point, p1: Point, p2: Point, p3: Point, t: f32) -> (Cubic, Cubic) {
-    let q0 = lerp(p0, p1, t);
-    let q1 = lerp(p1, p2, t);
-    let q2 = lerp(p2, p3, t);
-    let r0 = lerp(q0, q1, t);
-    let r1 = lerp(q1, q2, t);
-    let s = lerp(r0, r1, t);
+    let q0 = p0.lerp(p1, t);
+    let q1 = p1.lerp(p2, t);
+    let q2 = p2.lerp(p3, t);
+    let r0 = q0.lerp(q1, t);
+    let r1 = q1.lerp(q2, t);
+    let s = r0.lerp(r1, t);
     ((p0, q0, r0, s), (s, r1, q2, p3))
 }
 
 fn cubic_farthest_fit_inside(p0: Point, p1: Point, p2: Point, p3: Point, tolerance: f32) -> bool {
-    if norm(p2) <= tolerance && norm(p1) <= tolerance {
+    if p2.norm() <= tolerance && p1.norm() <= tolerance {
         return true;
     }
     let mid = Point::new(
         (p0.x + 3.0 * (p1.x + p2.x) + p3.x) * 0.125,
         (p0.y + 3.0 * (p1.y + p2.y) + p3.y) * 0.125,
     );
-    if norm(mid) > tolerance {
+    if mid.norm() > tolerance {
         return false;
     }
     let deriv3 = Point::new(
         (p3.x + p2.x - p1.x - p0.x) * 0.125,
         (p3.y + p2.y - p1.y - p0.y) * 0.125,
     );
-    cubic_farthest_fit_inside(p0, midpoint(p0, p1), sub(mid, deriv3), mid, tolerance)
-        && cubic_farthest_fit_inside(mid, add(mid, deriv3), midpoint(p2, p3), p3, tolerance)
-}
-
-fn lerp(a: Point, b: Point, t: f32) -> Point {
-    a.lerp(b, t)
-}
-fn midpoint(a: Point, b: Point) -> Point {
-    a.midpoint(b)
-}
-fn sub(a: Point, b: Point) -> Point {
-    a.sub(b)
-}
-fn add(a: Point, b: Point) -> Point {
-    a.add(b)
-}
-fn cross(a: Point, b: Point) -> f32 {
-    a.cross(b)
-}
-fn norm(point: Point) -> f32 {
-    point.norm()
+    cubic_farthest_fit_inside(p0, p0.midpoint(p1), mid - deriv3, mid, tolerance)
+        && cubic_farthest_fit_inside(mid, mid + deriv3, p2.midpoint(p3), p3, tolerance)
 }

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -15,7 +15,7 @@ pub(crate) fn merge_curves(outline: &Outline) -> Outline {
             Subpath::new(subpath.start(), elements, subpath.is_closed())
         })
         .collect();
-    outline.with_subpaths(subpaths)
+    Outline::new(subpaths)
 }
 
 fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathElement> {
@@ -140,16 +140,15 @@ fn try_merge_quads_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
         let (prev_h, prev_end) = quad_points(segs[k - 1]);
         let (curr_h, _curr_end) = quad_points(segs[k]);
 
-        let end_tan = sub(prev_end, prev_h);
-        let start_tan = sub(curr_h, prev_end);
-        let len_end = hypot(end_tan.x, end_tan.y);
-        let len_start = hypot(start_tan.x, start_tan.y);
+        let end_tan = prev_end - prev_h;
+        let start_tan = curr_h - prev_end;
+        let len_end = end_tan.norm();
+        let len_start = start_tan.norm();
         if len_end < 1e-10 {
             return None;
         }
         if len_start > 1e-10 {
-            let cross = end_tan.x * start_tan.y - end_tan.y * start_tan.x;
-            if cross.abs() > TOLERANCE * len_end * len_start {
+            if end_tan.cross(start_tan).abs() > TOLERANCE * len_end * len_start {
                 return None;
             }
             if end_tan.x * start_tan.x + end_tan.y * start_tan.y < 0.0 {
@@ -171,10 +170,7 @@ fn try_merge_quads_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
     }
 
     let (first_h, _first_end) = quad_points(segs[0]);
-    let p1 = Point::new(
-        p0.x + (first_h.x - p0.x) / t1,
-        p0.y + (first_h.y - p0.y) / t1,
-    );
+    let p1 = p0.lerp(first_h, 1.0 / t1);
     let (_last_h, p2) = quad_points(segs[n - 1]);
 
     if !validate_quad_merge(p0, p1, p2, segs, &ts) {
@@ -191,9 +187,7 @@ fn validate_quad_merge(p0: Point, p1: Point, p2: Point, segs: &[PathElement], ts
     let pieces = split_quad_at_ts(p0, p1, p2, ts);
     for (k, (_rp0, rp1, rp2)) in pieces.iter().enumerate() {
         let (orig_h, orig_end) = quad_points(segs[k]);
-        if hypot(rp1.x - orig_h.x, rp1.y - orig_h.y) > TOLERANCE
-            || hypot(rp2.x - orig_end.x, rp2.y - orig_end.y) > TOLERANCE
-        {
+        if (*rp1 - orig_h).norm() > TOLERANCE || (*rp2 - orig_end).norm() > TOLERANCE {
             return false;
         }
     }
@@ -226,9 +220,9 @@ fn split_quad_at_t(
     p2: Point,
     t: f32,
 ) -> (Point, Point, Point, Point, Point, Point) {
-    let q1 = lerp(p0, p1, t);
-    let q2 = lerp(p1, p2, t);
-    let s = lerp(q1, q2, t);
+    let q1 = p0.lerp(p1, t);
+    let q2 = p1.lerp(p2, t);
+    let s = q1.lerp(q2, t);
     (p0, q1, s, s, q2, p2)
 }
 
@@ -252,11 +246,11 @@ fn try_merge_cubics_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
         let (_prev_h1, prev_h2, prev_end) = cubic_points(segs[k - 1]);
         let (curr_h1, _curr_h2, _curr_end) = cubic_points(segs[k]);
 
-        let end_tan = sub(prev_end, prev_h2);
-        let start_tan = sub(curr_h1, prev_end);
+        let end_tan = prev_end - prev_h2;
+        let start_tan = curr_h1 - prev_end;
 
-        let len_end = hypot(end_tan.x, end_tan.y);
-        let len_start = hypot(start_tan.x, start_tan.y);
+        let len_end = end_tan.norm();
+        let len_start = start_tan.norm();
 
         if len_end < 1e-10 {
             return None;
@@ -264,8 +258,7 @@ fn try_merge_cubics_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
 
         // Tangents at the junction must be parallel and in the same direction.
         if len_start > 1e-10 {
-            let cross = end_tan.x * start_tan.y - end_tan.y * start_tan.x;
-            if cross.abs() > TOLERANCE * len_end * len_start {
+            if end_tan.cross(start_tan).abs() > TOLERANCE * len_end * len_start {
                 return None;
             }
             if end_tan.x * start_tan.x + end_tan.y * start_tan.y < 0.0 {
@@ -296,14 +289,8 @@ fn try_merge_cubics_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
     // Recover outer control points from the split relationship:
     //   first_h1 = lerp(P0, P1, t1)  →  P1 = P0 + (first_h1 − P0) / t1
     //   last_h2  = lerp(P2, P3, t_last)  →  P2 = P3 + (last_h2 − P3) / (1 − t_last)
-    let p1 = Point::new(
-        p0.x + (first_h1.x - p0.x) / t1,
-        p0.y + (first_h1.y - p0.y) / t1,
-    );
-    let p2 = Point::new(
-        p3.x + (last_h2.x - p3.x) / (1.0 - t_last),
-        p3.y + (last_h2.y - p3.y) / (1.0 - t_last),
-    );
+    let p1 = p0.lerp(first_h1, 1.0 / t1);
+    let p2 = p3.lerp(last_h2, 1.0 / (1.0 - t_last));
 
     if !validate_cubic_merge(p0, p1, p2, p3, segs, &ts) {
         return None;
@@ -330,15 +317,15 @@ fn validate_cubic_merge(
     for (k, (rp0, rp1, rp2, rp3)) in pieces.iter().enumerate() {
         let (orig_h1, orig_h2, orig_end) = cubic_points(segs[k]);
 
-        if hypot(rp3.x - orig_end.x, rp3.y - orig_end.y) > TOLERANCE {
+        if (*rp3 - orig_end).norm() > TOLERANCE {
             return false;
         }
 
         // Check that the difference cubic lies within TOLERANCE of the origin.
-        let d0 = sub(*rp0, prev_end);
-        let d1 = sub(*rp1, orig_h1);
-        let d2 = sub(*rp2, orig_h2);
-        let d3 = sub(*rp3, orig_end);
+        let d0 = *rp0 - prev_end;
+        let d1 = *rp1 - orig_h1;
+        let d2 = *rp2 - orig_h2;
+        let d3 = *rp3 - orig_end;
 
         if !cubic_farthest_fit_inside(d0, d1, d2, d3, TOLERANCE) {
             return false;
@@ -380,19 +367,19 @@ fn split_cubic_at_t(
     p3: Point,
     t: f32,
 ) -> (Point, Point, Point, Point, Point, Point, Point, Point) {
-    let q1 = lerp(p0, p1, t);
-    let q2 = lerp(p1, p2, t);
-    let q3 = lerp(p2, p3, t);
-    let r1 = lerp(q1, q2, t);
-    let r2 = lerp(q2, q3, t);
-    let s = lerp(r1, r2, t);
+    let q1 = p0.lerp(p1, t);
+    let q2 = p1.lerp(p2, t);
+    let q3 = p2.lerp(p3, t);
+    let r1 = q1.lerp(q2, t);
+    let r2 = q2.lerp(q3, t);
+    let s = r1.lerp(r2, t);
     (p0, q1, r1, s, s, r2, q3, p3)
 }
 
 // Recursive check: does the cubic (as a displacement field relative to the origin)
 // lie entirely within `tolerance` of the origin?  Ported from fonttools qu2cu.
 fn cubic_farthest_fit_inside(p0: Point, p1: Point, p2: Point, p3: Point, tolerance: f32) -> bool {
-    if hypot(p2.x, p2.y) <= tolerance && hypot(p1.x, p1.y) <= tolerance {
+    if p2.norm() <= tolerance && p1.norm() <= tolerance {
         return true;
     }
 
@@ -400,7 +387,7 @@ fn cubic_farthest_fit_inside(p0: Point, p1: Point, p2: Point, p3: Point, toleran
         (p0.x + 3.0 * (p1.x + p2.x) + p3.x) * 0.125,
         (p0.y + 3.0 * (p1.y + p2.y) + p3.y) * 0.125,
     );
-    if hypot(mid.x, mid.y) > tolerance {
+    if mid.norm() > tolerance {
         return false;
     }
 
@@ -409,11 +396,11 @@ fn cubic_farthest_fit_inside(p0: Point, p1: Point, p2: Point, p3: Point, toleran
         (p3.y + p2.y - p1.y - p0.y) * 0.125,
     );
 
-    let p01 = lerp(p0, p1, 0.5);
-    let p23 = lerp(p2, p3, 0.5);
+    let p01 = p0.lerp(p1, 0.5);
+    let p23 = p2.lerp(p3, 0.5);
 
-    cubic_farthest_fit_inside(p0, p01, sub(mid, deriv3), mid, tolerance)
-        && cubic_farthest_fit_inside(mid, add(mid, deriv3), p23, p3, tolerance)
+    cubic_farthest_fit_inside(p0, p01, mid - deriv3, mid, tolerance)
+        && cubic_farthest_fit_inside(mid, mid + deriv3, p23, p3, tolerance)
 }
 
 fn can_merge_lines(start: Point, middle: Point, end: Point) -> bool {
@@ -429,7 +416,7 @@ fn can_merge_lines(start: Point, middle: Point, end: Point) -> bool {
 
     let total_dx = end.x - start.x;
     let total_dy = end.y - start.y;
-    let total_len = hypot(total_dx, total_dy);
+    let total_len = total_dx.hypot(total_dy);
     if total_len < 1e-6 {
         return false;
     }
@@ -443,24 +430,4 @@ fn can_merge_lines(start: Point, middle: Point, end: Point) -> bool {
     }
 
     dx1 * dx2 + dy1 * dy2 >= 0.0
-}
-
-#[inline]
-fn lerp(a: Point, b: Point, t: f32) -> Point {
-    a.lerp(b, t)
-}
-
-#[inline]
-fn sub(a: Point, b: Point) -> Point {
-    a.sub(b)
-}
-
-#[inline]
-fn add(a: Point, b: Point) -> Point {
-    a.add(b)
-}
-
-#[inline]
-fn hypot(x: f32, y: f32) -> f32 {
-    (x * x + y * y).sqrt()
 }

--- a/src/transform/quad_to_cubic.rs
+++ b/src/transform/quad_to_cubic.rs
@@ -1,5 +1,5 @@
 use super::merge_curves;
-use crate::outline::{ElementType, Outline};
+use crate::outline::{ElementType, Outline, Point};
 
 pub(crate) fn quad_to_cubic(types: &mut [i64], coords: &mut [f32], seq_len: usize) {
     debug_assert_eq!(types.len() * 6, coords.len());
@@ -13,23 +13,21 @@ pub(crate) fn quad_to_cubic(types: &mut [i64], coords: &mut [f32], seq_len: usiz
         .chunks_mut(seq_len)
         .zip(coords.chunks_mut(seq_len * 6))
     {
-        let mut prev_x = 0.0f32;
-        let mut prev_y = 0.0f32;
+        let mut prev = Point::default();
         for (i, t) in t_seq.iter_mut().enumerate() {
             let base = i * 6;
-            let end_x = c_seq[base + 4];
-            let end_y = c_seq[base + 5];
+            let end = Point::new(c_seq[base + 4], c_seq[base + 5]);
             if *t == quad {
-                let cx0 = c_seq[base];
-                let cy0 = c_seq[base + 1];
-                c_seq[base] = prev_x + (2.0 / 3.0) * (cx0 - prev_x);
-                c_seq[base + 1] = prev_y + (2.0 / 3.0) * (cy0 - prev_y);
-                c_seq[base + 2] = end_x + (2.0 / 3.0) * (cx0 - end_x);
-                c_seq[base + 3] = end_y + (2.0 / 3.0) * (cy0 - end_y);
+                let ctrl = Point::new(c_seq[base], c_seq[base + 1]);
+                let c1 = prev.lerp(ctrl, 2.0 / 3.0);
+                let c2 = end.lerp(ctrl, 2.0 / 3.0);
+                c_seq[base] = c1.x;
+                c_seq[base + 1] = c1.y;
+                c_seq[base + 2] = c2.x;
+                c_seq[base + 3] = c2.y;
                 *t = cubic;
             }
-            prev_x = end_x;
-            prev_y = end_y;
+            prev = end;
         }
     }
 }

--- a/src/transform/remove_overlaps.rs
+++ b/src/transform/remove_overlaps.rs
@@ -8,10 +8,7 @@ pub(crate) fn remove_overlaps(outline: &Outline) -> Outline {
     };
     path.simplify().map_or_else(
         || outline.clone(),
-        |simplified| {
-            let simplified = outline_from_path(&simplified);
-            outline.with_subpaths(simplified.subpaths().to_vec())
-        },
+        |simplified| outline_from_path(&simplified),
     )
 }
 

--- a/src/transform/render_bitmap.rs
+++ b/src/transform/render_bitmap.rs
@@ -24,14 +24,6 @@ pub(crate) enum RenderBitmapError {
     BboxTooLarge,
 }
 
-struct RenderTransform {
-    sx: f32,
-    ky: f32,
-    sy: f32,
-    tx: f32,
-    ty: f32,
-}
-
 pub(crate) fn render_bitmap(
     outline: &Outline,
     size: u32,
@@ -43,7 +35,7 @@ pub(crate) fn render_bitmap(
     };
 
     let bitmap_size = size as f32;
-    let Some((width, height, transform)) = render_target(bounds, bitmap_size, mode)? else {
+    let Some((width, height, matrix)) = render_target(bounds, bitmap_size, mode)? else {
         return Ok(blank_for_mode(size, mode));
     };
 
@@ -60,7 +52,7 @@ pub(crate) fn render_bitmap(
     };
     let canvas = surface.canvas();
     canvas.clear(Color::TRANSPARENT);
-    canvas.concat(&transform.matrix());
+    canvas.concat(&matrix);
 
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
@@ -79,18 +71,15 @@ fn render_target(
     bounds: Option<Bounds>,
     bitmap_size: f32,
     mode: RenderMode,
-) -> Result<Option<(u32, u32, RenderTransform)>, RenderBitmapError> {
+) -> Result<Option<(u32, u32, Matrix)>, RenderBitmapError> {
     match mode {
         RenderMode::Fixed => {
             let scale = bitmap_size / (FIXED_MAX - FIXED_MIN);
-            let transform = RenderTransform {
-                sx: scale,
-                ky: 0.0,
-                sy: -scale,
-                tx: -FIXED_MIN * scale,
-                ty: bitmap_size + FIXED_MIN * scale,
-            };
-            Ok(Some((bitmap_size as u32, bitmap_size as u32, transform)))
+            Ok(Some((
+                bitmap_size as u32,
+                bitmap_size as u32,
+                render_matrix(scale, -FIXED_MIN * scale, bitmap_size + FIXED_MIN * scale),
+            )))
         }
         RenderMode::Bbox => {
             let Some(bounds) = bounds else {
@@ -110,14 +99,11 @@ fn render_target(
             if bitmap_width > MAX_BITMAP_SIDE || bitmap_height > MAX_BITMAP_SIDE {
                 return Err(RenderBitmapError::BboxTooLarge);
             }
-            let transform = RenderTransform {
-                sx: scale,
-                ky: 0.0,
-                sy: -scale,
-                tx: -bounds.x_min * scale,
-                ty: bounds.y_max * scale,
-            };
-            Ok(Some((bitmap_width, bitmap_height, transform)))
+            Ok(Some((
+                bitmap_width,
+                bitmap_height,
+                render_matrix(scale, -bounds.x_min * scale, bounds.y_max * scale),
+            )))
         }
         RenderMode::BboxSquare => {
             let Some(bounds) = bounds else {
@@ -131,24 +117,21 @@ fn render_target(
             let scale = bitmap_size / width.max(height);
             let offset_x = (bitmap_size - width * scale) * 0.5;
             let offset_y = (bitmap_size - height * scale) * 0.5;
-            let transform = RenderTransform {
-                sx: scale,
-                ky: 0.0,
-                sy: -scale,
-                tx: offset_x - bounds.x_min * scale,
-                ty: offset_y + bounds.y_max * scale,
-            };
-            Ok(Some((bitmap_size as u32, bitmap_size as u32, transform)))
+            Ok(Some((
+                bitmap_size as u32,
+                bitmap_size as u32,
+                render_matrix(
+                    scale,
+                    offset_x - bounds.x_min * scale,
+                    offset_y + bounds.y_max * scale,
+                ),
+            )))
         }
     }
 }
 
-impl RenderTransform {
-    fn matrix(&self) -> Matrix {
-        Matrix::new_all(
-            self.sx, 0.0, self.tx, self.ky, self.sy, self.ty, 0.0, 0.0, 1.0,
-        )
-    }
+fn render_matrix(scale: f32, tx: f32, ty: f32) -> Matrix {
+    Matrix::new_all(scale, 0.0, tx, 0.0, -scale, ty, 0.0, 0.0, 1.0)
 }
 
 fn blank_bitmap(width: u32, height: u32) -> RenderedBitmap {

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -30,7 +30,7 @@ pub(crate) fn reverse_closed_subpaths(outline: &Outline) -> Outline {
             }
         })
         .collect();
-    outline.with_subpaths(subpaths)
+    Outline::new(subpaths)
 }
 
 fn transform_start_points(
@@ -49,7 +49,7 @@ fn transform_start_points(
             }
         })
         .collect();
-    outline.with_subpaths(subpaths)
+    Outline::new(subpaths)
 }
 
 fn rotate_closed_subpath(subpath: &Subpath, start_idx: usize) -> Subpath {


### PR DESCRIPTION
## Summary

- `Point` に `Default`・`Add`・`Sub` trait を実装し、`zero()`/`add()`/`sub()` メソッドを削除。`a - b`・`a + b` の自然な演算子表記が可能に
- `ElementType` に `TryFrom<i64>` を実装し、`decode` の guard 付き match を enum 直接マッチに変更
- `merge_curves` と `cubic_to_quad` に存在した `lerp`/`sub`/`add`/`hypot`/`norm` 等のラッパー関数（両ファイルに重複）を削除し、Point のメソッドを直接呼び出しに統一
- `quad_to_cubic` の `prev_x`/`prev_y` (f32 ペア) を `Point` に統一
- `RenderTransform` 構造体を廃止し、`render_target` が `Matrix` を直接返すよう変更。3 モード共通の `render_matrix` ヘルパーを抽出
- `Outline::with_subpaths` を削除（`Outline::new` と等価）し、全呼び出し箇所を `Outline::new` に統一

## Test plan

- [x] `cargo test` — 全テスト通過
- [x] `mise run check` — fmt / clippy / ruff / ty すべてクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)