### PR TITLE
refactor: simplify Rust backend transform modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,11 +91,11 @@ fn randomize_subpath_start_points(
         ));
     }
     let outline = outline::Outline::decode(t, c);
-    let subpath_random_values = t
+    let subpath_random_values: Vec<f32> = t
         .iter()
-        .enumerate()
-        .filter_map(|(idx, &ty)| (ty == outline::ElementType::MoveTo as i64).then_some(r[idx]))
-        .collect::<Vec<_>>();
+        .zip(r)
+        .filter_map(|(&ty, &rv)| (ty == outline::ElementType::MoveTo as i64).then_some(rv))
+        .collect();
     Ok(
         transform::subpath::randomize_subpath_start_points(&outline, &subpath_random_values)
             .encode(),

--- a/src/outline/model.rs
+++ b/src/outline/model.rs
@@ -20,6 +20,10 @@ impl Point {
         self.lerp(other, 0.5)
     }
 
+    pub(crate) fn dot(self, other: Self) -> f32 {
+        self.x * other.x + self.y * other.y
+    }
+
     pub(crate) fn cross(self, other: Self) -> f32 {
         self.x * other.y - self.y * other.x
     }
@@ -28,7 +32,7 @@ impl Point {
         if !self.x.is_finite() || !self.y.is_finite() {
             return f32::INFINITY;
         }
-        (self.x * self.x + self.y * self.y).sqrt()
+        self.dot(self).sqrt()
     }
 }
 

--- a/src/transform/cubic_to_quad.rs
+++ b/src/transform/cubic_to_quad.rs
@@ -1,11 +1,8 @@
+use super::{Cubic, TOLERANCE, cubic_farthest_fit_inside, split_cubic_at};
 use crate::outline::{Outline, PathElement, Point, Subpath};
 
-// Absolute tolerance for quadratic approximation (normalized coords ≈ 1 font-unit in 1000 UPM).
-const TOLERANCE: f32 = 1e-3;
 // Keep this aligned with fonttools.cu2qu.MAX_N.
 const MAX_N: usize = 100;
-
-type Cubic = (Point, Point, Point, Point);
 
 pub(crate) enum CubicToQuadError {
     ApproximationFailed,
@@ -160,33 +157,4 @@ fn split_cubic_into_n(p0: Point, p1: Point, p2: Point, p3: Point, n: usize) -> V
     }
     result.push(current);
     result
-}
-
-fn split_cubic_at(p0: Point, p1: Point, p2: Point, p3: Point, t: f32) -> (Cubic, Cubic) {
-    let q0 = p0.lerp(p1, t);
-    let q1 = p1.lerp(p2, t);
-    let q2 = p2.lerp(p3, t);
-    let r0 = q0.lerp(q1, t);
-    let r1 = q1.lerp(q2, t);
-    let s = r0.lerp(r1, t);
-    ((p0, q0, r0, s), (s, r1, q2, p3))
-}
-
-fn cubic_farthest_fit_inside(p0: Point, p1: Point, p2: Point, p3: Point, tolerance: f32) -> bool {
-    if p2.norm() <= tolerance && p1.norm() <= tolerance {
-        return true;
-    }
-    let mid = Point::new(
-        (p0.x + 3.0 * (p1.x + p2.x) + p3.x) * 0.125,
-        (p0.y + 3.0 * (p1.y + p2.y) + p3.y) * 0.125,
-    );
-    if mid.norm() > tolerance {
-        return false;
-    }
-    let deriv3 = Point::new(
-        (p3.x + p2.x - p1.x - p0.x) * 0.125,
-        (p3.y + p2.y - p1.y - p0.y) * 0.125,
-    );
-    cubic_farthest_fit_inside(p0, p0.midpoint(p1), mid - deriv3, mid, tolerance)
-        && cubic_farthest_fit_inside(mid, mid + deriv3, p2.midpoint(p3), p3, tolerance)
 }

--- a/src/transform/cubic_to_quad.rs
+++ b/src/transform/cubic_to_quad.rs
@@ -22,7 +22,10 @@ pub(crate) fn cubic_to_quad(outline: &Outline) -> Result<Outline, CubicToQuadErr
                     end,
                 } => {
                     for (qcp, quad_end) in cubic_to_quads(prev, control0, control1, end)? {
-                        elements.push(PathElement::QuadTo { control: qcp, end: quad_end });
+                        elements.push(PathElement::QuadTo {
+                            control: qcp,
+                            end: quad_end,
+                        });
                     }
                     prev = end;
                 }

--- a/src/transform/cubic_to_quad.rs
+++ b/src/transform/cubic_to_quad.rs
@@ -21,11 +21,10 @@ pub(crate) fn cubic_to_quad(outline: &Outline) -> Result<Outline, CubicToQuadErr
                     control1,
                     end,
                 } => {
-                    let p3 = end;
-                    for (qcp, end) in cubic_to_quads(prev, control0, control1, p3)? {
-                        elements.push(PathElement::QuadTo { control: qcp, end });
+                    for (qcp, quad_end) in cubic_to_quads(prev, control0, control1, end)? {
+                        elements.push(PathElement::QuadTo { control: qcp, end: quad_end });
                     }
-                    prev = p3;
+                    prev = end;
                 }
                 other => {
                     elements.push(other);

--- a/src/transform/cubic_to_quad.rs
+++ b/src/transform/cubic_to_quad.rs
@@ -147,13 +147,8 @@ fn split_cubic_into_n(p0: Point, p1: Point, p2: Point, p3: Point, n: usize) -> V
     let mut result = Vec::with_capacity(n);
     let mut current = (p0, p1, p2, p3);
     for k in 0..n - 1 {
-        let (left, right) = split_cubic_at(
-            current.0,
-            current.1,
-            current.2,
-            current.3,
-            1.0 / (n - k) as f32,
-        );
+        let (p0, p1, p2, p3) = current;
+        let (left, right) = split_cubic_at(p0, p1, p2, p3, 1.0 / (n - k) as f32);
         result.push(left);
         current = right;
     }

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -26,29 +26,27 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
         let seg_start = result.last().map_or(start, |e: &PathElement| e.end());
 
         match element {
-            PathElement::CurveTo { .. } => {
-                let (element, len) = try_merge_run(
-                    seg_start,
-                    &elements,
-                    i,
-                    n,
-                    |e| matches!(e, PathElement::CurveTo { .. }),
-                    try_merge_cubics_n,
-                );
-                result.push(element);
-                result_starts.push(seg_start);
-                i += len;
-            }
-            PathElement::QuadTo { .. } => {
-                let (element, len) = try_merge_run(
-                    seg_start,
-                    &elements,
-                    i,
-                    n,
-                    |e| matches!(e, PathElement::QuadTo { .. }),
-                    try_merge_quads_n,
-                );
-                result.push(element);
+            PathElement::CurveTo { .. } | PathElement::QuadTo { .. } => {
+                let (merged, len) = if matches!(element, PathElement::CurveTo { .. }) {
+                    try_merge_run(
+                        seg_start,
+                        &elements,
+                        i,
+                        n,
+                        |e| matches!(e, PathElement::CurveTo { .. }),
+                        try_merge_cubics_n,
+                    )
+                } else {
+                    try_merge_run(
+                        seg_start,
+                        &elements,
+                        i,
+                        n,
+                        |e| matches!(e, PathElement::QuadTo { .. }),
+                        try_merge_quads_n,
+                    )
+                };
+                result.push(merged);
                 result_starts.push(seg_start);
                 i += len;
             }

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -37,24 +37,13 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
                     run_end += 1;
                 }
                 let run_len = run_end - i;
-                let mut merged = None;
-                for merge_len in (2..=run_len).rev() {
-                    if let Some(element) =
-                        try_merge_cubics_n(seg_start, &elements[i..i + merge_len])
-                    {
-                        merged = Some((element, merge_len));
-                        break;
-                    }
-                }
-                if let Some((element, len)) = merged {
-                    result.push(element);
-                    result_starts.push(seg_start);
-                    i += len;
-                } else {
-                    result.push(element);
-                    result_starts.push(seg_start);
-                    i += 1;
-                }
+                let merged = (2..=run_len).rev().find_map(|len| {
+                    try_merge_cubics_n(seg_start, &elements[i..i + len]).map(|e| (e, len))
+                });
+                let (element, len) = merged.unwrap_or((element, 1));
+                result.push(element);
+                result_starts.push(seg_start);
+                i += len;
             }
             PathElement::QuadTo { .. } => {
                 let mut run_end = i + 1;
@@ -62,23 +51,13 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
                     run_end += 1;
                 }
                 let run_len = run_end - i;
-                let mut merged = None;
-                for merge_len in (2..=run_len).rev() {
-                    if let Some(element) = try_merge_quads_n(seg_start, &elements[i..i + merge_len])
-                    {
-                        merged = Some((element, merge_len));
-                        break;
-                    }
-                }
-                if let Some((element, len)) = merged {
-                    result.push(element);
-                    result_starts.push(seg_start);
-                    i += len;
-                } else {
-                    result.push(element);
-                    result_starts.push(seg_start);
-                    i += 1;
-                }
+                let merged = (2..=run_len).rev().find_map(|len| {
+                    try_merge_quads_n(seg_start, &elements[i..i + len]).map(|e| (e, len))
+                });
+                let (element, len) = merged.unwrap_or((element, 1));
+                result.push(element);
+                result_starts.push(seg_start);
+                i += len;
             }
             PathElement::LineTo(end) => {
                 let merged = if let (Some(PathElement::LineTo(last_end)), Some(&last_start)) =
@@ -151,7 +130,7 @@ fn try_merge_quads_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
             if end_tan.cross(start_tan).abs() > TOLERANCE * len_end * len_start {
                 return None;
             }
-            if end_tan.x * start_tan.x + end_tan.y * start_tan.y < 0.0 {
+            if end_tan.dot(start_tan) < 0.0 {
                 return None;
             }
         }
@@ -204,26 +183,20 @@ fn split_quad_at_ts(p0: Point, p1: Point, p2: Point, ts: &[f32]) -> Vec<Quad> {
             return pieces;
         }
         let t_rel = (t - t_prev) / remaining;
-        let (lp0, lp1, lp2, rp0, rp1, rp2) =
-            split_quad_at_t(current.0, current.1, current.2, t_rel);
-        pieces.push((lp0, lp1, lp2));
-        current = (rp0, rp1, rp2);
+        let (left, right) = split_quad_at_t(current.0, current.1, current.2, t_rel);
+        pieces.push(left);
+        current = right;
         t_prev = t;
     }
     pieces.push(current);
     pieces
 }
 
-fn split_quad_at_t(
-    p0: Point,
-    p1: Point,
-    p2: Point,
-    t: f32,
-) -> (Point, Point, Point, Point, Point, Point) {
+fn split_quad_at_t(p0: Point, p1: Point, p2: Point, t: f32) -> (Quad, Quad) {
     let q1 = p0.lerp(p1, t);
     let q2 = p1.lerp(p2, t);
     let s = q1.lerp(q2, t);
-    (p0, q1, s, s, q2, p2)
+    ((p0, q1, s), (s, q2, p2))
 }
 
 // Attempt to merge n consecutive cubic segments into one.
@@ -261,7 +234,7 @@ fn try_merge_cubics_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
             if end_tan.cross(start_tan).abs() > TOLERANCE * len_end * len_start {
                 return None;
             }
-            if end_tan.x * start_tan.x + end_tan.y * start_tan.y < 0.0 {
+            if end_tan.dot(start_tan) < 0.0 {
                 return None; // anti-parallel (cusp)
             }
         }
@@ -350,30 +323,23 @@ fn split_cubic_at_ts(p0: Point, p1: Point, p2: Point, p3: Point, ts: &[f32]) -> 
             return pieces;
         }
         let t_rel = (t - t_prev) / remaining;
-        let (lp0, lp1, lp2, lp3, rp0, rp1, rp2, rp3) =
-            split_cubic_at_t(current.0, current.1, current.2, current.3, t_rel);
-        pieces.push((lp0, lp1, lp2, lp3));
-        current = (rp0, rp1, rp2, rp3);
+        let (left, right) = split_cubic_at_t(current.0, current.1, current.2, current.3, t_rel);
+        pieces.push(left);
+        current = right;
         t_prev = t;
     }
     pieces.push(current);
     pieces
 }
 
-fn split_cubic_at_t(
-    p0: Point,
-    p1: Point,
-    p2: Point,
-    p3: Point,
-    t: f32,
-) -> (Point, Point, Point, Point, Point, Point, Point, Point) {
+fn split_cubic_at_t(p0: Point, p1: Point, p2: Point, p3: Point, t: f32) -> (Cubic, Cubic) {
     let q1 = p0.lerp(p1, t);
     let q2 = p1.lerp(p2, t);
     let q3 = p2.lerp(p3, t);
     let r1 = q1.lerp(q2, t);
     let r2 = q2.lerp(q3, t);
     let s = r1.lerp(r2, t);
-    (p0, q1, r1, s, s, r2, q3, p3)
+    ((p0, q1, r1, s), (s, r2, q3, p3))
 }
 
 // Recursive check: does the cubic (as a displacement field relative to the origin)
@@ -404,19 +370,18 @@ fn cubic_farthest_fit_inside(p0: Point, p1: Point, p2: Point, p3: Point, toleran
 }
 
 fn can_merge_lines(start: Point, middle: Point, end: Point) -> bool {
-    let (dx1, dy1) = (middle.x - start.x, middle.y - start.y);
-    let (dx2, dy2) = (end.x - middle.x, end.y - middle.y);
+    let d1 = middle - start;
+    let d2 = end - middle;
 
-    let len1_sq = dx1 * dx1 + dy1 * dy1;
-    let len2_sq = dx2 * dx2 + dy2 * dy2;
+    let len1_sq = d1.dot(d1);
+    let len2_sq = d2.dot(d2);
 
     if len1_sq < 1e-12 || len2_sq < 1e-12 {
         return true;
     }
 
-    let total_dx = end.x - start.x;
-    let total_dy = end.y - start.y;
-    let total_len = total_dx.hypot(total_dy);
+    let total = end - start;
+    let total_len = total.x.hypot(total.y);
     if total_len < 1e-6 {
         return false;
     }
@@ -424,10 +389,9 @@ fn can_merge_lines(start: Point, middle: Point, end: Point) -> bool {
     // Measure the actual geometric deviation of the join from the merged line,
     // not just its angle. The rest of the module interprets TOLERANCE as an
     // absolute distance in normalized coordinates.
-    let distance = (dx1 * total_dy - dy1 * total_dx).abs() / total_len;
-    if distance > TOLERANCE {
+    if d1.cross(total).abs() / total_len > TOLERANCE {
         return false;
     }
 
-    dx1 * dx2 + dy1 * dy2 >= 0.0
+    d1.dot(d2) >= 0.0
 }

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -28,7 +28,10 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
         match element {
             PathElement::CurveTo { .. } => {
                 let (element, len) = try_merge_run(
-                    seg_start, &elements, i, n,
+                    seg_start,
+                    &elements,
+                    i,
+                    n,
                     |e| matches!(e, PathElement::CurveTo { .. }),
                     try_merge_cubics_n,
                 );
@@ -38,7 +41,10 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
             }
             PathElement::QuadTo { .. } => {
                 let (element, len) = try_merge_run(
-                    seg_start, &elements, i, n,
+                    seg_start,
+                    &elements,
+                    i,
+                    n,
                     |e| matches!(e, PathElement::QuadTo { .. }),
                     try_merge_quads_n,
                 );

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -23,35 +23,25 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
 
     while i < n {
         let element = elements[i];
-        let seg_start = result
-            .last()
-            .map_or(start, |element: &PathElement| element.end());
+        let seg_start = result.last().map_or(start, |e: &PathElement| e.end());
 
         match element {
             PathElement::CurveTo { .. } => {
-                let mut run_end = i + 1;
-                while run_end < n && matches!(elements[run_end], PathElement::CurveTo { .. }) {
-                    run_end += 1;
-                }
-                let run_len = run_end - i;
-                let merged = (2..=run_len).rev().find_map(|len| {
-                    try_merge_cubics_n(seg_start, &elements[i..i + len]).map(|e| (e, len))
-                });
-                let (element, len) = merged.unwrap_or((element, 1));
+                let (element, len) = try_merge_run(
+                    seg_start, &elements, i, n,
+                    |e| matches!(e, PathElement::CurveTo { .. }),
+                    try_merge_cubics_n,
+                );
                 result.push(element);
                 result_starts.push(seg_start);
                 i += len;
             }
             PathElement::QuadTo { .. } => {
-                let mut run_end = i + 1;
-                while run_end < n && matches!(elements[run_end], PathElement::QuadTo { .. }) {
-                    run_end += 1;
-                }
-                let run_len = run_end - i;
-                let merged = (2..=run_len).rev().find_map(|len| {
-                    try_merge_quads_n(seg_start, &elements[i..i + len]).map(|e| (e, len))
-                });
-                let (element, len) = merged.unwrap_or((element, 1));
+                let (element, len) = try_merge_run(
+                    seg_start, &elements, i, n,
+                    |e| matches!(e, PathElement::QuadTo { .. }),
+                    try_merge_quads_n,
+                );
                 result.push(element);
                 result_starts.push(seg_start);
                 i += len;
@@ -77,6 +67,25 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
     result
 }
 
+fn try_merge_run(
+    seg_start: Point,
+    elements: &[PathElement],
+    i: usize,
+    n: usize,
+    is_same: impl Fn(PathElement) -> bool,
+    try_merge: fn(Point, &[PathElement]) -> Option<PathElement>,
+) -> (PathElement, usize) {
+    let mut run_end = i + 1;
+    while run_end < n && is_same(elements[run_end]) {
+        run_end += 1;
+    }
+    let run_len = run_end - i;
+    (2..=run_len)
+        .rev()
+        .find_map(|len| try_merge(seg_start, &elements[i..i + len]).map(|e| (e, len)))
+        .unwrap_or((elements[i], 1))
+}
+
 fn quad_points(element: PathElement) -> (Point, Point) {
     match element {
         PathElement::QuadTo { control, end } => (control, end),
@@ -95,30 +104,26 @@ fn cubic_points(element: PathElement) -> (Point, Point, Point) {
     }
 }
 
-// Attempt to merge n consecutive quadratic segments into one.
-//
-// The split parameters can be recovered from adjacent tangent-length ratios in
-// the same way as cubics. A parent quadratic then has only one outer control
-// point to reconstruct and validate.
-fn try_merge_quads_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
-    let n = segs.len();
-    debug_assert!(n >= 2);
-
+// Reconstruct normalized split parameters from cumulative tangent-length ratios
+// at each junction. ratio_k = |start_tan_k| / |end_tan_{k-1}|; ts_unnorm
+// accumulates partial sums and the last entry (= total) is discarded.
+// Returns None if any junction tangent is degenerate or forms a cusp.
+fn compute_split_ts(
+    n: usize,
+    junction_tangents: impl Fn(usize) -> (Point, Point),
+) -> Option<Vec<f32>> {
     let mut prod_ratio = 1.0_f32;
     let mut sum_ratio = 1.0_f32;
     let mut ts_unnorm = vec![1.0_f32];
 
     for k in 1..n {
-        let (prev_h, prev_end) = quad_points(segs[k - 1]);
-        let (curr_h, _curr_end) = quad_points(segs[k]);
-
-        let end_tan = prev_end - prev_h;
-        let start_tan = curr_h - prev_end;
+        let (end_tan, start_tan) = junction_tangents(k);
         let len_end = end_tan.norm();
         let len_start = start_tan.norm();
         if len_end < 1e-10 {
             return None;
         }
+        // Tangents at the junction must be parallel and in the same direction.
         if len_start > 1e-10 {
             if end_tan.cross(start_tan).abs() > TOLERANCE * len_end * len_start {
                 return None;
@@ -127,23 +132,36 @@ fn try_merge_quads_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
                 return None;
             }
         }
-
         let ratio = len_start / len_end;
         prod_ratio *= ratio;
         sum_ratio += prod_ratio;
         ts_unnorm.push(sum_ratio);
     }
 
+    // ts has n-1 elements; ts[0] = t1 (first junction), ts[n-2] = t_{n-1} (last).
     ts_unnorm.pop();
-    let ts: Vec<f32> = ts_unnorm.iter().map(|&t| t / sum_ratio).collect();
+    Some(ts_unnorm.iter().map(|&t| t / sum_ratio).collect())
+}
+
+// Attempt to merge n consecutive quadratic segments into one.
+fn try_merge_quads_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
+    let n = segs.len();
+    debug_assert!(n >= 2);
+
+    let ts = compute_split_ts(n, |k| {
+        let (prev_h, prev_end) = quad_points(segs[k - 1]);
+        let (curr_h, _) = quad_points(segs[k]);
+        (prev_end - prev_h, curr_h - prev_end)
+    })?;
+
     let t1 = ts[0];
     if !(1e-6..=1.0 - 1e-6).contains(&t1) {
         return None;
     }
 
-    let (first_h, _first_end) = quad_points(segs[0]);
+    let (first_h, _) = quad_points(segs[0]);
     let p1 = p0.lerp(first_h, 1.0 / t1);
-    let (_last_h, p2) = quad_points(segs[n - 1]);
+    let (_, p2) = quad_points(segs[n - 1]);
 
     if !validate_quad_merge(p0, p1, p2, segs, &ts) {
         return None;
@@ -176,7 +194,8 @@ fn split_quad_at_ts(p0: Point, p1: Point, p2: Point, ts: &[f32]) -> Vec<Quad> {
             return pieces;
         }
         let t_rel = (t - t_prev) / remaining;
-        let (left, right) = split_quad_at_t(current.0, current.1, current.2, t_rel);
+        let (p0, p1, p2) = current;
+        let (left, right) = split_quad_at_t(p0, p1, p2, t_rel);
         pieces.push(left);
         current = right;
         t_prev = t;
@@ -201,46 +220,11 @@ fn try_merge_cubics_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
     let n = segs.len();
     debug_assert!(n >= 2);
 
-    // Compute cumulative tangent-length ratios at each junction.
-    // ratio_k = |start_tan_k| / |end_tan_{k-1}|
-    // ts_unnorm accumulates partial sums; the last entry is discarded (= total).
-    let mut prod_ratio = 1.0_f32;
-    let mut sum_ratio = 1.0_f32;
-    let mut ts_unnorm = vec![1.0_f32];
-
-    for k in 1..n {
-        let (_prev_h1, prev_h2, prev_end) = cubic_points(segs[k - 1]);
-        let (curr_h1, _curr_h2, _curr_end) = cubic_points(segs[k]);
-
-        let end_tan = prev_end - prev_h2;
-        let start_tan = curr_h1 - prev_end;
-
-        let len_end = end_tan.norm();
-        let len_start = start_tan.norm();
-
-        if len_end < 1e-10 {
-            return None;
-        }
-
-        // Tangents at the junction must be parallel and in the same direction.
-        if len_start > 1e-10 {
-            if end_tan.cross(start_tan).abs() > TOLERANCE * len_end * len_start {
-                return None;
-            }
-            if end_tan.dot(start_tan) < 0.0 {
-                return None; // anti-parallel (cusp)
-            }
-        }
-
-        let ratio = len_start / len_end;
-        prod_ratio *= ratio;
-        sum_ratio += prod_ratio;
-        ts_unnorm.push(sum_ratio);
-    }
-
-    // Normalize: ts has n-1 elements, ts[0] = t1 (first junction), ts[n-2] = t_{n-1} (last).
-    ts_unnorm.pop();
-    let ts: Vec<f32> = ts_unnorm.iter().map(|&t| t / sum_ratio).collect();
+    let ts = compute_split_ts(n, |k| {
+        let (_, prev_h2, prev_end) = cubic_points(segs[k - 1]);
+        let (curr_h1, _, _) = cubic_points(segs[k]);
+        (prev_end - prev_h2, curr_h1 - prev_end)
+    })?;
 
     let t1 = ts[0];
     let t_last = *ts.last().unwrap();
@@ -249,8 +233,8 @@ fn try_merge_cubics_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
         return None;
     }
 
-    let (first_h1, _first_h2, _first_end) = cubic_points(segs[0]);
-    let (_last_h1, last_h2, p3) = cubic_points(segs[n - 1]);
+    let (first_h1, _, _) = cubic_points(segs[0]);
+    let (_, last_h2, p3) = cubic_points(segs[n - 1]);
 
     // Recover outer control points from the split relationship:
     //   first_h1 = lerp(P0, P1, t1)  →  P1 = P0 + (first_h1 − P0) / t1
@@ -316,7 +300,8 @@ fn split_cubic_at_ts(p0: Point, p1: Point, p2: Point, p3: Point, ts: &[f32]) -> 
             return pieces;
         }
         let t_rel = (t - t_prev) / remaining;
-        let (left, right) = split_cubic_at(current.0, current.1, current.2, current.3, t_rel);
+        let (p0, p1, p2, p3) = current;
+        let (left, right) = split_cubic_at(p0, p1, p2, p3, t_rel);
         pieces.push(left);
         current = right;
         t_prev = t;

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -164,8 +164,8 @@ fn try_merge_quads_n(p0: Point, segs: &[PathElement]) -> Option<PathElement> {
 
 fn validate_quad_merge(p0: Point, p1: Point, p2: Point, segs: &[PathElement], ts: &[f32]) -> bool {
     let pieces = split_quad_at_ts(p0, p1, p2, ts);
-    for (k, (_rp0, rp1, rp2)) in pieces.iter().enumerate() {
-        let (orig_h, orig_end) = quad_points(segs[k]);
+    for ((_rp0, rp1, rp2), seg) in pieces.iter().zip(segs) {
+        let (orig_h, orig_end) = quad_points(*seg);
         if (*rp1 - orig_h).norm() > TOLERANCE || (*rp2 - orig_end).norm() > TOLERANCE {
             return false;
         }
@@ -287,8 +287,8 @@ fn validate_cubic_merge(
     let pieces = split_cubic_at_ts(p0, p1, p2, p3, ts);
     let mut prev_end = p0;
 
-    for (k, (rp0, rp1, rp2, rp3)) in pieces.iter().enumerate() {
-        let (orig_h1, orig_h2, orig_end) = cubic_points(segs[k]);
+    for ((rp0, rp1, rp2, rp3), seg) in pieces.iter().zip(segs) {
+        let (orig_h1, orig_h2, orig_end) = cubic_points(*seg);
 
         if (*rp3 - orig_end).norm() > TOLERANCE {
             return false;
@@ -381,7 +381,7 @@ fn can_merge_lines(start: Point, middle: Point, end: Point) -> bool {
     }
 
     let total = end - start;
-    let total_len = total.x.hypot(total.y);
+    let total_len = total.norm();
     if total_len < 1e-6 {
         return false;
     }

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -1,9 +1,6 @@
+use super::{Cubic, TOLERANCE, cubic_farthest_fit_inside, split_cubic_at};
 use crate::outline::{Outline, PathElement, Point, Subpath};
 
-// Absolute tolerance for merge validation (normalized coords ≈ 1 font-unit in 1000 UPM).
-const TOLERANCE: f32 = 1e-3;
-
-type Cubic = (Point, Point, Point, Point);
 type Quad = (Point, Point, Point);
 
 pub(crate) fn merge_curves(outline: &Outline) -> Outline {
@@ -60,23 +57,19 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
                 i += len;
             }
             PathElement::LineTo(end) => {
-                let merged = if let (Some(PathElement::LineTo(last_end)), Some(&last_start)) =
+                if let (Some(PathElement::LineTo(last_end)), Some(&last_start)) =
                     (result.last().copied(), result_starts.last())
+                    && can_merge_lines(last_start, last_end, end)
                 {
-                    can_merge_lines(last_start, last_end, end).then_some(PathElement::LineTo(end))
-                } else {
-                    None
-                };
-                if let Some(element) = merged {
-                    let saved_start = *result_starts.last().unwrap();
                     result.pop();
                     result_starts.pop();
-                    result.push(element);
-                    result_starts.push(saved_start);
-                } else {
-                    result.push(element);
-                    result_starts.push(seg_start);
+                    result.push(PathElement::LineTo(end));
+                    result_starts.push(last_start);
+                    i += 1;
+                    continue;
                 }
+                result.push(element);
+                result_starts.push(seg_start);
                 i += 1;
             }
         }
@@ -323,50 +316,13 @@ fn split_cubic_at_ts(p0: Point, p1: Point, p2: Point, p3: Point, ts: &[f32]) -> 
             return pieces;
         }
         let t_rel = (t - t_prev) / remaining;
-        let (left, right) = split_cubic_at_t(current.0, current.1, current.2, current.3, t_rel);
+        let (left, right) = split_cubic_at(current.0, current.1, current.2, current.3, t_rel);
         pieces.push(left);
         current = right;
         t_prev = t;
     }
     pieces.push(current);
     pieces
-}
-
-fn split_cubic_at_t(p0: Point, p1: Point, p2: Point, p3: Point, t: f32) -> (Cubic, Cubic) {
-    let q1 = p0.lerp(p1, t);
-    let q2 = p1.lerp(p2, t);
-    let q3 = p2.lerp(p3, t);
-    let r1 = q1.lerp(q2, t);
-    let r2 = q2.lerp(q3, t);
-    let s = r1.lerp(r2, t);
-    ((p0, q1, r1, s), (s, r2, q3, p3))
-}
-
-// Recursive check: does the cubic (as a displacement field relative to the origin)
-// lie entirely within `tolerance` of the origin?  Ported from fonttools qu2cu.
-fn cubic_farthest_fit_inside(p0: Point, p1: Point, p2: Point, p3: Point, tolerance: f32) -> bool {
-    if p2.norm() <= tolerance && p1.norm() <= tolerance {
-        return true;
-    }
-
-    let mid = Point::new(
-        (p0.x + 3.0 * (p1.x + p2.x) + p3.x) * 0.125,
-        (p0.y + 3.0 * (p1.y + p2.y) + p3.y) * 0.125,
-    );
-    if mid.norm() > tolerance {
-        return false;
-    }
-
-    let deriv3 = Point::new(
-        (p3.x + p2.x - p1.x - p0.x) * 0.125,
-        (p3.y + p2.y - p1.y - p0.y) * 0.125,
-    );
-
-    let p01 = p0.lerp(p1, 0.5);
-    let p23 = p2.lerp(p3, 0.5);
-
-    cubic_farthest_fit_inside(p0, p01, mid - deriv3, mid, tolerance)
-        && cubic_farthest_fit_inside(mid, mid + deriv3, p23, p3, tolerance)
 }
 
 fn can_merge_lines(start: Point, middle: Point, end: Point) -> bool {

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -1,7 +1,7 @@
 use skia_safe::{Path, PathBuilder, PathFillType};
 
 use crate::bounds::{Bounds, BoundsPen};
-use crate::outline::{Outline, PathElement};
+use crate::outline::{Outline, PathElement, Point};
 
 pub(crate) mod cubic_to_quad;
 pub(crate) mod merge_curves;
@@ -50,4 +50,46 @@ pub(crate) fn build_skia_path(
         }
     }
     (!builder.is_empty()).then(|| (builder.detach(), bounds.and_then(BoundsPen::finish)))
+}
+
+// Absolute tolerance for curve operations (normalized coords ≈ 1 font-unit in 1000 UPM).
+pub(super) const TOLERANCE: f32 = 1e-3;
+
+pub(super) type Cubic = (Point, Point, Point, Point);
+
+pub(super) fn split_cubic_at(p0: Point, p1: Point, p2: Point, p3: Point, t: f32) -> (Cubic, Cubic) {
+    let q0 = p0.lerp(p1, t);
+    let q1 = p1.lerp(p2, t);
+    let q2 = p2.lerp(p3, t);
+    let r0 = q0.lerp(q1, t);
+    let r1 = q1.lerp(q2, t);
+    let s = r0.lerp(r1, t);
+    ((p0, q0, r0, s), (s, r1, q2, p3))
+}
+
+// Recursive check: does the cubic (as a displacement field relative to the origin)
+// lie entirely within `tolerance` of the origin? Ported from fonttools qu2cu.
+pub(super) fn cubic_farthest_fit_inside(
+    p0: Point,
+    p1: Point,
+    p2: Point,
+    p3: Point,
+    tolerance: f32,
+) -> bool {
+    if p2.norm() <= tolerance && p1.norm() <= tolerance {
+        return true;
+    }
+    let mid = Point::new(
+        (p0.x + 3.0 * (p1.x + p2.x) + p3.x) * 0.125,
+        (p0.y + 3.0 * (p1.y + p2.y) + p3.y) * 0.125,
+    );
+    if mid.norm() > tolerance {
+        return false;
+    }
+    let deriv3 = Point::new(
+        (p3.x + p2.x - p1.x - p0.x) * 0.125,
+        (p3.y + p2.y - p1.y - p0.y) * 0.125,
+    );
+    cubic_farthest_fit_inside(p0, p0.midpoint(p1), mid - deriv3, mid, tolerance)
+        && cubic_farthest_fit_inside(mid, mid + deriv3, p2.midpoint(p3), p3, tolerance)
 }


### PR DESCRIPTION
## Summary

- Extract shared `split_cubic_at` and `cubic_farthest_fit_inside` helpers into `transform/mod.rs` to eliminate duplication across `cubic_to_quad` and `merge_curves`
- Add `Point::dot` method and use typed `Cubic` tuple alias for clearer split return types
- Consolidate symmetric `CurveTo`/`QuadTo` arms in `merge_subpath_elements` into a single arm
- Destructure `current` tuple in `split_cubic_into_n` loop instead of `.0/.1/.2/.3` indexing
- Use `find_map` for merge candidate search in `try_merge_run`

## Test plan

- [x] `mise run test` passes (195 passed, 4 skipped)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)