### PR TITLE
refactor: reduce verbosity in transform modules

### DIFF
--- a/src/transform/cubic_to_quad.rs
+++ b/src/transform/cubic_to_quad.rs
@@ -147,13 +147,8 @@ fn split_cubic_into_n(p0: Point, p1: Point, p2: Point, p3: Point, n: usize) -> V
     let mut result = Vec::with_capacity(n);
     let mut current = (p0, p1, p2, p3);
     for k in 0..n - 1 {
-        let (left, right) = split_cubic_at(
-            current.0,
-            current.1,
-            current.2,
-            current.3,
-            1.0 / (n - k) as f32,
-        );
+        let (p0, p1, p2, p3) = current;
+        let (left, right) = split_cubic_at(p0, p1, p2, p3, 1.0 / (n - k) as f32);
         result.push(left);
         current = right;
     }

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -26,29 +26,27 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
         let seg_start = result.last().map_or(start, |e: &PathElement| e.end());
 
         match element {
-            PathElement::CurveTo { .. } => {
-                let (element, len) = try_merge_run(
-                    seg_start,
-                    &elements,
-                    i,
-                    n,
-                    |e| matches!(e, PathElement::CurveTo { .. }),
-                    try_merge_cubics_n,
-                );
-                result.push(element);
-                result_starts.push(seg_start);
-                i += len;
-            }
-            PathElement::QuadTo { .. } => {
-                let (element, len) = try_merge_run(
-                    seg_start,
-                    &elements,
-                    i,
-                    n,
-                    |e| matches!(e, PathElement::QuadTo { .. }),
-                    try_merge_quads_n,
-                );
-                result.push(element);
+            PathElement::CurveTo { .. } | PathElement::QuadTo { .. } => {
+                let (merged, len) = if matches!(element, PathElement::CurveTo { .. }) {
+                    try_merge_run(
+                        seg_start,
+                        &elements,
+                        i,
+                        n,
+                        |e| matches!(e, PathElement::CurveTo { .. }),
+                        try_merge_cubics_n,
+                    )
+                } else {
+                    try_merge_run(
+                        seg_start,
+                        &elements,
+                        i,
+                        n,
+                        |e| matches!(e, PathElement::QuadTo { .. }),
+                        try_merge_quads_n,
+                    )
+                };
+                result.push(merged);
                 result_starts.push(seg_start);
                 i += len;
             }


### PR DESCRIPTION
## Summary

- `merge_subpath_elements`: 構造が同一だった `CurveTo`/`QuadTo` の 2 アームを 1 アームに統合し、どちらのマージ関数を呼ぶかを `if` で分岐
- `split_cubic_into_n`: ループ内の `current.0/.1/.2/.3` アクセスをデストラクチャ（`let (p0, p1, p2, p3) = current`）に変更し、`split_cubic_at_ts` と同じパターンに統一

## Test plan

- [x] `mise run test` 195 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)