### PR TITLE
simplify Rust backend: apply idiomatic patterns throughout

### DIFF
--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -86,11 +86,9 @@ impl BoundsPen {
     }
 
     fn include(&mut self, point: Point) {
-        if let Some(bounds) = &mut self.bounds {
-            bounds.include(point);
-        } else {
-            self.bounds = Some(Bounds::new(point));
-        }
+        self.bounds
+            .get_or_insert_with(|| Bounds::new(point))
+            .include(point);
     }
 
     fn include_quad(&mut self, start: Point, control: Point, end: Point) {
@@ -111,15 +109,9 @@ impl BoundsPen {
 
     fn include_cubic(&mut self, start: Point, control0: Point, control1: Point, end: Point) {
         self.include(end);
-        for t in cubic_extrema(start.x, control0.x, control1.x, end.x)
-            .into_iter()
-            .flatten()
-            .chain(
-                cubic_extrema(start.y, control0.y, control1.y, end.y)
-                    .into_iter()
-                    .flatten(),
-            )
-        {
+        let x_ts = cubic_extrema(start.x, control0.x, control1.x, end.x);
+        let y_ts = cubic_extrema(start.y, control0.y, control1.y, end.y);
+        for t in x_ts.into_iter().chain(y_ts).flatten() {
             self.include(Point::new(
                 cubic_at(start.x, control0.x, control1.x, end.x, t),
                 cubic_at(start.y, control0.y, control1.y, end.y, t),

--- a/src/dataset/entry.rs
+++ b/src/dataset/entry.rs
@@ -11,8 +11,6 @@ use super::{
 };
 use crate::error::{py_err, py_index_err};
 
-pub(super) type GlyphCompleteResult = GlyphItemData;
-
 pub(super) struct GlyphIndex {
     codepoints: Vec<u32>,
     glyph_ids: Vec<GlyphId>,
@@ -38,8 +36,7 @@ impl FontEntry {
             .map(|(face_index, face)| {
                 let font = face.map_err(|err| {
                     py_err(format!(
-                        "failed to parse '{path}' (face {face_index}): {err}",
-                        face_index = face_index
+                        "failed to parse '{path}' (face {face_index}): {err}"
                     ))
                 })?;
                 Self::from_face(path, face_index as u32, Arc::clone(&mapped), &font, filter)
@@ -58,7 +55,7 @@ impl FontEntry {
         &self,
         codepoint: u32,
         instance_index: Option<usize>,
-    ) -> PyResult<GlyphCompleteResult> {
+    ) -> PyResult<GlyphItemData> {
         let glyph_idx = self.lookup_glyph_index(codepoint)?;
         let glyph_id = self.index.glyph_ids[glyph_idx];
 
@@ -150,13 +147,12 @@ impl FontEntry {
             named_instances
                 .iter()
                 .map(|inst| {
-                    let user_coords: Vec<f32> = inst.user_coords().collect();
                     debug_assert_eq!(
                         axis_tags.len(),
-                        user_coords.len(),
+                        inst.user_coords().count(),
                         "font '{base_path}' (face {face_index}) reported mismatched axis metadata",
                     );
-                    axis_tags.iter().cloned().zip(user_coords).collect()
+                    axis_tags.iter().cloned().zip(inst.user_coords()).collect()
                 })
                 .collect()
         };

--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -24,35 +24,21 @@ pub(super) fn load_entries_and_index(
     let mut all_cps = Vec::new();
 
     for path in files {
-        let faces = FontEntry::load_faces(&path, filter)?;
-        for entry in faces
+        for entry in FontEntry::load_faces(&path, filter)?
             .into_iter()
-            .filter(|entry| entry.codepoint_count() > 0)
+            .filter(|e| e.codepoint_count() > 0)
         {
             all_cps.extend(entry.codepoints().iter().copied());
             entries.push(entry);
         }
     }
 
-    let sample_offsets = std::iter::once(0)
-        .chain(
-            entries
-                .iter()
-                .map(|entry| entry.codepoint_count() * entry.instance_count()),
-        )
-        .scan(0usize, |total, delta| {
-            *total += delta;
-            Some(*total)
-        })
-        .collect();
-
-    let inst_offsets = std::iter::once(0)
-        .chain(entries.iter().map(FontEntry::instance_count))
-        .scan(0usize, |total, delta| {
-            *total += delta;
-            Some(*total)
-        })
-        .collect();
+    let sample_offsets = cumulative_sums(
+        entries
+            .iter()
+            .map(|e| e.codepoint_count() * e.instance_count()),
+    );
+    let inst_offsets = cumulative_sums(entries.iter().map(FontEntry::instance_count));
 
     let mut content_classes = all_cps;
     content_classes.sort_unstable();
@@ -65,4 +51,14 @@ pub(super) fn load_entries_and_index(
     };
 
     Ok((entries, index))
+}
+
+fn cumulative_sums(deltas: impl Iterator<Item = usize>) -> Vec<usize> {
+    std::iter::once(0)
+        .chain(deltas)
+        .scan(0usize, |acc, d| {
+            *acc += d;
+            Some(*acc)
+        })
+        .collect()
 }

--- a/src/dataset/io.rs
+++ b/src/dataset/io.rs
@@ -57,9 +57,12 @@ fn is_vcs_metadata_dir(entry: &ignore::DirEntry) -> bool {
 fn has_font_extension(path: &Path) -> bool {
     path.extension()
         .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase())
-        .map(|ext| matches!(ext.as_str(), "ttf" | "otf" | "ttc" | "otc"))
-        .unwrap_or(false)
+        .is_some_and(|ext| {
+            matches!(
+                ext.to_ascii_lowercase().as_str(),
+                "ttf" | "otf" | "ttc" | "otc"
+            )
+        })
 }
 
 pub(super) fn map_font(path: &str) -> PyResult<Mmap> {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -103,11 +103,10 @@ impl GlyphDataset {
 
     #[getter]
     pub fn style_axes(&self) -> Vec<Vec<(String, f32)>> {
-        let mut axes = Vec::new();
-        for entry in self.entries.iter() {
-            axes.extend(entry.style_axes().iter().cloned());
-        }
-        axes
+        self.entries
+            .iter()
+            .flat_map(|e| e.style_axes().iter().cloned())
+            .collect()
     }
 
     pub fn item(&self, py: Python<'_>, idx: usize) -> PyResult<GlyphItem> {
@@ -133,10 +132,6 @@ impl GlyphDataset {
             glyph_name,
         ) = self.entries[font_idx].glyph_complete(codepoint, inst_idx)?;
 
-        let types_arr = types.into_pyarray(py).unbind();
-
-        let coords_arr = coords.into_pyarray(py).unbind();
-
         let metrics: Vec<f32> = vec![
             adv_w,
             lsb,
@@ -152,16 +147,14 @@ impl GlyphDataset {
             avg_width,
             italic_angle,
             upem as f32,
-            if is_monospace { 1.0_f32 } else { 0.0_f32 },
+            f32::from(is_monospace),
         ];
-        let metrics_arr = metrics.into_pyarray(py).unbind();
-
         Ok(GlyphItem {
-            types: types_arr,
-            coords: coords_arr,
+            types: types.into_pyarray(py).unbind(),
+            coords: coords.into_pyarray(py).unbind(),
             style_idx,
             content_idx,
-            metrics: metrics_arr,
+            metrics: metrics.into_pyarray(py).unbind(),
             glyph_name,
         })
     }
@@ -178,8 +171,7 @@ impl GlyphDataset {
                 let style_idx = inst_offset + inst_idx;
                 for &cp in entry.codepoints() {
                     let content_idx = self.index.content_index(cp)?;
-                    pairs.push(style_idx as i64);
-                    pairs.push(content_idx as i64);
+                    pairs.extend([style_idx as i64, content_idx as i64]);
                 }
             }
         }
@@ -194,31 +186,21 @@ impl GlyphDataset {
             let path = entry.path().to_owned();
             let face_idx = entry.face_index();
             let family_name = entry.family_name();
-
-            if entry.is_variable() {
-                let instance_names = entry.named_instance_names();
-                if instance_names.is_empty() {
-                    let display_name = if let Some(subfamily) = entry.subfamily_name() {
-                        format!("{family_name} {subfamily}")
-                    } else {
-                        family_name
+            let instance_names = entry.named_instance_names();
+            if !instance_names.is_empty() {
+                for (inst_idx, name_opt) in instance_names.iter().enumerate() {
+                    let display_name = match name_opt.as_deref().filter(|s| !s.is_empty()) {
+                        Some(name) => format!("{family_name} {name}"),
+                        None => family_name.clone(),
                     };
-                    rows.push((display_name, path, face_idx, None));
-                } else {
-                    for (inst_idx, name_opt) in instance_names.iter().enumerate() {
-                        let instance_name = name_opt.as_deref().unwrap_or("");
-                        let display_name = if instance_name.is_empty() {
-                            family_name.clone()
-                        } else {
-                            format!("{family_name} {instance_name}")
-                        };
-                        rows.push((display_name, path.clone(), face_idx, Some(inst_idx)));
-                    }
+                    rows.push((display_name, path.clone(), face_idx, Some(inst_idx)));
                 }
-            } else if let Some(subfamily) = entry.subfamily_name() {
-                rows.push((format!("{family_name} {subfamily}"), path, face_idx, None));
             } else {
-                rows.push((family_name, path, face_idx, None));
+                let display_name = match entry.subfamily_name() {
+                    Some(sub) => format!("{family_name} {sub}"),
+                    None => family_name,
+                };
+                rows.push((display_name, path, face_idx, None));
             }
         }
         rows
@@ -235,7 +217,7 @@ impl GlyphDataset {
         let font_idx = self
             .index
             .sample_offsets
-            .partition_point(|offset| *offset <= idx)
+            .partition_point(|&offset| offset <= idx)
             - 1;
 
         let entry = &self.entries[font_idx];

--- a/src/dataset/reader.rs
+++ b/src/dataset/reader.rs
@@ -15,6 +15,8 @@ use crate::{
     outline,
 };
 
+use skrifa::raw::types::NameId;
+
 pub(super) type GlyphItemData = (
     Vec<i64>,
     Vec<f32>,
@@ -77,6 +79,7 @@ impl GlyphReader {
 
             let location_ref = self.location_ref(locations, instance_index)?;
             let inv_upem = 1.0 / units_per_em;
+            let scale = |v: Option<f32>| v.map(|v| v * inv_upem).unwrap_or(f32::NAN);
 
             let outline = outline::extract_glyph_outline(
                 &glyph,
@@ -86,31 +89,21 @@ impl GlyphReader {
             .map_err(|err| py_err(format!("failed to draw glyph: {err}")))?;
 
             let glyph_metrics = font.glyph_metrics(Size::unscaled(), location_ref);
-            let advance_width = glyph_metrics
-                .advance_width(glyph_id)
-                .map(|v| v * inv_upem)
-                .unwrap_or(f32::NAN);
-            let lsb = glyph_metrics
-                .left_side_bearing(glyph_id)
-                .map(|v| v * inv_upem)
-                .unwrap_or(f32::NAN);
+            let advance_width = scale(glyph_metrics.advance_width(glyph_id));
+            let lsb = scale(glyph_metrics.left_side_bearing(glyph_id));
+            let nan4 = (f32::NAN, f32::NAN, f32::NAN, f32::NAN);
             let (x_min, y_min, x_max, y_max) = if metrics_bounds_are_outline_based(&font) {
                 bounds::bounds_from_outline(&outline)
-                    .map_or((f32::NAN, f32::NAN, f32::NAN, f32::NAN), |bb| {
-                        (bb.x_min, bb.y_min, bb.x_max, bb.y_max)
-                    })
+                    .map_or(nan4, |bb| (bb.x_min, bb.y_min, bb.x_max, bb.y_max))
             } else {
-                glyph_metrics.bounds(glyph_id).map_or(
-                    (f32::NAN, f32::NAN, f32::NAN, f32::NAN),
-                    |bb| {
-                        (
-                            bb.x_min * inv_upem,
-                            bb.y_min * inv_upem,
-                            bb.x_max * inv_upem,
-                            bb.y_max * inv_upem,
-                        )
-                    },
-                )
+                glyph_metrics.bounds(glyph_id).map_or(nan4, |bb| {
+                    (
+                        bb.x_min * inv_upem,
+                        bb.y_min * inv_upem,
+                        bb.x_max * inv_upem,
+                        bb.y_max * inv_upem,
+                    )
+                })
             };
 
             let m = font.metrics(Size::unscaled(), location_ref);
@@ -136,9 +129,9 @@ impl GlyphReader {
                 m.ascent * inv_upem,
                 m.descent * inv_upem,
                 m.leading * inv_upem,
-                m.cap_height.map(|v| v * inv_upem).unwrap_or(f32::NAN),
-                m.x_height.map(|v| v * inv_upem).unwrap_or(f32::NAN),
-                m.average_width.map(|v| v * inv_upem).unwrap_or(f32::NAN),
+                scale(m.cap_height),
+                scale(m.x_height),
+                scale(m.average_width),
                 m.is_monospace,
                 m.italic_angle,
                 glyph_name,
@@ -152,8 +145,7 @@ impl GlyphReader {
                 .named_instances()
                 .iter()
                 .map(|inst| {
-                    let name_id = inst.subfamily_name_id();
-                    font.localized_strings(name_id)
+                    font.localized_strings(inst.subfamily_name_id())
                         .english_or_first()
                         .map(|s| s.to_string())
                 })
@@ -164,16 +156,10 @@ impl GlyphReader {
 
     pub(super) fn family_name(&self) -> String {
         self.with_font_ref(|font| {
-            Ok([
-                skrifa::raw::types::NameId::TYPOGRAPHIC_FAMILY_NAME,
-                skrifa::raw::types::NameId::FAMILY_NAME,
-            ]
-            .into_iter()
-            .find_map(|id| {
-                font.localized_strings(id)
-                    .english_or_first()
-                    .map(|s| s.to_string())
-            })
+            Ok(localized_name(
+                &font,
+                [NameId::TYPOGRAPHIC_FAMILY_NAME, NameId::FAMILY_NAME],
+            )
             .unwrap_or_default())
         })
         .unwrap_or_default()
@@ -181,16 +167,10 @@ impl GlyphReader {
 
     pub(super) fn subfamily_name(&self) -> Option<String> {
         self.with_font_ref(|font| {
-            Ok([
-                skrifa::raw::types::NameId::TYPOGRAPHIC_SUBFAMILY_NAME,
-                skrifa::raw::types::NameId::SUBFAMILY_NAME,
-            ]
-            .into_iter()
-            .find_map(|id| {
-                font.localized_strings(id)
-                    .english_or_first()
-                    .map(|s| s.to_string())
-            }))
+            Ok(localized_name(
+                &font,
+                [NameId::TYPOGRAPHIC_SUBFAMILY_NAME, NameId::SUBFAMILY_NAME],
+            ))
         })
         .ok()
         .flatten()
@@ -211,18 +191,26 @@ impl GlyphReader {
         locations: &'a [Location],
         index: Option<usize>,
     ) -> PyResult<LocationRef<'a>> {
-        if let Some(idx) = index {
-            let location = locations.get(idx).ok_or_else(|| {
-                py_index_err(format!(
-                    "instance index {idx} out of range for '{}'",
-                    self.path
-                ))
-            })?;
-            Ok(LocationRef::from(location))
-        } else {
-            Ok(LocationRef::default())
-        }
+        index.map_or(Ok(LocationRef::default()), |idx| {
+            locations
+                .get(idx)
+                .ok_or_else(|| {
+                    py_index_err(format!(
+                        "instance index {idx} out of range for '{}'",
+                        self.path
+                    ))
+                })
+                .map(LocationRef::from)
+        })
     }
+}
+
+fn localized_name(font: &skrifa::FontRef<'_>, ids: [NameId; 2]) -> Option<String> {
+    ids.into_iter().find_map(|id| {
+        font.localized_strings(id)
+            .english_or_first()
+            .map(|s| s.to_string())
+    })
 }
 
 fn metrics_bounds_are_outline_based(font: &skrifa::FontRef<'_>) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,6 @@
 use pyo3::prelude::*;
 
 pub fn py_err(msg: impl Into<String>) -> PyErr {
-    py_value_err(msg)
-}
-
-pub fn py_value_err(msg: impl Into<String>) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyValueError, _>(msg.into())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,12 +42,10 @@ fn cubic_to_quad(
     let outline = outline::Outline::decode(t, c);
     transform::cubic_to_quad::cubic_to_quad(&outline)
         .map(|outline| outline.encode())
-        .map_err(|err| match err {
-            transform::cubic_to_quad::CubicToQuadError::ApproximationFailed => {
-                pyo3::exceptions::PyValueError::new_err(
-                    "cubic_to_quad could not approximate a curve within MAX_N segments",
-                )
-            }
+        .map_err(|_| {
+            pyo3::exceptions::PyValueError::new_err(
+                "cubic_to_quad could not approximate a curve within MAX_N segments",
+            )
         })
 }
 
@@ -165,14 +163,9 @@ fn render_bitmap(
     let c = coords.as_slice()?;
     ensure_flat_coords_len(t.len(), c.len())?;
     let outline = outline::Outline::decode(t, c);
-    let rendered =
-        transform::render_bitmap::render_bitmap(&outline, size, mode).map_err(|err| match err {
-            transform::render_bitmap::RenderBitmapError::BboxTooLarge => {
-                pyo3::exceptions::PyValueError::new_err(
-                    "bbox output dimensions must be between 1 and 4096",
-                )
-            }
-        })?;
+    let rendered = transform::render_bitmap::render_bitmap(&outline, size, mode).map_err(|_| {
+        pyo3::exceptions::PyValueError::new_err("bbox output dimensions must be between 1 and 4096")
+    })?;
     Ok((
         rendered.data.into_pyarray(py).unbind(),
         rendered.width,

--- a/src/transform/cubic_to_quad.rs
+++ b/src/transform/cubic_to_quad.rs
@@ -21,12 +21,11 @@ pub(crate) fn cubic_to_quad(outline: &Outline) -> Result<Outline, CubicToQuadErr
                     control1,
                     end,
                 } => {
-                    for (qcp, quad_end) in cubic_to_quads(prev, control0, control1, end)? {
-                        elements.push(PathElement::QuadTo {
-                            control: qcp,
-                            end: quad_end,
-                        });
-                    }
+                    elements.extend(
+                        cubic_to_quads(prev, control0, control1, end)?
+                            .into_iter()
+                            .map(|(control, end)| PathElement::QuadTo { control, end }),
+                    );
                     prev = end;
                 }
                 other => {
@@ -49,21 +48,22 @@ fn cubic_to_quads(
     p2: Point,
     p3: Point,
 ) -> Result<Vec<(Point, Point)>, CubicToQuadError> {
-    for n in 1..=MAX_N {
-        if let Some(spline) = cubic_approx_spline(p0, p1, p2, p3, n) {
-            let mut out = Vec::with_capacity(n);
-            for i in 0..n {
-                let end = if i + 1 == n {
-                    p3
-                } else {
-                    spline[i + 1].midpoint(spline[i + 2])
-                };
-                out.push((spline[i + 1], end));
-            }
-            return Ok(out);
-        }
-    }
-    Err(CubicToQuadError::ApproximationFailed)
+    (1..=MAX_N)
+        .find_map(|n| {
+            cubic_approx_spline(p0, p1, p2, p3, n).map(|spline| {
+                (0..n)
+                    .map(|i| {
+                        let end = if i + 1 < n {
+                            spline[i + 1].midpoint(spline[i + 2])
+                        } else {
+                            p3
+                        };
+                        (spline[i + 1], end)
+                    })
+                    .collect()
+            })
+        })
+        .ok_or(CubicToQuadError::ApproximationFailed)
 }
 
 fn cubic_approx_spline(p0: Point, p1: Point, p2: Point, p3: Point, n: usize) -> Option<Vec<Point>> {

--- a/src/transform/merge_curves.rs
+++ b/src/transform/merge_curves.rs
@@ -8,14 +8,14 @@ pub(crate) fn merge_curves(outline: &Outline) -> Outline {
         .subpaths()
         .iter()
         .map(|subpath| {
-            let elements = merge_subpath_elements(subpath.start(), subpath.elements().to_vec());
+            let elements = merge_subpath_elements(subpath.start(), subpath.elements());
             Subpath::new(subpath.start(), elements, subpath.is_closed())
         })
         .collect();
     Outline::new(subpaths)
 }
 
-fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathElement> {
+fn merge_subpath_elements(start: Point, elements: &[PathElement]) -> Vec<PathElement> {
     let n = elements.len();
     let mut result = Vec::with_capacity(n);
     let mut result_starts = Vec::with_capacity(n);
@@ -30,18 +30,16 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
                 let (merged, len) = if matches!(element, PathElement::CurveTo { .. }) {
                     try_merge_run(
                         seg_start,
-                        &elements,
+                        elements,
                         i,
-                        n,
                         |e| matches!(e, PathElement::CurveTo { .. }),
                         try_merge_cubics_n,
                     )
                 } else {
                     try_merge_run(
                         seg_start,
-                        &elements,
+                        elements,
                         i,
-                        n,
                         |e| matches!(e, PathElement::QuadTo { .. }),
                         try_merge_quads_n,
                     )
@@ -51,8 +49,8 @@ fn merge_subpath_elements(start: Point, elements: Vec<PathElement>) -> Vec<PathE
                 i += len;
             }
             PathElement::LineTo(end) => {
-                if let (Some(PathElement::LineTo(last_end)), Some(&last_start)) =
-                    (result.last().copied(), result_starts.last())
+                if let (Some(PathElement::LineTo(last_end)), Some(last_start)) =
+                    (result.last().copied(), result_starts.last().copied())
                     && can_merge_lines(last_start, last_end, end)
                 {
                     result.pop();
@@ -75,12 +73,11 @@ fn try_merge_run(
     seg_start: Point,
     elements: &[PathElement],
     i: usize,
-    n: usize,
     is_same: impl Fn(PathElement) -> bool,
     try_merge: fn(Point, &[PathElement]) -> Option<PathElement>,
 ) -> (PathElement, usize) {
     let mut run_end = i + 1;
-    while run_end < n && is_same(elements[run_end]) {
+    while run_end < elements.len() && is_same(elements[run_end]) {
         run_end += 1;
     }
     let run_len = run_end - i;

--- a/src/transform/render_bitmap.rs
+++ b/src/transform/render_bitmap.rs
@@ -82,14 +82,9 @@ fn render_target(
             )))
         }
         RenderMode::Bbox => {
-            let Some(bounds) = bounds else {
+            let Some((bounds, width, height)) = nonempty_bounds(bounds) else {
                 return Ok(None);
             };
-            let width = bounds.width();
-            let height = bounds.height();
-            if width <= f32::EPSILON || height <= f32::EPSILON {
-                return Ok(None);
-            }
             let scale = bitmap_size / (FIXED_MAX - FIXED_MIN);
             let bitmap_width = (width * scale).ceil() as u32;
             let bitmap_height = (height * scale).ceil() as u32;
@@ -106,14 +101,9 @@ fn render_target(
             )))
         }
         RenderMode::BboxSquare => {
-            let Some(bounds) = bounds else {
+            let Some((bounds, width, height)) = nonempty_bounds(bounds) else {
                 return Ok(None);
             };
-            let width = bounds.width();
-            let height = bounds.height();
-            if width <= f32::EPSILON || height <= f32::EPSILON {
-                return Ok(None);
-            }
             let scale = bitmap_size / width.max(height);
             let offset_x = (bitmap_size - width * scale) * 0.5;
             let offset_y = (bitmap_size - height * scale) * 0.5;
@@ -128,6 +118,13 @@ fn render_target(
             )))
         }
     }
+}
+
+fn nonempty_bounds(bounds: Option<Bounds>) -> Option<(Bounds, f32, f32)> {
+    let b = bounds?;
+    let w = b.width();
+    let h = b.height();
+    (w > f32::EPSILON && h > f32::EPSILON).then_some((b, w, h))
 }
 
 fn render_matrix(scale: f32, tx: f32, ty: f32) -> Matrix {

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -3,9 +3,9 @@ use crate::outline::{Outline, PathElement, Point, Subpath};
 pub(crate) fn normalize_subpath_start_points(outline: &Outline) -> Outline {
     transform_start_points(outline, |subpath, _| {
         subpath_nodes(subpath)
-            .iter()
+            .into_iter()
             .enumerate()
-            .min_by(|(_, a), (_, b)| compare_points(**a, **b))
+            .min_by(|(_, a), (_, b)| compare_points(*a, *b))
             .map_or(0, |(idx, _)| idx)
     })
 }
@@ -59,13 +59,16 @@ fn rotate_closed_subpath(subpath: &Subpath, start_idx: usize) -> Subpath {
 
     let nodes = subpath_nodes(subpath);
     let start = nodes[start_idx];
-    let split = start_idx;
     let mut elements = Vec::with_capacity(subpath.elements().len() + 1);
-    elements.extend_from_slice(&subpath.elements()[split..]);
-    if subpath.elements().last().map(|element| element.end()) != Some(subpath.start()) {
+    elements.extend_from_slice(&subpath.elements()[start_idx..]);
+    if subpath
+        .elements()
+        .last()
+        .is_none_or(|e| e.end() != subpath.start())
+    {
         elements.push(PathElement::LineTo(subpath.start()));
     }
-    elements.extend_from_slice(&subpath.elements()[..split]);
+    elements.extend_from_slice(&subpath.elements()[..start_idx]);
     Subpath::new(start, elements, true)
 }
 


### PR DESCRIPTION
## Summary

- **`src/bounds.rs`**: `BoundsPen::include` uses `get_or_insert_with` instead of if/else; cubic extrema chained before single `.flatten()`
- **`src/dataset/entry.rs`**: Removed `GlyphCompleteResult` type alias; removed redundant named argument in format string; user_coords avoids intermediate `Vec<f32>`
- **`src/dataset/index.rs`**: Extracted `cumulative_sums` helper to deduplicate two identical prefix-sum patterns; removed intermediate `faces` binding
- **`src/dataset/io.rs`**: `has_font_extension` uses `.is_some_and(...)` instead of chained `.map().map().unwrap_or(false)`
- **`src/dataset/mod.rs`**: `style_axes` uses `flat_map().collect()`; `is_monospace` uses `f32::from`; `targets` uses `extend([...])`; `locate_parts` uses `|&offset|` pattern deref
- **`src/dataset/reader.rs`**: Extracted `scale` closure and `localized_name` free function to deduplicate repeated patterns; `location_ref` uses `map_or` instead of if/let
- **`src/error.rs`**: Removed `py_value_err`; inlined its body into `py_err`
- **`src/lib.rs`**: Single-variant match errors simplified to `|_|` closures
- **`src/transform/cubic_to_quad.rs`**: `cubic_to_quads` uses `find_map` + `ok_or`; outer function uses `extend` + `map`
- **`src/transform/merge_curves.rs`**: `merge_subpath_elements` takes `&[PathElement]`; `try_merge_run` removes `n` parameter
- **`src/transform/render_bitmap.rs`**: Extracted `nonempty_bounds` helper to deduplicate bbox validation logic
- **`src/transform/subpath.rs`**: Uses `is_none_or`; removes redundant alias; uses `into_iter()` with single deref

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo check --all-targets --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)