### PR TITLE
refactor: decouple PyO3 from core and move font entry/reader to font/

### DIFF
--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -1,6 +1,5 @@
-use super::entry::FontEntry;
-use crate::error::py_index_err;
-use pyo3::prelude::*;
+use crate::error::Error;
+use crate::font::FontEntry;
 
 pub(crate) struct DatasetIndex {
     pub(crate) sample_offsets: Vec<usize>,
@@ -9,17 +8,17 @@ pub(crate) struct DatasetIndex {
 }
 
 impl DatasetIndex {
-    pub(crate) fn content_index(&self, codepoint: u32) -> PyResult<usize> {
-        self.content_classes
-            .binary_search(&codepoint)
-            .map_err(|_| py_index_err(format!("codepoint U+{codepoint:04X} missing from index")))
+    pub(crate) fn content_index(&self, codepoint: u32) -> Result<usize, Error> {
+        self.content_classes.binary_search(&codepoint).map_err(|_| {
+            Error::OutOfRange(format!("codepoint U+{codepoint:04X} missing from index"))
+        })
     }
 }
 
 pub(crate) fn load_entries_and_index(
     files: Vec<String>,
     filter: Option<&[u32]>,
-) -> PyResult<(Vec<FontEntry>, DatasetIndex)> {
+) -> Result<(Vec<FontEntry>, DatasetIndex), Error> {
     let mut entries = Vec::new();
     let mut all_cps = Vec::new();
 

--- a/src/dataset/io.rs
+++ b/src/dataset/io.rs
@@ -1,17 +1,12 @@
-use crate::error::py_err;
+use crate::error::Error;
 use ignore::{WalkBuilder, overrides::OverrideBuilder};
-use memmap2::Mmap;
-use pyo3::prelude::*;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-pub(crate) fn canonicalize_root(root: &str) -> PyResult<PathBuf> {
+pub(crate) fn canonicalize_root(root: &str) -> Result<PathBuf, Error> {
     let expanded = shellexpand::tilde(root);
     let path = PathBuf::from(expanded.as_ref());
-    fs::canonicalize(&path).map_err(|err| {
-        py_err(format!(
+    std::fs::canonicalize(&path).map_err(|err| {
+        Error::Io(format!(
             "failed to resolve font root '{}': {err}",
             path.display()
         ))
@@ -21,7 +16,7 @@ pub(crate) fn canonicalize_root(root: &str) -> PyResult<PathBuf> {
 pub(crate) fn discover_font_files(
     root: &Path,
     patterns: Option<&[String]>,
-) -> PyResult<Vec<String>> {
+) -> Result<Vec<String>, Error> {
     let mut builder = WalkBuilder::new(root);
     builder.standard_filters(false);
     builder.filter_entry(|entry| !is_vcs_metadata_dir(entry));
@@ -32,8 +27,8 @@ pub(crate) fn discover_font_files(
     let mut files = Vec::new();
 
     for result in builder.build() {
-        let entry =
-            result.map_err(|err| py_err(format!("failed to walk '{}': {err}", root.display())))?;
+        let entry = result
+            .map_err(|err| Error::Io(format!("failed to walk '{}': {err}", root.display())))?;
 
         let path = entry.path();
 
@@ -65,23 +60,14 @@ fn has_font_extension(path: &Path) -> bool {
         })
 }
 
-pub(super) fn map_font(path: &str) -> PyResult<Mmap> {
-    let file =
-        fs::File::open(path).map_err(|err| py_err(format!("failed to open '{path}': {err}")))?;
-    let mmap = unsafe { Mmap::map(&file) }
-        .map_err(|err| py_err(format!("failed to map '{path}': {err}")))?;
-    Ok(mmap)
-}
-
-fn build_overrides(root: &Path, patterns: &[String]) -> PyResult<ignore::overrides::Override> {
+fn build_overrides(root: &Path, patterns: &[String]) -> Result<ignore::overrides::Override, Error> {
     let mut builder = OverrideBuilder::new(root);
     for pattern in patterns {
         builder
             .add(pattern)
-            .map_err(|err| py_err(format!("invalid pattern '{pattern}': {err}")))?;
+            .map_err(|err| Error::Io(format!("invalid pattern '{pattern}': {err}")))?;
     }
-
     builder
         .build()
-        .map_err(|err| py_err(format!("failed to compile patterns: {err}")))
+        .map_err(|err| Error::Io(format!("failed to compile patterns: {err}")))
 }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -1,8 +1,6 @@
-pub(crate) mod entry;
 pub(crate) mod index;
 mod io;
-mod reader;
 
-pub(crate) use entry::FontEntry;
+pub(crate) use crate::font::FontEntry;
 pub(crate) use index::{DatasetIndex, load_entries_and_index};
 pub(crate) use io::{canonicalize_root, discover_font_files};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,29 @@
-use pyo3::prelude::*;
+use std::fmt;
 
-pub fn py_err(msg: impl Into<String>) -> PyErr {
-    PyErr::new::<pyo3::exceptions::PyValueError, _>(msg.into())
+#[derive(Debug)]
+pub enum Error {
+    Parse(String),
+    Io(String),
+    OutOfRange(String),
 }
 
-pub fn py_index_err(msg: impl Into<String>) -> PyErr {
-    PyErr::new::<pyo3::exceptions::PyIndexError, _>(msg.into())
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse(msg) | Self::Io(msg) | Self::OutOfRange(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl From<Error> for pyo3::PyErr {
+    fn from(e: Error) -> Self {
+        match e {
+            Error::OutOfRange(_) => {
+                pyo3::PyErr::new::<pyo3::exceptions::PyIndexError, _>(e.to_string())
+            }
+            Error::Parse(_) | Error::Io(_) => {
+                pyo3::PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string())
+            }
+        }
+    }
 }

--- a/src/font/entry.rs
+++ b/src/font/entry.rs
@@ -1,15 +1,11 @@
-use std::sync::Arc;
+use std::{fs, sync::Arc};
 
 use memmap2::Mmap;
-use pyo3::prelude::*;
 use skrifa::raw::{FileRef, TableProvider};
 use skrifa::{GlyphId, MetadataProvider, instance::Location};
 
-use super::{
-    io::map_font,
-    reader::{GlyphItemData, GlyphReader},
-};
-use crate::error::{py_err, py_index_err};
+use super::reader::{GlyphItemData, GlyphReader};
+use crate::error::Error;
 
 pub(super) struct GlyphIndex {
     codepoints: Vec<u32>,
@@ -25,26 +21,26 @@ pub(crate) struct FontEntry {
 }
 
 impl FontEntry {
-    pub(crate) fn load_faces(path: &str, filter: Option<&[u32]>) -> PyResult<Vec<Self>> {
+    pub(crate) fn load_faces(path: &str, filter: Option<&[u32]>) -> Result<Vec<Self>, Error> {
         let mapped = Arc::new(map_font(path)?);
         let parsed = FileRef::new(&mapped[..])
-            .map_err(|err| py_err(format!("failed to parse '{path}': {err}")))?;
+            .map_err(|err| Error::Parse(format!("failed to parse '{path}': {err}")))?;
 
         let entries = parsed
             .fonts()
             .enumerate()
             .map(|(face_index, face)| {
                 let font = face.map_err(|err| {
-                    py_err(format!(
+                    Error::Parse(format!(
                         "failed to parse '{path}' (face {face_index}): {err}"
                     ))
                 })?;
                 Self::from_face(path, face_index as u32, Arc::clone(&mapped), &font, filter)
             })
-            .collect::<PyResult<Vec<_>>>()?;
+            .collect::<Result<Vec<_>, Error>>()?;
 
         if entries.is_empty() {
-            return Err(py_err(format!(
+            return Err(Error::Parse(format!(
                 "font file '{path}' does not contain any fonts"
             )));
         }
@@ -55,10 +51,9 @@ impl FontEntry {
         &self,
         codepoint: u32,
         instance_index: Option<usize>,
-    ) -> PyResult<GlyphItemData> {
+    ) -> Result<GlyphItemData, Error> {
         let glyph_idx = self.lookup_glyph_index(codepoint)?;
         let glyph_id = self.index.glyph_ids[glyph_idx];
-
         self.reader
             .draw_glyph(glyph_id, self.units_per_em, &self.locations, instance_index)
     }
@@ -112,11 +107,11 @@ impl FontEntry {
         data: Arc<Mmap>,
         font: &skrifa::FontRef<'_>,
         filter: Option<&[u32]>,
-    ) -> PyResult<Self> {
+    ) -> Result<Self, Error> {
         let upem = font
             .head()
             .map_err(|_| {
-                py_err(format!(
+                Error::Parse(format!(
                     "font '{base_path}' (face {face_index}) is missing a head table"
                 ))
             })?
@@ -169,15 +164,23 @@ impl FontEntry {
         })
     }
 
-    fn lookup_glyph_index(&self, codepoint: u32) -> PyResult<usize> {
+    fn lookup_glyph_index(&self, codepoint: u32) -> Result<usize, Error> {
         self.index
             .codepoints
             .binary_search(&codepoint)
             .map_err(|_| {
-                py_index_err(format!(
+                Error::OutOfRange(format!(
                     "codepoint U+{codepoint:04X} missing from '{}'",
                     self.reader.path()
                 ))
             })
     }
+}
+
+fn map_font(path: &str) -> Result<Mmap, Error> {
+    let file =
+        fs::File::open(path).map_err(|err| Error::Io(format!("failed to open '{path}': {err}")))?;
+    let mmap = unsafe { Mmap::map(&file) }
+        .map_err(|err| Error::Io(format!("failed to map '{path}': {err}")))?;
+    Ok(mmap)
 }

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -1,3 +1,6 @@
+mod entry;
 mod extract;
+mod reader;
 
+pub(crate) use entry::FontEntry;
 pub(crate) use extract::extract_glyph_outline;

--- a/src/font/reader.rs
+++ b/src/font/reader.rs
@@ -1,21 +1,15 @@
 use std::sync::Arc;
 
 use memmap2::Mmap;
-use pyo3::prelude::*;
 use skrifa::{
     GlyphId, MetadataProvider,
     instance::{Location, LocationRef, Size},
     outline::DrawSettings,
     raw::TableProvider,
+    raw::types::NameId,
 };
 
-use crate::{
-    error::{py_err, py_index_err},
-    font::extract_glyph_outline,
-    geom::bounds_from_outline,
-};
-
-use skrifa::raw::types::NameId;
+use crate::{error::Error, font::extract_glyph_outline, geom::bounds_from_outline};
 
 pub(super) type GlyphItemData = (
     Vec<i64>,
@@ -67,10 +61,10 @@ impl GlyphReader {
         units_per_em: f32,
         locations: &[Location],
         instance_index: Option<usize>,
-    ) -> PyResult<GlyphItemData> {
+    ) -> Result<GlyphItemData, Error> {
         self.with_font_ref(|font| {
             let glyph = font.outline_glyphs().get(glyph_id).ok_or_else(|| {
-                py_err(format!(
+                Error::Parse(format!(
                     "glyph id {} missing from '{}'",
                     glyph_id.to_u32(),
                     self.path
@@ -86,7 +80,7 @@ impl GlyphReader {
                 DrawSettings::unhinted(Size::unscaled(), location_ref),
                 units_per_em,
             )
-            .map_err(|err| py_err(format!("failed to draw glyph: {err}")))?;
+            .map_err(|err| Error::Parse(format!("failed to draw glyph: {err}")))?;
 
             let glyph_metrics = font.glyph_metrics(Size::unscaled(), location_ref);
             let advance_width = scale(glyph_metrics.advance_width(glyph_id));
@@ -176,9 +170,12 @@ impl GlyphReader {
         .flatten()
     }
 
-    fn with_font_ref<T>(&self, f: impl FnOnce(skrifa::FontRef<'_>) -> PyResult<T>) -> PyResult<T> {
+    fn with_font_ref<T>(
+        &self,
+        f: impl FnOnce(skrifa::FontRef<'_>) -> Result<T, Error>,
+    ) -> Result<T, Error> {
         let font = skrifa::FontRef::from_index(&self.data[..], self.face_index).map_err(|err| {
-            py_err(format!(
+            Error::Parse(format!(
                 "failed to parse '{}' (face {}): {err}",
                 self.path, self.face_index
             ))
@@ -190,12 +187,12 @@ impl GlyphReader {
         &self,
         locations: &'a [Location],
         index: Option<usize>,
-    ) -> PyResult<LocationRef<'a>> {
+    ) -> Result<LocationRef<'a>, Error> {
         index.map_or(Ok(LocationRef::default()), |idx| {
             locations
                 .get(idx)
                 .ok_or_else(|| {
-                    py_index_err(format!(
+                    Error::OutOfRange(format!(
                         "instance index {idx} out of range for '{}'",
                         self.path
                     ))

--- a/src/py/dataset.rs
+++ b/src/py/dataset.rs
@@ -65,7 +65,7 @@ impl GlyphDataset {
             .copied()
             .map(|codepoint| {
                 let ch = char::from_u32(codepoint).ok_or_else(|| {
-                    crate::error::py_err(format!(
+                    pyo3::exceptions::PyValueError::new_err(format!(
                         "indexed codepoint U+{codepoint:04X} is not a Unicode scalar value"
                     ))
                 })?;
@@ -204,7 +204,7 @@ impl GlyphDataset {
     fn locate_parts(&self, idx: usize) -> PyResult<(usize, Option<usize>, u32, usize, usize)> {
         let total = self.sample_count();
         if idx >= total {
-            return Err(crate::error::py_index_err(format!(
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
                 "sample index {idx} out of range (len={total})"
             )));
         }
@@ -251,7 +251,7 @@ fn style_label_id(
     instance_idx: Option<usize>,
 ) -> PyResult<String> {
     let relative_path = font_path.strip_prefix(root).map_err(|_| {
-        crate::error::py_err(format!(
+        pyo3::exceptions::PyValueError::new_err(format!(
             "font path '{}' is not under dataset root '{}'",
             font_path.display(),
             root.display()


### PR DESCRIPTION
## Summary

- Introduce a crate-level `Error` enum (`Parse`, `Io`, `OutOfRange`) in `error.rs` with `From<Error> for PyErr`, removing all `pyo3` imports from `font/` and `dataset/`. The `py/` layer now converts errors automatically via `?`.
- Move `FontEntry` (`entry.rs`) and `GlyphReader` (`reader.rs`) from `dataset/` to `font/`, where font-parsing logic belongs. `dataset/` is now limited to collection-level concerns: file discovery and index building.
- `dataset/mod.rs` re-exports `FontEntry` from `font/` so existing call sites in `py/dataset.rs` are unaffected.

## Test plan

- [x] `cargo clippy` — no warnings
- [x] `mise run test` — 195 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)