### PR TITLE
docs: record skia-safe non-optional as known non-starter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,9 @@
 
 - Use `gh` for issue and pull request operations.
 - Resolve PR conversations after addressing the feedback.
+
+## Known non-starters
+
+- **Making `skia-safe` an optional Cargo feature**: PyPI wheels are compiled
+  binaries — Cargo features cannot be selected via `pip install`. Truly optional
+  Skia would require a separate distribution package, which is not planned.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ ignore = "0.4.25"
 memmap2 = "0.9.10"
 numpy = "0.28.0"
 shellexpand = "3.1.2"
+# Intentionally non-optional: PyPI wheels are compiled binaries and Cargo
+# features cannot be selected via pip install.
 skia-safe = "0.97.0"
 skrifa = "0.42.1"
 urlencoding = "2.1.3"


### PR DESCRIPTION
## Summary

- `AGENTS.md` に `## Known non-starters` セクションを追加し、`skia-safe` を Cargo feature でオプション化することが PyPI 配布においては無意味であることを記録
- `Cargo.toml` の `skia-safe` 宣言にも同趣旨のコメントを追記

## Background

コードレビューのたびに「`skia-safe` は `remove_overlaps` と `render_bitmap` にしか使われていないので optional feature にできる」という提案が繰り返し上がっていた。技術的には Cargo feature として実装できるが、PyPI wheel はビルド時にバイナリが固定されるため `pip install` で feature を選択する手段がなく、エンドユーザーには届かない。実際に実装して差し戻すというサイクルが発生したため、その経緯と理由を記録する。

## Test plan

- ドキュメント変更のみ。コードの変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)