### PR TITLE
chore: switch Dev Container to vscode user and add oncreate hook

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,9 @@
 {
   "features": {
-    "ghcr.io/devcontainers/features/common-utils:": {
-      "version": "2.5.8",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:c42fdefe6d737a3a6f61cc52b23c7c9a565d08cc4d9c303669a7cf2ee5fd81fc",
-      "integrity": "sha256:c42fdefe6d737a3a6f61cc52b23c7c9a565d08cc4d9c303669a7cf2ee5fd81fc"
+    "ghcr.io/devcontainers/features/common-utils:2.5.9": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,12 +2,12 @@
 	"name": "mise",
 	"image": "jdxcode/mise:latest",
 	"features": {
-		"ghcr.io/devcontainers/features/common-utils:": {}
+		"ghcr.io/devcontainers/features/common-utils:2.5.9": {}
 	},
 	"mounts": [
 		{
 			"source": "uv",
-			"target": "/root/.cache/uv",
+			"target": "/home/vscode/.cache/uv",
 			"type": "volume"
 		},
 		{
@@ -32,6 +32,7 @@
 		"MISE_TRUSTED_CONFIG_PATHS": "/workspaces",
 		"UV_LINK_MODE": "copy"
 	},
+	"onCreateCommand": ".devcontainer/oncreate.sh",
 	"postCreateCommand": "mise run setup",
 	"customizations": {
 		"vscode": {
@@ -42,5 +43,6 @@
 				"tamasfe.even-better-toml"
 			]
 		}
-	}
+	},
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/oncreate.sh
+++ b/.devcontainer/oncreate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+paths=(
+  "/mise"
+  "/home/vscode/.cache/uv"
+  "${containerWorkspaceFolder:-/workspaces/torchfont}/.venv"
+  "${containerWorkspaceFolder:-/workspaces/torchfont}/target"
+  "${containerWorkspaceFolder:-/workspaces/torchfont}/node_modules"
+  "${containerWorkspaceFolder:-/workspaces/torchfont}/data"
+)
+
+for path in "${paths[@]}"; do
+  if [[ -e "${path}" ]]; then
+    sudo chmod -R a+rwX "${path}"
+  fi
+done


### PR DESCRIPTION
## Summary

- Set `remoteUser` to `vscode` and update the uv cache path from `/root/.cache/uv` to `/home/vscode/.cache/uv`
- Pin `common-utils` feature to `2.5.9`
- Add `onCreateCommand` pointing to `.devcontainer/oncreate.sh` (renamed from `fix-mount-permissions.sh`) to fix volume mount permissions for the `vscode` user on container creation

## Test plan

- [ ] Rebuild Dev Container and verify it starts without permission errors on mounted volumes
- [ ] Confirm `mise run setup` completes successfully after container creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)