### PR TITLE
fix: replace chmod with chown in Dev Container oncreate hook

### DIFF
--- a/.devcontainer/oncreate.sh
+++ b/.devcontainer/oncreate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
+
+USER_NAME="${USER_NAME:-vscode}"
 
 paths=(
   "/mise"
@@ -13,6 +14,6 @@ paths=(
 
 for path in "${paths[@]}"; do
   if [[ -e "${path}" ]]; then
-    sudo chmod -R a+rwX "${path}"
+    sudo chown -R "${USER_NAME}:${USER_NAME}" "${path}"
   fi
 done


### PR DESCRIPTION
## Summary

- `chmod -R a+rwX` を `chown -R ${USER_NAME}:${USER_NAME}` に置き換え
- Docker が volume を作成する際に `root` 所有になるファイルを、`remoteUser` である `vscode` に正しく移譲するようにした
- `USER_NAME` 環境変数を導入（デフォルト: `vscode`）

## Motivation

前 PR (#253) で `remoteUser` を `root` から `vscode` に変更した。`chmod a+rwX` は全ユーザーへの書き込み権限付与で動作はするが world-writable なパーミッションはセキュリティ上好ましくない。`chown` によるオーナー移譲が正しいアプローチ。

## Test plan

- [x] `devcontainer up` で起動確認
- [x] 全対象パス（`/mise`, `uv` キャッシュ, `.venv`, `target`, `node_modules`, `data`）が `vscode:vscode` 所有になることを `stat` で確認
- [x] `mise` タスク群が正常に認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)