### PR TITLE
docs: update GlyphSample field docs to reflect per-table metadata split

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -35,7 +35,7 @@ features:
   - icon: 🧱
     title: Sample-first data model
     details:
-      "`GlyphSample` represents one glyph with outline, metrics, and name, so
+      "`GlyphSample` represents one glyph with outline, structured font metadata, and name, so
       batching policy can stay in your training code."
   - icon: 🧩
     title: Flexible preprocessing

--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -75,13 +75,21 @@ GlyphDataset(
 sample = dataset[idx]
 ```
 
-| Field         | Type                | Shape          |
-| ------------- | ------------------- | -------------- |
+| Field                | Type                | Shape          |
+| -------------------- | ------------------- | -------------- |
 | `sample.types`       | `torch.LongTensor`  | `(seq_len,)`   |
 | `sample.coords`      | `torch.FloatTensor` | `(seq_len, 6)` |
 | `sample.style_idx`   | `int`               | scalar         |
 | `sample.content_idx` | `int`               | scalar         |
-| `sample.metrics`     | `torch.FloatTensor` | `(15,)`        |
+| `sample.head`        | `torch.FloatTensor` | `(8,)`         |
+| `sample.hhea`        | `torch.FloatTensor` | `(10,)`        |
+| `sample.os2`         | `torch.FloatTensor` | `(42,)`        |
+| `sample.post`        | `torch.FloatTensor` | `(4,)`         |
+| `sample.maxp`        | `torch.FloatTensor` | `(14,)`        |
+| `sample.hmtx`        | `torch.FloatTensor` | `(2,)`         |
+| `sample.bounds`      | `torch.FloatTensor` | `(4,)`         |
+| `sample.name`        | `NameRecord`        | —              |
+| `sample.codepoint`   | `int`               | —              |
 | `sample.glyph_name`  | `str`               | —              |
 
 Without `transform`, `sample` is a `GlyphSample`. With `transform`, the

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -28,7 +28,7 @@ features:
     details: "skrifa + PyO3 による実装で、グリフアウトラインを element type + coordinates テンソルへ高速に変換します。"
   - icon: 🧱
     title: Sample-first なデータモデル
-    details: "`GlyphSample` が 1 グリフを outline・metrics・名前つきで表し、batch 化方針は学習コード側に置けます。"
+    details: "`GlyphSample` が 1 グリフを outline・構造化フォントメタデータ・名前つきで表し、batch 化方針は学習コード側に置けます。"
   - icon: 🧩
     title: 柔軟な前処理
     details: "`quad_to_cubic` のような小さな utility を使い、tensor 整形は dataset やモデル固有コードで調整できます。"

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -81,8 +81,16 @@ sample = dataset[idx]
 | `sample.coords`      | `torch.FloatTensor` | `(seq_len, 6)` |
 | `sample.style_idx`   | `int`               | スカラー       |
 | `sample.content_idx` | `int`               | スカラー       |
-| `sample.metrics`     | `torch.FloatTensor` | `(15,)`       |
-| `sample.glyph_name`  | `str`               | —             |
+| `sample.head`        | `torch.FloatTensor` | `(8,)`         |
+| `sample.hhea`        | `torch.FloatTensor` | `(10,)`        |
+| `sample.os2`         | `torch.FloatTensor` | `(42,)`        |
+| `sample.post`        | `torch.FloatTensor` | `(4,)`         |
+| `sample.maxp`        | `torch.FloatTensor` | `(14,)`        |
+| `sample.hmtx`        | `torch.FloatTensor` | `(2,)`         |
+| `sample.bounds`      | `torch.FloatTensor` | `(4,)`         |
+| `sample.name`        | `NameRecord`        | —              |
+| `sample.codepoint`   | `int`               | —              |
+| `sample.glyph_name`  | `str`               | —              |
 
 `transform` なしでは `sample` 自体の型は `GlyphSample` です。`transform`
 ありでは、dataset item の型は transform の返り値型から推論されます。


### PR DESCRIPTION
## Summary

- Replace stale `sample.metrics (15,)` row in the EN/JA `GlyphDataset` return-value tables with the new per-table fields (`head`, `hhea`, `os2`, `post`, `maxp`, `hmtx`, `bounds`, `name`, `codepoint`)
- Update the top-page feature description from "outline, metrics, and name" → "outline, structured font metadata, and name" (EN/JA)

These docs were left behind when #251 split the flat `metrics` tensor into per-table fields.

## Test plan

- [ ] Verify the reference tables render correctly in VitePress (`docs/en/reference/datasets.md`, `docs/ja/reference/datasets.md`)
- [ ] Confirm top-page feature card copy looks correct in both locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)