### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.9.6"
+version = "0.10.0"
 dependencies = [
  "ignore",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.9.6"
+version = "0.10.0"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` version from `0.9.6` to `0.10.0`
- Update `Cargo.lock` accordingly

## Why 0.10.0

`GlyphSample.metrics` was removed and replaced with per-table fields (`head`, `hhea`, `os2`, `post`, `maxp`, `hmtx`, `bounds`, `name`, `codepoint`) in #251, which is a breaking change warranting a minor version bump.

## Test plan

- [ ] Confirm `cargo build` succeeds with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)