### PR TITLE
fix(devcontainer): scope data volume to devcontainerId

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 			"type": "volume"
 		},
 		{
-			"source": "torchfont",
+			"source": "data-${devcontainerId}",
 			"target": "${containerWorkspaceFolder}/data",
 			"type": "volume"
 		}


### PR DESCRIPTION
## Summary

- `data` ボリュームのソース名を固定値 `"torchfont"` から `"data-${devcontainerId}"` に変更
- 複数の Dev Container インスタンスを同時に起動した際に同一ボリュームを共有してしまう問題を解消
- 各インスタンスが独立したデータボリュームを持つようになり、データ競合を防ぐ

## Test plan

- [ ] Dev Container をリビルドして `data/` ボリュームが正常にマウントされることを確認
- [ ] 複数インスタンスを起動した場合に別々のボリュームが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)