### PR TITLE
fix(devcontainer): use relative paths in oncreate.sh chown loop

### DIFF
--- a/.devcontainer/oncreate.sh
+++ b/.devcontainer/oncreate.sh
@@ -6,10 +6,10 @@ USER_NAME="${USER_NAME:-vscode}"
 paths=(
   "/mise"
   "/home/vscode/.cache/uv"
-  "${containerWorkspaceFolder:-/workspaces/torchfont}/.venv"
-  "${containerWorkspaceFolder:-/workspaces/torchfont}/target"
-  "${containerWorkspaceFolder:-/workspaces/torchfont}/node_modules"
-  "${containerWorkspaceFolder:-/workspaces/torchfont}/data"
+  ".venv"
+  "target"
+  "node_modules"
+  "data"
 )
 
 for path in "${paths[@]}"; do


### PR DESCRIPTION
## Summary

- `oncreate.sh`: `chown` ループ内のパスを `${containerWorkspaceFolder:-/workspaces/torchfont}/...` 形式の絶対パスから `.venv`、`target`、`node_modules`、`data` の相対パスに変更

## Test plan

- [ ] Dev Container を新規作成し、`oncreate.sh` が正常に実行されて各ディレクトリの所有者が `vscode` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)