### PR TITLE
[codex] Test remove overlaps across all Google Fonts

### DIFF
--- a/tests/google_fonts/test_remove_overlaps.py
+++ b/tests/google_fonts/test_remove_overlaps.py
@@ -142,8 +142,6 @@ def test_remove_overlaps_google_fonts(
             "ofl/*/*.ttf",
             "ufl/*/*.ttf",
             "!ofl/adobeblank/*.ttf",
-            "!ofl/handjet/*.ttf",
-            "!ofl/bitcount*/*.ttf",
         ),
         transform=_transform,
     )


### PR DESCRIPTION
## Summary

- include Handjet fonts in the Google Fonts remove-overlaps corpus test
- include Bitcount fonts in the same corpus test

## Why

These families were previously excluded from the corpus scan. The current remove-overlaps implementation handles them within the existing failure-rate allowance, so the test should cover them as well.

## Validation

- `uv run pytest tests/google_fonts/test_remove_overlaps.py --google-fonts -s`
- Result: `1 passed in 1351.28s`