### PR TITLE
[codex] Fix line merging in merge curves

### DIFF
--- a/src/curves/merge_curves.rs
+++ b/src/curves/merge_curves.rs
@@ -18,7 +18,6 @@ pub(crate) fn merge_curves(outline: &Outline) -> Outline {
 fn merge_subpath_elements(start: Point, elements: &[PathElement]) -> Vec<PathElement> {
     let n = elements.len();
     let mut result = Vec::with_capacity(n);
-    let mut result_starts = Vec::with_capacity(n);
     let mut i = 0;
 
     while i < n {
@@ -26,43 +25,32 @@ fn merge_subpath_elements(start: Point, elements: &[PathElement]) -> Vec<PathEle
         let seg_start = result.last().map_or(start, |e: &PathElement| e.end());
 
         match element {
-            PathElement::CurveTo { .. } | PathElement::QuadTo { .. } => {
-                let (merged, len) = if matches!(element, PathElement::CurveTo { .. }) {
-                    try_merge_run(
+            PathElement::CurveTo { .. } | PathElement::QuadTo { .. } | PathElement::LineTo(_) => {
+                let (merged, len) = match element {
+                    PathElement::CurveTo { .. } => try_merge_run(
                         seg_start,
                         elements,
                         i,
                         |e| matches!(e, PathElement::CurveTo { .. }),
                         try_merge_cubics_n,
-                    )
-                } else {
-                    try_merge_run(
+                    ),
+                    PathElement::QuadTo { .. } => try_merge_run(
                         seg_start,
                         elements,
                         i,
                         |e| matches!(e, PathElement::QuadTo { .. }),
                         try_merge_quads_n,
-                    )
+                    ),
+                    PathElement::LineTo(_) => try_merge_run(
+                        seg_start,
+                        elements,
+                        i,
+                        |e| matches!(e, PathElement::LineTo(_)),
+                        try_merge_lines_n,
+                    ),
                 };
                 result.push(merged);
-                result_starts.push(seg_start);
                 i += len;
-            }
-            PathElement::LineTo(end) => {
-                if let (Some(PathElement::LineTo(last_end)), Some(last_start)) =
-                    (result.last().copied(), result_starts.last().copied())
-                    && can_merge_lines(last_start, last_end, end)
-                {
-                    result.pop();
-                    result_starts.pop();
-                    result.push(PathElement::LineTo(end));
-                    result_starts.push(last_start);
-                    i += 1;
-                    continue;
-                }
-                result.push(element);
-                result_starts.push(seg_start);
-                i += 1;
             }
         }
     }
@@ -311,29 +299,34 @@ fn split_cubic_at_ts(p0: Point, p1: Point, p2: Point, p3: Point, ts: &[f32]) -> 
     pieces
 }
 
-fn can_merge_lines(start: Point, middle: Point, end: Point) -> bool {
-    let d1 = middle - start;
-    let d2 = end - middle;
-
-    let len1_sq = d1.dot(d1);
-    let len2_sq = d2.dot(d2);
-
-    if len1_sq < 1e-12 || len2_sq < 1e-12 {
-        return true;
-    }
-
+fn try_merge_lines_n(start: Point, segs: &[PathElement]) -> Option<PathElement> {
+    let end = segs.last()?.end();
     let total = end - start;
-    let total_len = total.norm();
-    if total_len < 1e-6 {
-        return false;
+    if total.x == 0.0 && total.y == 0.0 {
+        return segs
+            .iter()
+            .all(|seg| seg.end() == start)
+            .then_some(PathElement::LineTo(end));
     }
 
-    // Measure the actual geometric deviation of the join from the merged line,
-    // not just its angle. The rest of the module interprets TOLERANCE as an
-    // absolute distance in normalized coordinates.
-    if d1.cross(total).abs() / total_len > TOLERANCE {
-        return false;
+    let mut previous = start;
+    for seg in segs {
+        let point = seg.end();
+        let direction = point - previous;
+        if !points_are_collinear(start, point, end) || direction.dot(total) < 0.0 {
+            return None;
+        }
+        previous = point;
     }
 
-    d1.dot(d2) >= 0.0
+    Some(PathElement::LineTo(end))
+}
+
+fn points_are_collinear(a: Point, b: Point, c: Point) -> bool {
+    let ab = b - a;
+    let ac = c - a;
+    let cross = ab.cross(ac).abs();
+    let product_scale = (ab.x * ac.y).abs() + (ab.y * ac.x).abs();
+
+    cross <= 8.0 * f32::EPSILON * product_scale
 }

--- a/tests/google_fonts/test_merge_curves.py
+++ b/tests/google_fonts/test_merge_curves.py
@@ -1,0 +1,93 @@
+import logging
+from pathlib import Path
+
+import pytest
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from torchfont.datasets import GlyphDataset, GlyphSample
+from torchfont.transforms import merge_curves, render_bitmap
+
+logger = logging.getLogger(__name__)
+
+GOOGLE_FONTS_ROOT = Path("data/google/fonts")
+
+# Allow rare rasterizer edge cases while still catching corpus-wide regressions.
+MAX_FAILURE_RATE = 0.001  # 0.1 %
+BITMAP_SIZE = 128
+
+
+def _hard_diff(a: Tensor, b: Tensor) -> Tensor:
+    """Ignore antialiasing noise and detect foreground/background changes."""
+    return ((a == 255) & (b == 0)) | ((a == 0) & (b == 255))
+
+
+def _transform(sample: GlyphSample) -> Tensor:
+    merged_types, merged_coords = merge_curves(sample.types, sample.coords)
+
+    original = render_bitmap(
+        sample.types,
+        sample.coords,
+        size=BITMAP_SIZE,
+        mode="fixed",
+        fill_rule="winding",
+    )
+    merged = render_bitmap(
+        merged_types,
+        merged_coords,
+        size=BITMAP_SIZE,
+        mode="fixed",
+        fill_rule="winding",
+    )
+
+    failed = _hard_diff(original, merged).any()
+    if failed:
+        logger.warning(
+            "merge_curves bitmap mismatch: %s U+%04X %s",
+            sample.name.family_name,
+            sample.codepoint,
+            sample.glyph_name,
+        )
+    return failed
+
+
+@pytest.mark.google_fonts
+def test_merge_curves_google_fonts(
+    request: pytest.FixtureRequest,
+) -> None:
+    if not GOOGLE_FONTS_ROOT.is_dir():
+        pytest.fail(f"Google Fonts checkout not available: {GOOGLE_FONTS_ROOT}")
+
+    limit: int | None = request.config.getoption("--limit")
+
+    dataset = GlyphDataset(
+        root=GOOGLE_FONTS_ROOT,
+        patterns=(
+            "apache/*/*.ttf",
+            "ofl/*/*.ttf",
+            "ufl/*/*.ttf",
+            "!ofl/adobeblank/*.ttf",
+        ),
+        transform=_transform,
+    )
+    dataloader = DataLoader(
+        dataset,
+        batch_size=256,
+        shuffle=True,
+        num_workers=8,
+        prefetch_factor=2,
+    )
+
+    total = 0
+    failures = 0
+    for batch in dataloader:
+        failures += batch.sum().item()
+        total += batch.numel()
+        if limit is not None and total >= limit:
+            break
+
+    failure_rate = failures / max(1, total)
+    assert failure_rate <= MAX_FAILURE_RATE, (
+        f"merge_curves failure rate {failure_rate:.4%} ({failures}/{total}) "
+        f"exceeds threshold {MAX_FAILURE_RATE:.4%}"
+    )

--- a/tests/transforms/curves/test_merge_curves.py
+++ b/tests/transforms/curves/test_merge_curves.py
@@ -33,6 +33,16 @@ def test_merge_curves_collinear_lines_are_merged() -> None:
     assert out_coords[line_idx, 5].item() == pytest.approx(0.0)
 
 
+def test_merge_curves_allows_normalization_roundoff_for_lines() -> None:
+    upm = 1000.0
+    points = [(x / upm, y / upm) for x, y in [(101, 37), (202, 74), (303, 111)]]
+    types, coords = _line_path_to_tensors(points)
+
+    out_types, _out_coords = merge_curves(types, coords)
+
+    assert out_types.tolist().count(ElementType.LINE_TO.value) == 1
+
+
 @pytest.mark.parametrize(
     "points",
     [
@@ -41,6 +51,7 @@ def test_merge_curves_collinear_lines_are_merged() -> None:
         pytest.param(
             [(0.0, 0.0), (1_000.0, 0.0), (2_000.0, 0.5)], id="absolute-tolerance"
         ),
+        pytest.param([(0.0, 0.0), (1.0, 1e-7), (2.0, 0.0)], id="tiny-bend"),
         pytest.param([(0.0, 0.0), (1.0, 0.0), (0.5, 0.0)], id="antiparallel"),
     ],
 )
@@ -50,6 +61,20 @@ def test_merge_curves_non_mergeable_lines_stay_separate(points: list[_Point]) ->
     out_types, _out_coords = merge_curves(types, coords)
 
     assert out_types.tolist().count(ElementType.LINE_TO.value) == 2
+
+
+def test_merge_curves_does_not_accumulate_line_error() -> None:
+    # A one-unit perpendicular segment is within the absolute tolerance when
+    # preceded by a long line, but must not turn the following polyline into a
+    # single diagonal chord.
+    upm = 1024.0
+    points = [(87.0 / upm, 193.0 / upm), (87.0 / upm, 0.0)]
+    points.extend((x / upm, -(x // 64) / upm) for x in range(88, 184))
+    types, coords = _line_path_to_tensors(points)
+
+    out_types, _out_coords = merge_curves(types, coords)
+
+    assert out_types.tolist().count(ElementType.LINE_TO.value) > 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- validate complete `LineTo` runs before merging them
- use a scale-aware `f32::EPSILON` check instead of the curve approximation tolerance
- add regression coverage for accumulated line error, normalization roundoff, and tiny real bends
- add a Google Fonts bitmap regression test for `merge_curves`

## Root cause

Line segments were merged incrementally using the shared `1e-3` curve tolerance. A short perpendicular segment could therefore be accepted after a long segment, and repeated merging discarded earlier vertices without validating them against the final chord. In Yaldevi Colombo Bold U+20BA, 97 line segments collapsed into one line whose maximum deviation from the original outline was about 85 font units.

## Impact

`LineTo` merging now preserves geometry apart from floating-point normalization roundoff. The affected glyph renders identically before and after merging.

## Validation

- `mise run check`
- `uv run pytest tests/transforms/curves/test_merge_curves.py -q` (`50 passed`)
- `uv run pytest tests/google_fonts/test_merge_curves.py --google-fonts --limit 10000 -q` (`1 passed`)
- full Google Fonts corpus: `1 passed in 411.05s`, with no bitmap mismatches