### PR TITLE
refactor: drop legacy _metadata pickle compatibility

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -685,21 +685,6 @@ def test_dataset_metadata_does_not_add_python_cache_state() -> None:
     assert first is not second
 
 
-def test_unpickling_drops_legacy_metadata_cache_state() -> None:
-    dataset = GlyphDataset(
-        root="tests/fonts",
-        patterns=("lato/Lato-Regular.ttf",),
-        codepoints=range(0x41, 0x44),
-    )
-
-    state = dataset.__getstate__()
-    state["_metadata"] = "legacy-cache"
-
-    dataset.__setstate__(state)
-
-    assert "_metadata" not in dataset.__dict__
-
-
 def test_dataset_metadata_does_not_route_through_python_projections() -> None:
     dataset = GlyphDataset(
         root="tests/fonts",

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -342,7 +342,6 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
 
     def __setstate__(self, state: dict[str, object]) -> None:
         """Restore state and recreate the native backend after unpickling."""
-        state.pop("_metadata", None)
         self.__dict__.update(state)
         self._validate_root_dir(self.root)
         self._backend = _torchfont.GlyphDatasetBackend(


### PR DESCRIPTION
## Summary

`GlyphDataset.__setstate__` popped a `_metadata` key from the pickled state, but no current code ever writes that attribute — it was backward compatibility for pickles created by old versions that cached metadata on the instance.

Dataset pickles are transient (they exist to transport the dataset to `DataLoader` workers within the same process generation), so pickles never cross library versions in practice. Per the project policy of preferring better architecture over backward compatibility, this removes the pop and its dedicated test (`test_unpickling_drops_legacy_metadata_cache_state`).

## Test plan

- `mise run test` — 199 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)