### PR TITLE
chore: remove stale ruff per-file-ignore for torchfont/datasets/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ ignore = ["COM812", "D203", "D213", "EXE002"]
 [tool.ruff.lint.per-file-ignores]
 "examples/**/*.py" = ["D", "T201"]
 "torchfont/transforms/geometric.py" = ["PLR0913"]
-"torchfont/datasets/*.py" = ["PLR0913"]
 "tests/**/*.py" = ["D", "PLR2004", "S101"]
 
 [tool.maturin]


### PR DESCRIPTION
## Summary

The per-file-ignore glob `torchfont/datasets/*.py` in `pyproject.toml` dates from when `torchfont.datasets` was a package directory. The module is now the single file `torchfont/datasets.py`, so the glob matches nothing, and nothing in that module triggers `PLR0913` anyway. Remove the dead config entry.

## Test plan

- `mise run python-check` — ruff format/check and ty all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)