### PR TITLE
docs: align README BibTeX entry with software citation conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,9 @@ If you find TorchFont useful in your work, please consider citing the following 
 
 ```bibtex
 @software{fujioka2025torchfont,
-    title        = {TorchFont: A Machine Learning library for Vector Fonts},
-    author       = {Takumu Fujioka},
-    year         = 2025,
-    journal      = {GitHub repository},
-    publisher    = {GitHub},
-    howpublished = {\url{https://github.com/torchfont/torchfont}}
+    author = {Fujioka, Takumu},
+    title  = {{TorchFont: A Machine Learning library for Vector Fonts}},
+    year   = {2025},
+    url    = {https://github.com/torchfont/torchfont}
 }
 ```


### PR DESCRIPTION
## Summary

The README's citation entry used `@software` but mixed in fields from other entry types: `journal = {GitHub repository}` and `publisher = {GitHub}` are not `@software` fields, and the repository URL was tucked into `howpublished`.

Best-practice research:

- [GitHub Docs: About CITATION files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) — the BibTeX GitHub generates from a `CITATION.cff` uses `@software` with `author` (in `Last, First` form), brace-protected `title`, `url`, `year` (plus `version`/`doi` when available).
- The [biblatex-software](https://ctan.org/pkg/biblatex-software) package defines `@software` with the same core fields; `journal`/`publisher`/`howpublished` are not part of the entry type.

This PR rewrites the entry to follow that format. `version`/`doi` are omitted: there is no DOI yet, and pinning a version in the README would go stale on every release.

A follow-up option (not in this PR) is adding a `CITATION.cff` so GitHub renders a "Cite this repository" button and keeps the citation machine-readable.

## Test plan

- Markdown-only change; verified the entry parses cleanly as BibTeX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)