### PR TITLE
feat: verify dataset structure fingerprint when unpickling

### DIFF
--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -52,6 +52,53 @@ pub(crate) fn load_entries_and_index(
     Ok((entries, index))
 }
 
+/// Hash everything that determines the sample -> (style, content) mapping:
+/// entry order, paths, face indices, code point lists, and instance counts.
+pub(crate) fn structure_fingerprint(entries: &[FontEntry]) -> u64 {
+    let mut hash = Fnv1a::new();
+    hash.write_u64(entries.len() as u64);
+    for entry in entries {
+        let path = entry.path().as_bytes();
+        hash.write_u64(path.len() as u64);
+        hash.write(path);
+        hash.write_u32(entry.face_index());
+        hash.write_u64(entry.instance_count() as u64);
+        hash.write_u64(entry.codepoint_count() as u64);
+        for &codepoint in entry.codepoints() {
+            hash.write_u32(codepoint);
+        }
+    }
+    hash.finish()
+}
+
+/// FNV-1a (64-bit). Fingerprints are compared across processes and library
+/// versions, so the hash must stay stable, unlike `std::hash::DefaultHasher`.
+struct Fnv1a(u64);
+
+impl Fnv1a {
+    fn new() -> Self {
+        Self(0xcbf2_9ce4_8422_2325)
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.0 = (self.0 ^ u64::from(byte)).wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+
+    fn write_u32(&mut self, value: u32) {
+        self.write(&value.to_le_bytes());
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.write(&value.to_le_bytes());
+    }
+
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
 fn cumulative_sums(deltas: impl Iterator<Item = usize>) -> Vec<usize> {
     std::iter::once(0)
         .chain(deltas)

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -2,5 +2,5 @@ pub(crate) mod index;
 mod io;
 
 pub(crate) use crate::font::FontEntry;
-pub(crate) use index::{DatasetIndex, load_entries_and_index};
+pub(crate) use index::{DatasetIndex, load_entries_and_index, structure_fingerprint};
 pub(crate) use io::{canonicalize_root, discover_font_files};

--- a/src/py/dataset.rs
+++ b/src/py/dataset.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use crate::dataset::{
     DatasetIndex, FontEntry, canonicalize_root, discover_font_files, load_entries_and_index,
+    structure_fingerprint,
 };
 
 #[pyclass(get_all)]
@@ -29,6 +30,7 @@ pub(crate) struct GlyphItem {
 pub(crate) struct GlyphDatasetBackend {
     entries: Vec<FontEntry>,
     index: DatasetIndex,
+    fingerprint: u64,
 }
 
 #[pymethods]
@@ -48,8 +50,18 @@ impl GlyphDatasetBackend {
         let root_path = canonicalize_root(&root)?;
         let files = discover_font_files(&root_path, patterns.as_deref())?;
         let (entries, index) = load_entries_and_index(files, filter.as_deref())?;
+        let fingerprint = structure_fingerprint(&entries);
 
-        Ok(Self { entries, index })
+        Ok(Self {
+            entries,
+            index,
+            fingerprint,
+        })
+    }
+
+    #[getter]
+    pub fn fingerprint(&self) -> u64 {
+        self.fingerprint
     }
 
     #[getter]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -980,6 +980,42 @@ def test_targets_survives_pickle() -> None:
     assert torch.equal(restored.targets, original_targets)
 
 
+def test_unpickle_raises_when_font_removed(tmp_path: Path) -> None:
+    """Unpickling must fail loudly when fonts changed since pickling."""
+    shutil.copy("tests/fonts/lato/Lato-Regular.ttf", tmp_path)
+    shutil.copy("tests/fonts/ubuntu/Ubuntu-Regular.ttf", tmp_path)
+
+    dataset = GlyphDataset(root=tmp_path, codepoints=range(0x41, 0x44))
+    payload = pickle.dumps(dataset)
+
+    (tmp_path / "Ubuntu-Regular.ttf").unlink()
+
+    with pytest.raises(RuntimeError, match="no longer match"):
+        pickle.loads(payload)  # noqa: S301
+
+
+def test_unpickle_raises_when_font_added(tmp_path: Path) -> None:
+    shutil.copy("tests/fonts/lato/Lato-Regular.ttf", tmp_path)
+
+    dataset = GlyphDataset(root=tmp_path, codepoints=range(0x41, 0x44))
+    payload = pickle.dumps(dataset)
+
+    shutil.copy("tests/fonts/ubuntu/Ubuntu-Regular.ttf", tmp_path)
+
+    with pytest.raises(RuntimeError, match="no longer match"):
+        pickle.loads(payload)  # noqa: S301
+
+
+def test_unpickle_succeeds_when_fonts_unchanged(tmp_path: Path) -> None:
+    shutil.copy("tests/fonts/lato/Lato-Regular.ttf", tmp_path)
+
+    dataset = GlyphDataset(root=tmp_path, codepoints=range(0x41, 0x44))
+    restored = pickle.loads(pickle.dumps(dataset))  # noqa: S301
+
+    assert len(restored) == len(dataset)
+    assert torch.equal(restored.targets, dataset.targets)
+
+
 def test_glyph_dataset_getitem_survives_spawn_pickle_roundtrip() -> None:
     dataset = GlyphDataset(
         root="tests/fonts",

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -66,6 +66,7 @@ class GlyphDatasetBackend:
     sample_count: int
     style_class_count: int
     content_class_count: int
+    fingerprint: int
 
     def content_metadata_rows(self) -> list[tuple[str, str, int]]: ...
     def style_metadata_rows(self, root: str) -> list[tuple[str, str]]: ...

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -7,6 +7,11 @@ Notes:
     is still in use, results are undefined and may include incorrect samples
     or runtime errors.
 
+    Unpickling (including ``DataLoader`` worker spawn) rebuilds the index from
+    the files on disk and verifies it against the pickled structure
+    fingerprint, raising ``RuntimeError`` instead of silently misaligning
+    labels when the files changed in between.
+
 Examples:
     Iterate glyph samples from a directory of fonts::
 
@@ -242,6 +247,7 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
             self.codepoints,
             self.patterns,
         )
+        self._fingerprint: int = self._backend.fingerprint
 
     def __repr__(self) -> str:
         """Return a human-readable summary of this dataset.
@@ -341,14 +347,36 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         return state
 
     def __setstate__(self, state: dict[str, object]) -> None:
-        """Restore state and recreate the native backend after unpickling."""
+        """Restore state and recreate the native backend after unpickling.
+
+        The backend is rebuilt by re-scanning ``root``, so the restored index
+        is verified against the pickled structure fingerprint. The fingerprint
+        covers everything that determines the sample-to-label mapping: font
+        file order, paths, face indices, code points, and variation instance
+        counts.
+
+        Raises:
+            RuntimeError: If the font files under ``root`` no longer produce
+                the same index structure as when the dataset was pickled,
+                which would silently misalign ``targets`` and class indices.
+
+        """
         self.__dict__.update(state)
         self._validate_root_dir(self.root)
-        self._backend = _torchfont.GlyphDatasetBackend(
+        backend = _torchfont.GlyphDatasetBackend(
             str(self.root),
             self.codepoints,
             self.patterns,
         )
+        if backend.fingerprint != self._fingerprint:
+            msg = (
+                f"font files under {str(self.root)!r} no longer match the "
+                "dataset this object was pickled from; sample indices and "
+                "targets would be inconsistent. Recreate the dataset from "
+                "the current files."
+            )
+            raise RuntimeError(msg)
+        self._backend = backend
 
     @staticmethod
     def _validate_root_dir(root: Path) -> None:


### PR DESCRIPTION
## Summary

`GlyphDataset.__setstate__` rebuilds the native backend by re-scanning `root`, so font files changing between pickling and unpickling (e.g. before a `DataLoader` worker spawns) silently shifted `style_idx` / `content_idx` and made `targets` inconsistent — the worst failure mode for training labels.

This PR adds a structure fingerprint that is computed at construction, stored in the pickled state, and verified after reconstruction. On mismatch, unpickling raises `RuntimeError` instead of returning a silently misaligned dataset.

## Design

The fingerprint hashes exactly the data that determines the sample → (style, content) mapping: entry order, paths, face indices, code point lists, and variation instance counts. Fingerprint equality therefore guarantees label-structure identity. Outline-only edits are deliberately not detected: they do not shift labels, and the files on disk remain the source of truth (local-first).

The hash is a hand-rolled FNV-1a 64-bit (~10 lines, no new dependencies). Unlike `std::hash::DefaultHasher`, it is stable across processes and library versions, which pickle comparison requires.

Alternatives measured on a full Google Fonts checkout (3,868 files / 2.45 GB / 13.7M samples):

| Approach | Cost | Verdict |
|---|---|---|
| Structural hash (this PR) | within noise of the 0.75s rebuild | no extra I/O, no false positives |
| stat-based (size, mtime) | +0.05s | false positives after `git checkout` rewrites mtimes |
| Full content hash | +2.4s warm cache | 3x the rebuild cost, paid per worker spawn |

## Verification

- 202 tests pass, including 3 new ones (font removed / font added / unchanged round-trip)
- Fingerprint deterministic across 4 independent processes on the Google Fonts checkout
- Full-checkout pickle round-trip restores in 0.74s with verification
- `DataLoader(num_workers=2)` worker spawn works
- Deleting one font from a scratch copy between dump and load raises the new `RuntimeError`

## Breaking change

Pickles created by older torchfont versions lack `_fingerprint` and can no longer be restored. This follows the same policy as #270 (architecture over backward compatibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)