### PR TITLE
[codex] validate quad to cubic input shapes

### DIFF
--- a/src/py/transforms.rs
+++ b/src/py/transforms.rs
@@ -14,6 +14,7 @@ pub(crate) fn quad_to_cubic<'py>(
 ) -> PyResult<()> {
     let t = types.as_slice_mut()?;
     let c = coords.as_slice_mut()?;
+    ensure_flat_coords_len(t.len(), c.len())?;
     ensure_element_types(t)?;
     curves::quad_to_cubic::quad_to_cubic(t, c, seq_len);
     Ok(())

--- a/tests/transforms/curves/test_quad_to_cubic.py
+++ b/tests/transforms/curves/test_quad_to_cubic.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torchfont.io import ElementType
@@ -85,6 +86,21 @@ def test_quad_to_cubic_returns_inputs_when_no_quadratic_segments() -> None:
     assert out_coords is coords
     assert out_types.device.type == "cpu"
     assert out_coords.device.type == "cpu"
+
+
+def test_quad_to_cubic_rejects_mismatched_coords() -> None:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO.value,
+            ElementType.QUAD_TO.value,
+            ElementType.END.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(2, 6, dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="coords length"):
+        quad_to_cubic(types, coords)
 
 
 def test_quad_to_cubic_supports_extra_leading_dimensions() -> None:


### PR DESCRIPTION
## Summary

- validate flattened coordinate length before native `quad_to_cubic` conversion
- add regression coverage for mismatched `types` and `coords`

## Root cause

Unlike the other native transforms, `quad_to_cubic` entered its indexing loop without checking that each type had six coordinate values. A mismatch caused an out-of-bounds Rust panic to surface as `PanicException`.

## Impact

Invalid input now raises a regular `ValueError` at the Python/Rust boundary.

## Validation

- `mise run check`
- `mise run test` (`203 passed, 6 skipped`)
