### PR TITLE
[codex] support non-UTF-8 font paths

### DIFF
--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::font::FontEntry;
+use std::path::PathBuf;
 
 pub(crate) struct DatasetIndex {
     pub(crate) sample_offsets: Vec<usize>,
@@ -16,7 +17,7 @@ impl DatasetIndex {
 }
 
 pub(crate) fn load_entries_and_index(
-    files: Vec<String>,
+    files: Vec<PathBuf>,
     filter: Option<&[u32]>,
 ) -> Result<(Vec<FontEntry>, DatasetIndex), Error> {
     let mut entries = Vec::new();
@@ -58,7 +59,7 @@ pub(crate) fn structure_fingerprint(entries: &[FontEntry]) -> u64 {
     let mut hash = Fnv1a::new();
     hash.write_u64(entries.len() as u64);
     for entry in entries {
-        let path = entry.path().as_bytes();
+        let path = entry.path().as_os_str().as_encoded_bytes();
         hash.write_u64(path.len() as u64);
         hash.write(path);
         hash.write_u32(entry.face_index());

--- a/src/dataset/io.rs
+++ b/src/dataset/io.rs
@@ -16,7 +16,7 @@ pub(crate) fn canonicalize_root(root: &str) -> Result<PathBuf, Error> {
 pub(crate) fn discover_font_files(
     root: &Path,
     patterns: Option<&[String]>,
-) -> Result<Vec<String>, Error> {
+) -> Result<Vec<PathBuf>, Error> {
     let mut builder = WalkBuilder::new(root);
     builder.standard_filters(false);
     builder.filter_entry(|entry| !is_vcs_metadata_dir(entry));
@@ -33,7 +33,7 @@ pub(crate) fn discover_font_files(
         let path = entry.path();
 
         if entry.file_type().is_some_and(|ft| ft.is_file()) && has_font_extension(path) {
-            files.push(path.to_string_lossy().into_owned());
+            files.push(path.to_path_buf());
         }
     }
 

--- a/src/font/entry.rs
+++ b/src/font/entry.rs
@@ -1,4 +1,4 @@
-use std::{fs, sync::Arc};
+use std::{fs, path::Path, sync::Arc};
 
 use memmap2::Mmap;
 use skrifa::raw::types::NameId;
@@ -30,10 +30,10 @@ pub(crate) struct FontEntry {
 }
 
 impl FontEntry {
-    pub(crate) fn load_faces(path: &str, filter: Option<&[u32]>) -> Result<Vec<Self>, Error> {
+    pub(crate) fn load_faces(path: &Path, filter: Option<&[u32]>) -> Result<Vec<Self>, Error> {
         let mapped = Arc::new(map_font(path)?);
         let parsed = FileRef::new(&mapped[..])
-            .map_err(|err| Error::Parse(format!("failed to parse '{path}': {err}")))?;
+            .map_err(|err| Error::Parse(format!("failed to parse '{}': {err}", path.display())))?;
 
         let entries = parsed
             .fonts()
@@ -41,7 +41,8 @@ impl FontEntry {
             .map(|(face_index, face)| {
                 let font = face.map_err(|err| {
                     Error::Parse(format!(
-                        "failed to parse '{path}' (face {face_index}): {err}"
+                        "failed to parse '{}' (face {face_index}): {err}",
+                        path.display()
                     ))
                 })?;
                 Self::from_face(path, face_index as u32, Arc::clone(&mapped), &font, filter)
@@ -50,7 +51,8 @@ impl FontEntry {
 
         if entries.is_empty() {
             return Err(Error::Parse(format!(
-                "font file '{path}' does not contain any fonts"
+                "font file '{}' does not contain any fonts",
+                path.display()
             )));
         }
         Ok(entries)
@@ -79,7 +81,7 @@ impl FontEntry {
         !self.locations.is_empty()
     }
 
-    pub(crate) fn path(&self) -> &str {
+    pub(crate) fn path(&self) -> &Path {
         self.reader.path()
     }
 
@@ -107,7 +109,7 @@ impl FontEntry {
     }
 
     fn from_face(
-        base_path: &str,
+        base_path: &Path,
         face_index: u32,
         data: Arc<Mmap>,
         font: &skrifa::FontRef<'_>,
@@ -143,7 +145,8 @@ impl FontEntry {
                     debug_assert_eq!(
                         axis_tags.len(),
                         inst.user_coords().count(),
-                        "font '{base_path}' (face {face_index}) reported mismatched axis metadata",
+                        "font '{}' (face {face_index}) reported mismatched axis metadata",
+                        base_path.display(),
                     );
                     axis_tags.iter().cloned().zip(inst.user_coords()).collect()
                 })
@@ -155,7 +158,7 @@ impl FontEntry {
                 codepoints,
                 glyph_ids,
             },
-            reader: GlyphReader::new(base_path.to_string(), face_index, data),
+            reader: GlyphReader::new(base_path.to_path_buf(), face_index, data),
             head,
             hhea,
             os2,
@@ -174,7 +177,7 @@ impl FontEntry {
             .map_err(|_| {
                 Error::OutOfRange(format!(
                     "codepoint U+{codepoint:04X} missing from '{}'",
-                    self.reader.path()
+                    self.reader.path().display()
                 ))
             })
     }
@@ -182,13 +185,14 @@ impl FontEntry {
 
 fn parse_font_tables(
     font: &skrifa::FontRef<'_>,
-    path: &str,
+    path: &Path,
     face_index: u32,
 ) -> Result<(Head, Hhea, Os2, Post, Maxp, Name), Error> {
     let table_err = |table: &'static str| {
         move |err: skrifa::raw::ReadError| {
             Error::Parse(format!(
-                "font '{path}' (face {face_index}) '{table}' table error: {err}"
+                "font '{}' (face {face_index}) '{table}' table error: {err}",
+                path.display()
             ))
         }
     };
@@ -326,10 +330,10 @@ fn parse_font_tables(
     Ok((head, hhea, os2, post, maxp, name))
 }
 
-fn map_font(path: &str) -> Result<Mmap, Error> {
-    let file =
-        fs::File::open(path).map_err(|err| Error::Io(format!("failed to open '{path}': {err}")))?;
+fn map_font(path: &Path) -> Result<Mmap, Error> {
+    let file = fs::File::open(path)
+        .map_err(|err| Error::Io(format!("failed to open '{}': {err}", path.display())))?;
     let mmap = unsafe { Mmap::map(&file) }
-        .map_err(|err| Error::Io(format!("failed to map '{path}': {err}")))?;
+        .map_err(|err| Error::Io(format!("failed to map '{}': {err}", path.display())))?;
     Ok(mmap)
 }

--- a/src/font/reader.rs
+++ b/src/font/reader.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use memmap2::Mmap;
 use skrifa::{
@@ -15,13 +18,13 @@ use crate::{
 };
 
 pub(super) struct GlyphReader {
-    path: String,
+    path: PathBuf,
     face_index: u32,
     data: Arc<Mmap>,
 }
 
 impl GlyphReader {
-    pub(super) fn new(path: String, face_index: u32, data: Arc<Mmap>) -> Self {
+    pub(super) fn new(path: PathBuf, face_index: u32, data: Arc<Mmap>) -> Self {
         Self {
             path,
             face_index,
@@ -29,7 +32,7 @@ impl GlyphReader {
         }
     }
 
-    pub(super) fn path(&self) -> &str {
+    pub(super) fn path(&self) -> &Path {
         &self.path
     }
 
@@ -49,7 +52,7 @@ impl GlyphReader {
                 Error::Parse(format!(
                     "glyph id {} missing from '{}'",
                     glyph_id.to_u32(),
-                    self.path
+                    self.path.display()
                 ))
             })?;
 
@@ -122,7 +125,8 @@ impl GlyphReader {
         let face_index = self.face_index;
         let font = skrifa::FontRef::from_index(&self.data[..], face_index).map_err(|err| {
             Error::Parse(format!(
-                "failed to parse '{path}' (face {face_index}): {err}"
+                "failed to parse '{}' (face {face_index}): {err}",
+                path.display()
             ))
         })?;
         f(font)
@@ -139,7 +143,7 @@ impl GlyphReader {
                 .ok_or_else(|| {
                     Error::OutOfRange(format!(
                         "instance index {idx} out of range for '{}'",
-                        self.path
+                        self.path.display()
                     ))
                 })
                 .map(LocationRef::from)

--- a/src/py/dataset.rs
+++ b/src/py/dataset.rs
@@ -107,7 +107,7 @@ impl GlyphDatasetBackend {
             .map(|(name, path, face_idx, instance_idx)| {
                 Ok((
                     name,
-                    style_label_id(&self.root, Path::new(&path), face_idx, instance_idx)?,
+                    style_label_id(&self.root, &path, face_idx, instance_idx)?,
                 ))
             })
             .collect()
@@ -292,7 +292,7 @@ impl GlyphDatasetBackend {
 }
 
 impl GlyphDatasetBackend {
-    fn style_rows(&self) -> Vec<(String, String, u32, Option<usize>)> {
+    fn style_rows(&self) -> Vec<(String, PathBuf, u32, Option<usize>)> {
         let mut rows = Vec::new();
         for entry in self.entries.iter() {
             let path = entry.path().to_owned();
@@ -350,7 +350,7 @@ impl GlyphDatasetBackend {
         debug_assert!(
             cp_count > 0,
             "font '{}' has no indexed code points",
-            entry.path()
+            entry.path().display()
         );
 
         let inst_start = self.index.inst_offsets[font_idx];
@@ -359,7 +359,7 @@ impl GlyphDatasetBackend {
             inst_idx < entry.instance_count(),
             "instance index {} out of range for font '{}'",
             inst_idx,
-            entry.path()
+            entry.path().display()
         );
 
         let cp_offset = sample_idx % cp_count;
@@ -387,7 +387,9 @@ fn style_label_id(
     })?;
     let quoted_path = relative_path
         .components()
-        .map(|component| urlencoding::encode(&component.as_os_str().to_string_lossy()).into_owned())
+        .map(|component| {
+            urlencoding::encode_binary(component.as_os_str().as_encoded_bytes()).into_owned()
+        })
         .collect::<Vec<_>>()
         .join("/");
     let instance_value = instance_idx.map_or_else(|| "static".to_string(), |idx| idx.to_string());

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import multiprocessing as mp
+import os
 import pickle
 import shutil
 import subprocess
@@ -471,6 +472,22 @@ def test_glyph_dataset_discovers_fonts_in_hidden_directories(
             "style:path=.fonts/Lato-Regular.ttf;face=0;instance=static"
         )
         for label in dataset.metadata.styles
+    )
+
+
+def test_glyph_dataset_supports_non_utf8_font_paths(tmp_path: Path) -> None:
+    if os.name == "nt":
+        pytest.skip("Windows paths are Unicode")
+
+    source = Path("tests/fonts/lato/Lato-Regular.ttf").resolve()
+    font_path = tmp_path / os.fsdecode(b"Lato-\xff.ttf")
+    shutil.copy(source, font_path)
+
+    dataset = GlyphDataset(root=tmp_path, codepoints=[0x41])
+
+    assert len(dataset) == 1
+    assert dataset.metadata.styles[0].label_id.startswith(
+        "style:path=Lato-%FF.ttf;face=0;instance=static"
     )
 
 


### PR DESCRIPTION
## Summary

- keep discovered font paths as `PathBuf` throughout indexing and glyph reading
- hash the native OS path bytes in dataset fingerprints
- percent-encode native path bytes in stable style label IDs
- add Unix regression coverage for a non-UTF-8 font filename

## Root cause

Font discovery converted paths with `to_string_lossy()` before opening them. On Unix, replacement characters changed non-UTF-8 filenames into paths that did not exist.

## Impact

Datasets can index and read fonts whose filenames are not valid UTF-8, while existing UTF-8 metadata paths remain unchanged.

## Validation

- `mise run check`
- `mise run test` (`203 passed, 6 skipped`)
