### PR TITLE
[codex] Fix geometric transforms on CUDA

### DIFF
--- a/tests/transforms/geometric/test_affine.py
+++ b/tests/transforms/geometric/test_affine.py
@@ -104,3 +104,15 @@ def test_affine_non_positive_scale_raises(
     types, coords = simple_outline
     with pytest.raises(ValueError, match="scale must be positive"):
         affine(types, coords, scale=0.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_affine_preserves_cuda_device(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in simple_outline)
+
+    out_types, out_coords = affine(types, coords, angle=15.0)
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/tests/transforms/geometric/test_horizontal_flip.py
+++ b/tests/transforms/geometric/test_horizontal_flip.py
@@ -118,3 +118,15 @@ def test_horizontal_flip_does_not_reverse_open_subpaths(
     assert torch.equal(out_types, types)
     assert out[0, 4].item() == pytest.approx(1.0)
     assert out[1, 4].item() == pytest.approx(2.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_horizontal_flip_preserves_cuda_device(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in simple_outline)
+
+    out_types, out_coords = horizontal_flip(types, coords)
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/tests/transforms/geometric/test_vertical_flip.py
+++ b/tests/transforms/geometric/test_vertical_flip.py
@@ -69,3 +69,15 @@ def test_vertical_flip_can_leave_reflected_winding(
     types, coords = simple_outline
     out_types, out = vertical_flip(types, coords, preserve_winding=False)
     assert _signed_area(out_types, out) == pytest.approx(-_signed_area(types, coords))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_vertical_flip_preserves_cuda_device(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in simple_outline)
+
+    out_types, out_coords = vertical_flip(types, coords)
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -74,17 +74,18 @@ def _rotation_scale_shear_matrix(
     angle_deg: float,
     scale: float,
     shear_deg: float,
+    *,
+    like: Tensor,
 ) -> Tensor:
     """Return a 2x2 matrix for scale * x-shear * rotation (all applied in place)."""
     a = math.radians(angle_deg)
     s = math.radians(shear_deg)
     cos_a, sin_a, tan_s = math.cos(a), math.sin(a), math.tan(s)
-    return torch.tensor(
+    return like.new_tensor(
         [
             [scale * (cos_a + sin_a * tan_s), scale * (-sin_a + cos_a * tan_s)],
             [scale * sin_a, scale * cos_a],
         ],
-        dtype=torch.float32,
     )
 
 
@@ -125,7 +126,7 @@ def horizontal_flip(
         ``preserve_winding`` is enabled.
 
     """
-    matrix = torch.tensor([[-1.0, 0.0], [0.0, 1.0]])
+    matrix = coords.new_tensor([[-1.0, 0.0], [0.0, 1.0]])
     center = _bbox_center(types, coords)
     out_coords = _apply_matrix(types, coords, matrix, center, (0.0, 0.0))
     if preserve_winding:
@@ -153,7 +154,7 @@ def vertical_flip(
         ``preserve_winding`` is enabled.
 
     """
-    matrix = torch.tensor([[1.0, 0.0], [0.0, -1.0]])
+    matrix = coords.new_tensor([[1.0, 0.0], [0.0, -1.0]])
     center = _bbox_center(types, coords)
     out_coords = _apply_matrix(types, coords, matrix, center, (0.0, 0.0))
     if preserve_winding:
@@ -194,7 +195,7 @@ def affine(
     if scale <= 0:
         msg = "scale must be positive"
         raise ValueError(msg)
-    matrix = _rotation_scale_shear_matrix(angle, scale, shear)
+    matrix = _rotation_scale_shear_matrix(angle, scale, shear, like=coords)
     center = _bbox_center(types, coords)
     return types, _apply_matrix(types, coords, matrix, center, translate)
 


### PR DESCRIPTION
## Summary

- create affine and reflection matrices on the input coordinate tensor device
- preserve the existing coordinate dtype
- add CUDA regression coverage for affine, horizontal flip, and vertical flip

## Root cause

The transform matrices were created with `torch.tensor`, which always placed them on CPU. Matrix multiplication then failed when outline coordinates lived on CUDA.

## Validation

- `mise run python-check`
- `uv run pytest tests/transforms/geometric/test_affine.py tests/transforms/geometric/test_horizontal_flip.py tests/transforms/geometric/test_vertical_flip.py` (26 passed, 3 CUDA tests skipped on this CPU runner)