### PR TITLE
[codex] Split Rust and Python test tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Install skia-safe native dependencies
+        run: sudo sh .github/scripts/install-linux-deps.sh host
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo check --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo check --all-targets --all-features
+      - run: cargo test --all-targets --all-features
 
   test:
     name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ mise run test
 ```
 
 `mise run check` covers Rust formatting, clippy, cargo check, Ruff, and `ty`.
-`mise run test` builds the Rust extension with `maturin develop` before running
-pytest.
+`mise run test` runs both `rust-test` and `python-test`; the Python task builds
+the Rust extension with `maturin develop` before running pytest.
 
 ## Documentation
 

--- a/mise.toml
+++ b/mise.toml
@@ -73,9 +73,16 @@ run = [
   "uv run maturin develop --release",
 ]
 
-[tasks.test]
+[tasks.rust-test]
+sources = ["Cargo.toml", "Cargo.lock", "src/**/*.rs"]
+run = "cargo test --all-targets --all-features"
+
+[tasks.python-test]
 depends = ["build"]
 run = "uv run pytest tests"
+
+[tasks.test]
+depends = ["rust-test", "python-test"]
 
 [tasks.test-google-fonts]
 depends = ["build", "data-sync"]


### PR DESCRIPTION
## Summary

- rename the existing pytest task to `python-test`
- add a `rust-test` task that runs all Rust test targets and features
- make the aggregate `test` task depend on both language-specific tasks
- run Rust unit tests in CI
- document the new task structure

## Why

Rust unit tests existed in the crate but were outside both the standard `mise run test` workflow and CI, so regressions in Rust-only behavior could pass the repository checks.

## Validation

- `mise run test`
  - Rust: 2 passed
  - Python: 206 passed, 6 skipped