### PR TITLE
[codex] Validate random flip probabilities

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -254,7 +254,7 @@ types, coords = random_horizontal_flip(types, coords, p=0.5)
 
 Randomly applies `horizontal_flip` with probability `p`.
 
-- `p`: flip probability (default: `0.5`)
+- `p`: flip probability in the inclusive range `[0.0, 1.0]` (default: `0.5`)
 - `preserve_winding`: preserve closed subpath winding after reflection (default: `True`)
 - `generator`: optional `torch.Generator` for reproducibility
 
@@ -275,7 +275,7 @@ types, coords = random_vertical_flip(types, coords, p=0.5)
 
 Randomly applies `vertical_flip` with probability `p`.
 
-- `p`: flip probability (default: `0.5`)
+- `p`: flip probability in the inclusive range `[0.0, 1.0]` (default: `0.5`)
 - `preserve_winding`: preserve closed subpath winding after reflection (default: `True`)
 - `generator`: optional `torch.Generator` for reproducibility
 

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -253,7 +253,7 @@ types, coords = random_horizontal_flip(types, coords, p=0.5)
 
 確率 `p` で `horizontal_flip` をランダムに適用します。
 
-- `p`: 反転確率（デフォルト: `0.5`）
+- `p`: `[0.0, 1.0]` の範囲の反転確率（デフォルト: `0.5`）
 - `preserve_winding`: 反転後も閉じた subpath の巻き順を保持します（デフォルト: `True`）
 - `generator`: 再現性のためのオプション `torch.Generator`
 
@@ -274,7 +274,7 @@ types, coords = random_vertical_flip(types, coords, p=0.5)
 
 確率 `p` で `vertical_flip` をランダムに適用します。
 
-- `p`: 反転確率（デフォルト: `0.5`）
+- `p`: `[0.0, 1.0]` の範囲の反転確率（デフォルト: `0.5`）
 - `preserve_winding`: 反転後も閉じた subpath の巻き順を保持します（デフォルト: `True`）
 - `generator`: 再現性のためのオプション `torch.Generator`
 

--- a/tests/transforms/geometric/test_random_horizontal_flip.py
+++ b/tests/transforms/geometric/test_random_horizontal_flip.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torchfont.transforms import random_horizontal_flip
@@ -29,3 +30,14 @@ def test_random_horizontal_flip_deterministic_with_generator(
     _, out1 = random_horizontal_flip(types, coords, generator=g1)
     _, out2 = random_horizontal_flip(types, coords, generator=g2)
     assert torch.equal(out1, out2)
+
+
+@pytest.mark.parametrize("p", [-0.1, 1.1, float("nan"), float("inf")])
+def test_random_horizontal_flip_rejects_invalid_probability(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    p: float,
+) -> None:
+    types, coords = simple_outline
+
+    with pytest.raises(ValueError, match="p must be between 0 and 1"):
+        random_horizontal_flip(types, coords, p=p)

--- a/tests/transforms/geometric/test_random_vertical_flip.py
+++ b/tests/transforms/geometric/test_random_vertical_flip.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torchfont.transforms import random_vertical_flip
@@ -24,3 +25,14 @@ def test_random_vertical_flip_skips_with_p0(
     types, coords = simple_outline
     _, out = random_vertical_flip(types, coords, p=0.0)
     assert torch.equal(out, coords)
+
+
+@pytest.mark.parametrize("p", [-0.1, 1.1, float("nan"), float("inf")])
+def test_random_vertical_flip_rejects_invalid_probability(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    p: float,
+) -> None:
+    types, coords = simple_outline
+
+    with pytest.raises(ValueError, match="p must be between 0 and 1"):
+        random_vertical_flip(types, coords, p=p)

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -221,6 +221,7 @@ def random_horizontal_flip(
         Either the original ``(types, coords)`` unchanged, or a flipped copy.
 
     """
+    _validate_probability(p)
     if torch.rand(1, generator=generator).item() < p:
         return horizontal_flip(types, coords, preserve_winding=preserve_winding)
     return types, coords
@@ -248,9 +249,16 @@ def random_vertical_flip(
         Either the original ``(types, coords)`` unchanged, or a flipped copy.
 
     """
+    _validate_probability(p)
     if torch.rand(1, generator=generator).item() < p:
         return vertical_flip(types, coords, preserve_winding=preserve_winding)
     return types, coords
+
+
+def _validate_probability(p: float) -> None:
+    if not 0.0 <= p <= 1.0:
+        msg = "p must be between 0 and 1"
+        raise ValueError(msg)
 
 
 def _sym_range(value: float | tuple[float, float]) -> tuple[float, float]:


### PR DESCRIPTION
## Summary

- reject random flip probabilities outside the inclusive `[0.0, 1.0]` range
- reject `NaN` and infinite probabilities
- cover both horizontal and vertical random flips
- document the accepted range in English and Japanese

## Root cause

The transforms compared sampled random values directly with `p`, so invalid values silently became always-on or always-off behavior instead of reporting configuration errors.

## Validation

- `mise run python-check`
- `uv run pytest tests/transforms/geometric/test_random_horizontal_flip.py tests/transforms/geometric/test_random_vertical_flip.py` (13 passed)
- `mise run docs-build`