### PR TITLE
[codex] Clarify post metadata units

### DIFF
--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -92,6 +92,10 @@ sample = dataset[idx]
 | `sample.codepoint`   | `int`               | —              |
 | `sample.glyph_name`  | `str`               | —              |
 
+`sample.post` stores `(italic_angle, is_fixed_pitch, underline_position,
+underline_thickness)`. The italic angle is in degrees, `is_fixed_pitch` is
+`0.0` or `1.0`, and the two underline metrics are UPM-normalised.
+
 Without `transform`, `sample` is a `GlyphSample`. With `transform`, the
 dataset item type is inferred from the transform return type.
 

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -92,6 +92,10 @@ sample = dataset[idx]
 | `sample.codepoint`   | `int`               | —              |
 | `sample.glyph_name`  | `str`               | —              |
 
+`sample.post` は `(italic_angle, is_fixed_pitch, underline_position,
+underline_thickness)` を保持します。`italic_angle` の単位は度、
+`is_fixed_pitch` は `0.0` または `1.0`、下線の2値は UPM 正規化済みです。
+
 `transform` なしでは `sample` 自体の型は `GlyphSample` です。`transform`
 ありでは、dataset item の型は transform の返り値型から推論されます。
 

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -113,7 +113,8 @@ class GlyphSample:
             ``hhea.descender`` are **negative**.
         post (Tensor): ``post`` table fields (4,): ``italic_angle``,
             ``is_fixed_pitch`` (0.0 or 1.0), ``underline_position``,
-            ``underline_thickness``. UPM-normalised.
+            ``underline_thickness``. ``italic_angle`` is stored in degrees;
+            underline metrics are UPM-normalised.
         maxp (Tensor): ``maxp`` table fields (14,) starting with
             ``num_glyphs``. TrueType-only fields are ``nan`` for CFF fonts.
         hmtx (Tensor): ``advance_width``, ``lsb`` (2,). UPM-normalised.


### PR DESCRIPTION
## Summary

- clarify the field order and units of `GlyphSample.post`
- state that `italic_angle` is measured in degrees
- distinguish the boolean-like `is_fixed_pitch` value from UPM-normalised underline metrics
- keep the English and Japanese dataset references aligned

## Root cause

The existing docstring said the whole `post` tensor was UPM-normalised even though only the underline position and thickness are length metrics.

## Validation

- `mise run python-check`
- `mise run docs-build`