### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install skia-safe native dependencies
-        run: sudo sh .github/scripts/install-linux-deps.sh host
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: "true"
-      - run: uv run ruff format --diff
-      - run: uv run ruff check
-      - run: uv run ty check
+      - run: uvx ruff format --check
+      - run: uvx ruff check
 
   rust-static-check:
     name: Rust static check
@@ -87,6 +84,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: "true"
+      - run: uv run --locked ty check
       - run: >-
           uv run
           --isolated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   python-static-check:
     name: Python static check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: "true"
-      - run: uv add "torch==${{ matrix.torch-version }}"
-      - run: uv run pytest tests
+      - run: >-
+          uv run
+          --isolated
+          --locked
+          --index https://download.pytorch.org/whl/cpu
+          --with "torch==${{ matrix.torch-version }}"
+          pytest tests
 
   linux:
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
-  python-static-check:
-    name: Python static check
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -53,12 +53,6 @@ jobs:
           enable-cache: "true"
       - run: uvx ruff format --check
       - run: uvx ruff check
-
-  rust-static-check:
-    name: Rust static check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo check --all-targets --all-features
@@ -66,7 +60,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: [python-static-check, rust-static-check]
+    needs: check
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install skia-safe native dependencies
         run: sudo sh .github/scripts/install-linux-deps.sh host
+      - run: cargo test --all-targets --all-features
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,37 +59,46 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: check
     strategy:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.10"
+          - environment: development
+            runner: ubuntu-latest
+          - environment: minimum
+            runner: ubuntu-latest
+            python-version: "3.10"
             torch-version: "2.3.*"
-          - python-version: "3.14"
-            torch-version: "2.10.*"
+          - environment: windows
+            runner: windows-latest
     steps:
       - uses: actions/checkout@v6
       - name: Install skia-safe native dependencies
+        if: runner.os == 'Linux'
         run: sudo sh .github/scripts/install-linux-deps.sh host
-      - run: cargo test --all-targets --all-features
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ matrix.python-version }}
           enable-cache: "true"
-      - run: uv run --locked ty check
-      - run: >-
+      - run: cargo test --all-targets --all-features
+      - if: matrix.environment == 'development'
+        run: uv run --locked ty check
+      - if: matrix.environment != 'minimum'
+        run: uv run --locked pytest tests
+      - if: matrix.environment == 'minimum'
+        run: >-
           uv run
           --isolated
           --locked
+          --python ${{ matrix.python-version }}
           --index https://download.pytorch.org/whl/cpu
           --with "torch==${{ matrix.torch-version }}"
           pytest tests
 
   linux:
     runs-on: ${{ matrix.platform.runner }}
-    needs: test
+    needs: check
     strategy:
       matrix:
         platform:
@@ -126,7 +135,7 @@ jobs:
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
-    needs: test
+    needs: check
     strategy:
       matrix:
         platform:
@@ -166,7 +175,7 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
-    needs: test
+    needs: check
     strategy:
       matrix:
         platform:
@@ -202,7 +211,7 @@ jobs:
 
   sdist:
     runs-on: ubuntu-latest
-    needs: test
+    needs: check
     steps:
       - uses: actions/checkout@v6
       - name: Build sdist
@@ -220,7 +229,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, windows, macos, sdist]
+    needs: [test, linux, windows, macos, sdist]
     environment: pypi
     permissions:
       id-token: write

--- a/mise.toml
+++ b/mise.toml
@@ -42,6 +42,7 @@ run = [
   "cargo fmt --all -- --check",
   "cargo clippy --all-targets --all-features -- -D warnings",
   "cargo check --all-targets --all-features",
+  "cargo test --all-targets --all-features",
 ]
 
 [tasks.python-check]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ build-backend = "maturin"
 dev = [
     "fonttools>=4.63.0",
     "lightning>=2.6.0",
-    "maturin[patchelf]>=1.10.2",
+    "maturin[patchelf]>=1.10.2; sys_platform == 'linux'",
+    "maturin>=1.10.2; sys_platform != 'linux'",
     "numpy>=2.2.6",
     "pytest>=8.4.2",
     "pytest-benchmark>=5.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.11' and sys_platform == 'linux'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
     "python_full_version >= '3.11' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
@@ -565,7 +567,7 @@ wheels = [
 
 [package.optional-dependencies]
 patchelf = [
-    { name = "patchelf" },
+    { name = "patchelf", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -720,7 +722,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
@@ -733,7 +736,8 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.11' and sys_platform == 'linux'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
     "python_full_version >= '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
@@ -746,7 +750,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
@@ -812,7 +817,8 @@ name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.11' and sys_platform == 'linux'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
     "python_full_version >= '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
@@ -905,7 +911,6 @@ version = "0.17.2.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/a3/fdd3fa938c864aa2f11dd0b7f08befeda983d2dcdee44da493c6977a653f/patchelf-0.17.2.4.tar.gz", hash = "sha256:970ee5cd8af33e5ea2099510b2f9013fa1b8d5cd763bf3fd3961281c18101a09", size = 149629, upload-time = "2025-07-23T21:16:32.071Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/a7/8c4f86c78ec03db954d05fd9c57a114cc3a172a2d3e4a8b949cd5ff89471/patchelf-0.17.2.4-py3-none-macosx_10_9_universal2.whl", hash = "sha256:343bb1b94e959f9070ca9607453b04390e36bbaa33c88640b989cefad0aa049e", size = 184436, upload-time = "2025-07-23T21:16:20.578Z" },
     { url = "https://files.pythonhosted.org/packages/0b/6d/2e9f5483cdb352fab36b8076667b062b2d79cb09d2e3fd09b6fca5771cb6/patchelf-0.17.2.4-py3-none-manylinux1_i686.manylinux_2_5_i686.musllinux_1_1_i686.whl", hash = "sha256:09fd848d625a165fc7b7e07745508c24077129b019c4415a882938781d43adf8", size = 547318, upload-time = "2025-07-23T21:16:22.135Z" },
     { url = "https://files.pythonhosted.org/packages/7e/19/f7821ef31aab01fa7dc8ebe697ece88ec4f7a0fdd3155dab2dfee4b00e5c/patchelf-0.17.2.4-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:d9b35ebfada70c02679ad036407d9724ffe1255122ba4ac5e4be5868618a5689", size = 482846, upload-time = "2025-07-23T21:16:23.73Z" },
     { url = "https://files.pythonhosted.org/packages/d1/50/107fea848ecfd851d473b079cab79107487d72c4c3cdb25b9d2603a24ca2/patchelf-0.17.2.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:2931a1b5b85f3549661898af7bf746afbda7903c7c9a967cfc998a3563f84fad", size = 477811, upload-time = "2025-07-23T21:16:25.145Z" },
@@ -1338,8 +1343,10 @@ name = "torch"
 version = "2.11.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.11' and sys_platform == 'linux'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
     { name = "filelock", marker = "sys_platform != 'darwin'" },
@@ -1394,7 +1401,8 @@ dependencies = [
 dev = [
     { name = "fonttools" },
     { name = "lightning" },
-    { name = "maturin", extra = ["patchelf"] },
+    { name = "maturin" },
+    { name = "maturin", extra = ["patchelf"], marker = "sys_platform == 'linux'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
@@ -1413,7 +1421,8 @@ requires-dist = [{ name = "torch", specifier = ">=2.3.0", index = "https://downl
 dev = [
     { name = "fonttools", specifier = ">=4.63.0" },
     { name = "lightning", specifier = ">=2.6.0" },
-    { name = "maturin", extras = ["patchelf"], specifier = ">=1.10.2" },
+    { name = "maturin", marker = "sys_platform != 'linux'", specifier = ">=1.10.2" },
+    { name = "maturin", extras = ["patchelf"], marker = "sys_platform == 'linux'", specifier = ">=1.10.2" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },


### PR DESCRIPTION
## Summary

- Merge `python-static-check` and `rust-static-check` into a single `check` job (removes skia native dep install, switches to `uvx` for ruff)
- Add `concurrency` block to cancel superseded runs on same PR/branch
- Restructure `test` matrix: `development` (ubuntu, latest deps + ty check), `minimum` (ubuntu, Python 3.10 / torch 2.3 isolated), `windows` (windows-latest)
- Fix dependency mutation: replace `uv add "torch==..."` with `uv run --isolated --with "torch==..."` 
- Parallelize build jobs (`linux`/`windows`/`macos`/`sdist`) against `test` by making them depend on `check` directly; add explicit `test` to `release` needs to preserve the invariant
- Add `cargo test` to `mise` check task

## Test plan

- [ ] CI passes on this PR
- [ ] Verify `minimum` environment installs torch 2.3.* without mutating the lockfile
- [ ] Verify `windows` test environment runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)