### PR TITLE
[codex] strip padding after outline end

### DIFF
--- a/src/geom/encoding.rs
+++ b/src/geom/encoding.rs
@@ -5,6 +5,7 @@ use super::{Outline, PathElement, Point};
 pub(crate) enum DecodeError {
     CoordsLen,
     InvalidElementType { index: usize, value: i64 },
+    NonPaddingAfterEnd { index: usize, value: i64 },
 }
 
 impl<'a> TryFrom<(&'a [i64], &'a [f32])> for Outline {
@@ -13,7 +14,12 @@ impl<'a> TryFrom<(&'a [i64], &'a [f32])> for Outline {
         if coords.len() != types.len() * 6 {
             return Err(DecodeError::CoordsLen);
         }
-        if let Some((index, value)) = types
+
+        let outline_len = types
+            .iter()
+            .position(|&value| value == ElementType::End as i64)
+            .map_or(types.len(), |index| index + 1);
+        if let Some((index, value)) = types[..outline_len]
             .iter()
             .copied()
             .enumerate()
@@ -21,7 +27,22 @@ impl<'a> TryFrom<(&'a [i64], &'a [f32])> for Outline {
         {
             return Err(DecodeError::InvalidElementType { index, value });
         }
-        Ok(Self::decode(types, coords))
+        if let Some((offset, value)) = types[outline_len..]
+            .iter()
+            .copied()
+            .enumerate()
+            .find(|&(_, value)| value != 0)
+        {
+            return Err(DecodeError::NonPaddingAfterEnd {
+                index: outline_len + offset,
+                value,
+            });
+        }
+
+        Ok(Self::decode(
+            &types[..outline_len],
+            &coords[..outline_len * 6],
+        ))
     }
 }
 
@@ -152,4 +173,48 @@ fn push_endpoint(types: &mut Vec<i64>, coords: &mut Vec<f32>, ty: ElementType, p
 fn push(types: &mut Vec<i64>, coords: &mut Vec<f32>, ty: ElementType, values: [f32; 6]) {
     types.push(ty as i64);
     coords.extend_from_slice(&values);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_strips_padding_after_end() {
+        let types = [ElementType::MoveTo as i64, ElementType::End as i64, 0, 0];
+        let coords = [0.0; 24];
+
+        let outline = Outline::try_from((types.as_slice(), coords.as_slice())).unwrap();
+
+        assert_eq!(
+            outline.encode().0,
+            [ElementType::MoveTo as i64, ElementType::End as i64]
+        );
+    }
+
+    #[test]
+    fn try_from_rejects_padding_before_end() {
+        let types = [ElementType::MoveTo as i64, 0, ElementType::End as i64];
+        let coords = [0.0; 18];
+
+        assert!(matches!(
+            Outline::try_from((types.as_slice(), coords.as_slice())),
+            Err(DecodeError::InvalidElementType { index: 1, value: 0 })
+        ));
+    }
+
+    #[test]
+    fn try_from_rejects_non_padding_after_end() {
+        let types = [
+            ElementType::MoveTo as i64,
+            ElementType::End as i64,
+            ElementType::LineTo as i64,
+        ];
+        let coords = [0.0; 18];
+
+        assert!(matches!(
+            Outline::try_from((types.as_slice(), coords.as_slice())),
+            Err(DecodeError::NonPaddingAfterEnd { index: 2, value: 2 })
+        ));
+    }
 }

--- a/src/py/transforms.rs
+++ b/src/py/transforms.rs
@@ -16,6 +16,11 @@ fn decode(types: &[i64], coords: &[f32]) -> PyResult<Outline> {
                 "invalid element type {value} at index {index}"
             ))
         }
+        DecodeError::NonPaddingAfterEnd { index, value } => {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "only PAD elements may follow END; found {value} at index {index}"
+            ))
+        }
     })
 }
 

--- a/tests/transforms/curves/test_merge_curves.py
+++ b/tests/transforms/curves/test_merge_curves.py
@@ -241,3 +241,52 @@ def test_variable_length_transforms_reject_invalid_element_types(
 
     with pytest.raises(ValueError, match="invalid element type 99 at index 1"):
         transform(types, coords)
+
+
+@pytest.mark.parametrize("transform", [cubic_to_quad, merge_curves])
+def test_variable_length_transforms_strip_padding_after_end(
+    transform: Callable[
+        [torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]
+    ],
+) -> None:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO.value,
+            ElementType.LINE_TO.value,
+            ElementType.END.value,
+            ElementType.PAD.value,
+            ElementType.PAD.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(5, 6, dtype=torch.float32)
+    coords[1, 4:6] = torch.tensor([1.0, 1.0])
+
+    out_types, out_coords = transform(types, coords)
+
+    assert out_types.tolist() == [
+        ElementType.MOVE_TO.value,
+        ElementType.LINE_TO.value,
+        ElementType.END.value,
+    ]
+    assert out_coords.shape == (3, 6)
+
+
+@pytest.mark.parametrize("transform", [cubic_to_quad, merge_curves])
+def test_variable_length_transforms_reject_non_padding_after_end(
+    transform: Callable[
+        [torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]
+    ],
+) -> None:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO.value,
+            ElementType.END.value,
+            ElementType.LINE_TO.value,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(3, 6, dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="only PAD elements may follow END"):
+        transform(types, coords)


### PR DESCRIPTION
## Summary

- strip trailing `PAD` elements at the `Outline::try_from` boundary
- reject `PAD` before `END` and non-padding elements after `END`
- expose a clear Python error for malformed data after `END`
- add Rust and Python regression coverage

## Why

TorchFont padding belongs to the tensor representation, while the Rust `Outline` model does not represent `PAD`. The shared decoder validated the entire type buffer before stopping at `END`, so otherwise valid padded tensors were rejected. This change makes `TryFrom` perform the intended boundary normalization and keeps padding out of the Rust outline model.

## Impact

Transforms backed by Rust now accept tensors padded with zero-valued `PAD` entries after `END`. Malformed sequences remain rejected with an index-specific error. Transform outputs stay normalized and end with a single `END`.

## Validation

- `mise run check`
- `mise run test` (`216 passed, 9 skipped`)
