### PR TITLE
[codex] fix uniform subpath start randomization

### DIFF
--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -28,7 +28,13 @@ pub(crate) fn normalize_subpath_start_points(outline: &Outline) -> Outline {
 
 pub(crate) fn randomize_subpath_start_points(outline: &Outline, random_values: &[f32]) -> Outline {
     transform_start_points(outline, |subpath, subpath_idx| {
-        let node_count = subpath.elements().len() + 1;
+        let node_count = subpath.elements().len()
+            + usize::from(
+                subpath
+                    .elements()
+                    .last()
+                    .is_none_or(|element| element.end() != subpath.start()),
+            );
         let value = random_values[subpath_idx].clamp(0.0, 1.0 - f32::EPSILON);
         (value * node_count as f32) as usize
     })
@@ -200,6 +206,30 @@ mod tests {
         let outline = Outline::new(vec![subpath.clone()]);
         let result = normalize_subpath_start_points(&outline);
         assert_eq!(result.subpaths()[0], subpath);
+    }
+
+    // --- randomize_subpath_start_points ---
+
+    #[test]
+    fn randomize_counts_implicit_close_endpoint() {
+        let outline = Outline::new(vec![closed(
+            pt(0.0, 0.0),
+            vec![line(1.0, 0.0), line(1.0, 1.0)],
+        )]);
+        let result = randomize_subpath_start_points(&outline, &[0.9]);
+
+        assert_eq!(result.subpaths()[0].start(), pt(1.0, 1.0));
+    }
+
+    #[test]
+    fn randomize_excludes_duplicate_explicit_close_endpoint() {
+        let outline = Outline::new(vec![closed(
+            pt(0.0, 0.0),
+            vec![line(1.0, 0.0), line(1.0, 1.0), line(0.0, 0.0)],
+        )]);
+        let result = randomize_subpath_start_points(&outline, &[0.9]);
+
+        assert_eq!(result.subpaths()[0].start(), pt(1.0, 1.0));
     }
 
     // --- reverse_closed_subpaths ---


### PR DESCRIPTION
## Summary

- exclude a duplicated explicit closing endpoint from randomized start-point candidates
- keep the final endpoint eligible when the contour relies on an implicit closing edge
- add Rust regression tests for both contour encodings

## Root cause

`randomize_subpath_start_points` always counted `elements.len() + 1` nodes. For contours whose final path element explicitly returns to the start point, this counted the same geometric endpoint twice and gave it twice the probability of other endpoints.

## Impact

Closed-subpath start endpoints are now sampled uniformly across unique encoded endpoints, regardless of whether the closing edge is explicit or implicit.

## Validation

- `mise run check`
- `mise run test` (`212 passed, 9 skipped`)
