### PR TITLE
[codex] reject outline elements outside subpaths

### DIFF
--- a/src/geom/encoding.rs
+++ b/src/geom/encoding.rs
@@ -5,6 +5,7 @@ use super::{Outline, PathElement, Point};
 pub(crate) enum DecodeError {
     CoordsLen,
     InvalidElementType { index: usize, value: i64 },
+    ElementOutsideSubpath { index: usize, value: i64 },
     NonPaddingAfterEnd { index: usize, value: i64 },
 }
 
@@ -26,6 +27,25 @@ impl<'a> TryFrom<(&'a [i64], &'a [f32])> for Outline {
             .find(|&(_, v)| !(1..=ElementType::End as i64).contains(&v))
         {
             return Err(DecodeError::InvalidElementType { index, value });
+        }
+        let mut in_subpath = false;
+        for (index, &value) in types[..outline_len].iter().enumerate() {
+            match ElementType::try_from(value) {
+                Ok(ElementType::MoveTo) => in_subpath = true,
+                Ok(ElementType::LineTo | ElementType::QuadTo | ElementType::CurveTo)
+                    if !in_subpath =>
+                {
+                    return Err(DecodeError::ElementOutsideSubpath { index, value });
+                }
+                Ok(ElementType::Close) => {
+                    if !in_subpath {
+                        return Err(DecodeError::ElementOutsideSubpath { index, value });
+                    }
+                    in_subpath = false;
+                }
+                Ok(ElementType::End) => break,
+                Ok(_) | Err(_) => {}
+            }
         }
         if let Some((offset, value)) = types[outline_len..]
             .iter()
@@ -215,6 +235,33 @@ mod tests {
         assert!(matches!(
             Outline::try_from((types.as_slice(), coords.as_slice())),
             Err(DecodeError::NonPaddingAfterEnd { index: 2, value: 2 })
+        ));
+    }
+
+    #[test]
+    fn try_from_rejects_drawing_element_before_move() {
+        let types = [ElementType::LineTo as i64, ElementType::End as i64];
+        let coords = [0.0; 12];
+
+        assert!(matches!(
+            Outline::try_from((types.as_slice(), coords.as_slice())),
+            Err(DecodeError::ElementOutsideSubpath { index: 0, value: 2 })
+        ));
+    }
+
+    #[test]
+    fn try_from_rejects_drawing_element_after_close() {
+        let types = [
+            ElementType::MoveTo as i64,
+            ElementType::Close as i64,
+            ElementType::LineTo as i64,
+            ElementType::End as i64,
+        ];
+        let coords = [0.0; 24];
+
+        assert!(matches!(
+            Outline::try_from((types.as_slice(), coords.as_slice())),
+            Err(DecodeError::ElementOutsideSubpath { index: 2, value: 2 })
         ));
     }
 }

--- a/src/py/transforms.rs
+++ b/src/py/transforms.rs
@@ -16,6 +16,11 @@ fn decode(types: &[i64], coords: &[f32]) -> PyResult<Outline> {
                 "invalid element type {value} at index {index}"
             ))
         }
+        DecodeError::ElementOutsideSubpath { index, value } => {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "element type {value} at index {index} requires a preceding MOVE_TO"
+            ))
+        }
         DecodeError::NonPaddingAfterEnd { index, value } => {
             pyo3::exceptions::PyValueError::new_err(format!(
                 "only PAD elements may follow END; found {value} at index {index}"

--- a/tests/transforms/curves/test_merge_curves.py
+++ b/tests/transforms/curves/test_merge_curves.py
@@ -244,6 +244,39 @@ def test_variable_length_transforms_reject_invalid_element_types(
 
 
 @pytest.mark.parametrize("transform", [cubic_to_quad, merge_curves])
+@pytest.mark.parametrize(
+    ("values", "index"),
+    [
+        ([ElementType.LINE_TO.value, ElementType.END.value], 0),
+        (
+            [
+                ElementType.MOVE_TO.value,
+                ElementType.CLOSE.value,
+                ElementType.LINE_TO.value,
+                ElementType.END.value,
+            ],
+            2,
+        ),
+    ],
+)
+def test_variable_length_transforms_reject_elements_outside_subpath(
+    transform: Callable[
+        [torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]
+    ],
+    values: list[int],
+    index: int,
+) -> None:
+    types = torch.tensor(values, dtype=torch.long)
+    coords = torch.zeros(len(values), 6, dtype=torch.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"element type 2 at index {index} requires a preceding MOVE_TO",
+    ):
+        transform(types, coords)
+
+
+@pytest.mark.parametrize("transform", [cubic_to_quad, merge_curves])
 def test_variable_length_transforms_strip_padding_after_end(
     transform: Callable[
         [torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]


### PR DESCRIPTION
## Summary
- reject drawing commands that appear before `MOVE_TO` or after `CLOSE`
- expose malformed outline order as `ValueError` through the Python bindings
- cover Rust decoding and Python transform entry points

## Why
The decoder previously ignored drawing elements when no subpath was open. Malformed model output could therefore be silently converted into a different outline instead of reporting invalid input.

## Validation
- `mise run check`
- `mise run test` (224 passed, 9 skipped)