### PR TITLE
[codex] reject non-finite affine parameters

### DIFF
--- a/tests/transforms/geometric/test_affine.py
+++ b/tests/transforms/geometric/test_affine.py
@@ -108,6 +108,39 @@ def test_affine_invalid_scale_raises(
         affine(types, coords, scale=scale)
 
 
+@pytest.mark.parametrize("angle", [float("nan"), float("inf")])
+def test_affine_rejects_non_finite_angle(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    angle: float,
+) -> None:
+    types, coords = simple_outline
+    with pytest.raises(ValueError, match="angle must be finite"):
+        affine(types, coords, angle=angle)
+
+
+@pytest.mark.parametrize("shear", [float("nan"), float("inf")])
+def test_affine_rejects_non_finite_shear(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    shear: float,
+) -> None:
+    types, coords = simple_outline
+    with pytest.raises(ValueError, match="shear must be finite"):
+        affine(types, coords, shear=shear)
+
+
+@pytest.mark.parametrize(
+    "translate",
+    [(float("nan"), 0.0), (0.0, float("inf"))],
+)
+def test_affine_rejects_non_finite_translate(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    translate: tuple[float, float],
+) -> None:
+    types, coords = simple_outline
+    with pytest.raises(ValueError, match="translate values must be finite"):
+        affine(types, coords, translate=translate)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 def test_affine_preserves_cuda_device(
     simple_outline: tuple[torch.Tensor, torch.Tensor],

--- a/tests/transforms/geometric/test_random_affine.py
+++ b/tests/transforms/geometric/test_random_affine.py
@@ -77,6 +77,45 @@ def test_random_affine_reversed_scale_range_raises(
         random_affine(types, coords, scale=(2.0, 1.0))
 
 
+@pytest.mark.parametrize(
+    "degrees",
+    [float("nan"), (0.0, float("inf"))],
+)
+def test_random_affine_rejects_non_finite_degrees(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    degrees: float | tuple[float, float],
+) -> None:
+    types, coords = simple_outline
+    with pytest.raises(ValueError, match="range values must be finite"):
+        random_affine(types, coords, degrees=degrees)
+
+
+@pytest.mark.parametrize(
+    "shear",
+    [float("inf"), (float("nan"), 0.0)],
+)
+def test_random_affine_rejects_non_finite_shear(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    shear: float | tuple[float, float],
+) -> None:
+    types, coords = simple_outline
+    with pytest.raises(ValueError, match="range values must be finite"):
+        random_affine(types, coords, shear=shear)
+
+
+@pytest.mark.parametrize(
+    "translate",
+    [(float("inf"), 0.0), (0.0, float("nan"))],
+)
+def test_random_affine_rejects_non_finite_translate(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+    translate: tuple[float, float],
+) -> None:
+    types, coords = simple_outline
+    with pytest.raises(ValueError, match="translate values must be finite"):
+        random_affine(types, coords, translate=translate)
+
+
 def test_random_affine_quad_pair1_stays_zero(
     quad_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -195,6 +195,15 @@ def affine(
     if not math.isfinite(scale) or scale <= 0:
         msg = "scale must be positive and finite"
         raise ValueError(msg)
+    if not math.isfinite(angle):
+        msg = "angle must be finite"
+        raise ValueError(msg)
+    if not math.isfinite(shear):
+        msg = "shear must be finite"
+        raise ValueError(msg)
+    if not all(math.isfinite(value) for value in translate):
+        msg = "translate values must be finite"
+        raise ValueError(msg)
     matrix = _rotation_scale_shear_matrix(angle, scale, shear, like=coords)
     center = _bbox_center(types, coords)
     return types, _apply_matrix(types, coords, matrix, center, translate)
@@ -264,8 +273,15 @@ def _validate_probability(p: float) -> None:
 
 def _sym_range(value: float | tuple[float, float]) -> tuple[float, float]:
     if isinstance(value, (int, float)):
-        return (-abs(float(value)), abs(float(value)))
+        limit = float(value)
+        if not math.isfinite(limit):
+            msg = "range values must be finite"
+            raise ValueError(msg)
+        return (-abs(limit), abs(limit))
     lo, hi = float(value[0]), float(value[1])
+    if not math.isfinite(lo) or not math.isfinite(hi):
+        msg = "range values must be finite"
+        raise ValueError(msg)
     if lo > hi:
         msg = "range must satisfy min <= max"
         raise ValueError(msg)
@@ -321,6 +337,9 @@ def random_affine(
     """
     deg_lo, deg_hi = _sym_range(degrees)
     shear_lo, shear_hi = _sym_range(shear)
+    if translate is not None and not all(math.isfinite(value) for value in translate):
+        msg = "translate values must be finite"
+        raise ValueError(msg)
 
     r = torch.rand(5, generator=generator)
 


### PR DESCRIPTION
## Summary
- reject non-finite angle, shear, and translation values in `affine`
- reject non-finite degree, shear, and translation ranges in `random_affine`
- add focused coverage for every affected parameter

## Why
Non-finite affine parameters previously completed successfully and returned coordinates containing `NaN` or `Inf`. Rejecting them at the public API boundary prevents corrupted tensors from propagating into training pipelines.

## Validation
- `mise run check`
- `mise run test` (232 passed, 9 skipped)