### PR TITLE
[codex] fix review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,10 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: "true"
-      - run: uvx ruff format --check
-      - run: uvx ruff check
+      # Keep lint isolated from project dependencies so this job never syncs Torch.
+      # The version matches uv.lock and should be updated alongside it.
+      - run: uvx --from ruff==0.15.12 ruff format --check
+      - run: uvx --from ruff==0.15.12 ruff check
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo check --all-targets --all-features

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -317,8 +317,8 @@ types, coords = random_coord_jitter(types, coords, std=0.005)
 
 Adds independent Gaussian noise to each active value in the outline coordinates.
 
-- `std`: standard deviation in UPM-normalised units; `0.005` ≈ 5 font-units in
-  a 1000-UPM font
+- `std`: non-negative, finite standard deviation in UPM-normalised units;
+  `0.005` ≈ 5 font-units in a 1000-UPM font
 - only active `coords` columns are perturbed (zero-coordinate element types
   CLOSE, END, PAD and unused zero-padding columns are left unchanged)
 - `generator`: optional `torch.Generator` for reproducibility

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -315,8 +315,8 @@ types, coords = random_coord_jitter(types, coords, std=0.005)
 
 各アクティブな outline 座標に独立したガウスノイズを加算します。
 
-- `std`: UPM 正規化単位での標準偏差。`0.005` は 1000-UPM フォントで
-  約 5 フォントユニットに相当します
+- `std`: UPM 正規化単位での有限な非負の標準偏差。`0.005` は
+  1000-UPM フォントで約 5 フォントユニットに相当します
 - 座標が 0 の element type（CLOSE、END、PAD）と未使用の座標列は変更しません
 - `generator`: 再現性のためのオプション `torch.Generator`
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -998,7 +998,7 @@ def test_targets_survives_pickle() -> None:
 
 
 def test_unpickle_raises_when_font_removed(tmp_path: Path) -> None:
-    """Unpickling must fail loudly when fonts changed since pickling."""
+    """Unpickling must fail when the dataset structure changed."""
     shutil.copy("tests/fonts/lato/Lato-Regular.ttf", tmp_path)
     shutil.copy("tests/fonts/ubuntu/Ubuntu-Regular.ttf", tmp_path)
 
@@ -1007,7 +1007,7 @@ def test_unpickle_raises_when_font_removed(tmp_path: Path) -> None:
 
     (tmp_path / "Ubuntu-Regular.ttf").unlink()
 
-    with pytest.raises(RuntimeError, match="no longer match"):
+    with pytest.raises(RuntimeError, match="same dataset structure"):
         pickle.loads(payload)  # noqa: S301
 
 
@@ -1019,7 +1019,7 @@ def test_unpickle_raises_when_font_added(tmp_path: Path) -> None:
 
     shutil.copy("tests/fonts/ubuntu/Ubuntu-Regular.ttf", tmp_path)
 
-    with pytest.raises(RuntimeError, match="no longer match"):
+    with pytest.raises(RuntimeError, match="same dataset structure"):
         pickle.loads(payload)  # noqa: S301
 
 
@@ -1030,6 +1030,22 @@ def test_unpickle_succeeds_when_fonts_unchanged(tmp_path: Path) -> None:
     restored = pickle.loads(pickle.dumps(dataset))  # noqa: S301
 
     assert len(restored) == len(dataset)
+    assert torch.equal(restored.targets, dataset.targets)
+
+
+def test_unpickle_uses_changed_font_when_structure_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    font_path = tmp_path / "font.ttf"
+    shutil.copy("tests/fonts/lato/Lato-Regular.ttf", font_path)
+
+    dataset = GlyphDataset(root=tmp_path, codepoints=range(0x41, 0x44))
+    payload = pickle.dumps(dataset)
+
+    shutil.copy("tests/fonts/ubuntu/Ubuntu-Regular.ttf", font_path)
+    restored = pickle.loads(payload)  # noqa: S301
+
+    assert restored.style_classes == ["Ubuntu Regular"]
     assert torch.equal(restored.targets, dataset.targets)
 
 

--- a/tests/transforms/geometric/test_random_coord_jitter.py
+++ b/tests/transforms/geometric/test_random_coord_jitter.py
@@ -70,12 +70,14 @@ def test_random_coord_jitter_does_not_modify_types(
     assert torch.equal(out_types, types)
 
 
-def test_random_coord_jitter_negative_std_raises(
+@pytest.mark.parametrize("std", [-0.1, float("nan"), float("inf")])
+def test_random_coord_jitter_invalid_std_raises(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
+    std: float,
 ) -> None:
     types, coords = simple_outline
-    with pytest.raises(ValueError, match="std must be non-negative"):
-        random_coord_jitter(types, coords, std=-0.1)
+    with pytest.raises(ValueError, match="std must be non-negative and finite"):
+        random_coord_jitter(types, coords, std=std)
 
 
 def test_random_coord_jitter_deterministic_with_generator(

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -10,7 +10,9 @@ Notes:
     Unpickling (including ``DataLoader`` worker spawn) rebuilds the index from
     the files on disk and verifies it against the pickled structure
     fingerprint, raising ``RuntimeError`` instead of silently misaligning
-    labels when the files changed in between.
+    labels when paths, faces, code points, or variation instance counts changed
+    in between. Outline and metadata-only edits that preserve this structure
+    are intentionally read from the current files on disk.
 
 Examples:
     Iterate glyph samples from a directory of fonts::
@@ -356,6 +358,10 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         file order, paths, face indices, code points, and variation instance
         counts.
 
+        Outline and metadata-only edits are deliberately not fingerprinted:
+        files on disk remain the source of truth when the sample-to-label
+        structure is unchanged.
+
         Raises:
             RuntimeError: If the font files under ``root`` no longer produce
                 the same index structure as when the dataset was pickled,
@@ -371,10 +377,10 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         )
         if backend.fingerprint != self._fingerprint:
             msg = (
-                f"font files under {str(self.root)!r} no longer match the "
-                "dataset this object was pickled from; sample indices and "
-                "targets would be inconsistent. Recreate the dataset from "
-                "the current files."
+                f"font files under {str(self.root)!r} no longer have the same "
+                "dataset structure as when this object was pickled; sample "
+                "indices and targets would be inconsistent. Recreate the "
+                "dataset from the current files."
             )
             raise RuntimeError(msg)
         self._backend = backend

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -384,7 +384,7 @@ def random_coord_jitter(
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
         std: Standard deviation of the Gaussian noise in UPM-normalised units.
-            Must be non-negative.
+            Must be non-negative and finite.
         generator: Optional ``torch.Generator`` for reproducible sampling.
 
     Returns:
@@ -392,8 +392,8 @@ def random_coord_jitter(
         ``types`` is returned unchanged (same object).
 
     """
-    if std < 0:
-        msg = "std must be non-negative"
+    if not math.isfinite(std) or std < 0:
+        msg = "std must be non-negative and finite"
         raise ValueError(msg)
     if std == 0.0:
         return types, coords


### PR DESCRIPTION
## Summary

- clarify that the dataset fingerprint protects sample-to-label structure rather than font contents
- reject non-finite `random_coord_jitter` standard deviations
- pin the CI Ruff version while keeping lint isolated from project dependencies

## Details

PR #273 deliberately excluded outline-only edits from the fingerprint because files on disk remain the source of truth and content hashing added substantial worker startup cost. This change preserves that design, makes the public documentation explicit, and adds a regression test showing that a same-structure font replacement is loaded successfully.

`random_coord_jitter` now rejects `NaN` and infinity with the same `ValueError` contract used by the other geometric transforms. The English and Japanese transform references are updated together.

CI now runs `uvx --from ruff==0.15.12`, matching `uv.lock`. The isolated tool environment installs only Ruff and does not sync Torch or other project dependencies.

## Verification

- `uvx --from ruff==0.15.12 ruff format --check`
- `uvx --from ruff==0.15.12 ruff check`
- `uv run --no-sync ty check`
- `uv run --no-sync pytest tests` (239 passed, 9 skipped)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --all-features`
- `npm run docs:build`