### PR TITLE
[codex] clarify dataset fingerprint contract

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -998,7 +998,7 @@ def test_targets_survives_pickle() -> None:
 
 
 def test_unpickle_raises_when_font_removed(tmp_path: Path) -> None:
-    """Unpickling must fail loudly when fonts changed since pickling."""
+    """Unpickling must fail when the dataset structure changed."""
     shutil.copy("tests/fonts/lato/Lato-Regular.ttf", tmp_path)
     shutil.copy("tests/fonts/ubuntu/Ubuntu-Regular.ttf", tmp_path)
 
@@ -1007,7 +1007,7 @@ def test_unpickle_raises_when_font_removed(tmp_path: Path) -> None:
 
     (tmp_path / "Ubuntu-Regular.ttf").unlink()
 
-    with pytest.raises(RuntimeError, match="no longer match"):
+    with pytest.raises(RuntimeError, match="same dataset structure"):
         pickle.loads(payload)  # noqa: S301
 
 
@@ -1019,7 +1019,7 @@ def test_unpickle_raises_when_font_added(tmp_path: Path) -> None:
 
     shutil.copy("tests/fonts/ubuntu/Ubuntu-Regular.ttf", tmp_path)
 
-    with pytest.raises(RuntimeError, match="no longer match"):
+    with pytest.raises(RuntimeError, match="same dataset structure"):
         pickle.loads(payload)  # noqa: S301
 
 
@@ -1031,6 +1031,24 @@ def test_unpickle_succeeds_when_fonts_unchanged(tmp_path: Path) -> None:
 
     assert len(restored) == len(dataset)
     assert torch.equal(restored.targets, dataset.targets)
+
+
+def test_unpickle_uses_changed_font_when_structure_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    font_path = tmp_path / "font.ttf"
+    shutil.copy("tests/fonts/lato/Lato-Regular.ttf", font_path)
+
+    dataset = GlyphDataset(root=tmp_path, codepoints=range(0x41, 0x44))
+    original_targets = dataset.targets.clone()
+    payload = pickle.dumps(dataset)
+    del dataset
+
+    shutil.copy("tests/fonts/ubuntu/Ubuntu-Regular.ttf", font_path)
+    restored = pickle.loads(payload)  # noqa: S301
+
+    assert restored.style_classes == ["Ubuntu Regular"]
+    assert torch.equal(restored.targets, original_targets)
 
 
 def test_glyph_dataset_getitem_survives_spawn_pickle_roundtrip() -> None:

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -10,7 +10,9 @@ Notes:
     Unpickling (including ``DataLoader`` worker spawn) rebuilds the index from
     the files on disk and verifies it against the pickled structure
     fingerprint, raising ``RuntimeError`` instead of silently misaligning
-    labels when the files changed in between.
+    labels when paths, faces, code points, or variation instance counts changed
+    in between. Outline and metadata-only edits that preserve this structure
+    are intentionally read from the current files on disk.
 
 Examples:
     Iterate glyph samples from a directory of fonts::
@@ -356,6 +358,10 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         file order, paths, face indices, code points, and variation instance
         counts.
 
+        Outline and metadata-only edits are deliberately not fingerprinted:
+        files on disk remain the source of truth when the sample-to-label
+        structure is unchanged.
+
         Raises:
             RuntimeError: If the font files under ``root`` no longer produce
                 the same index structure as when the dataset was pickled,
@@ -371,10 +377,10 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         )
         if backend.fingerprint != self._fingerprint:
             msg = (
-                f"font files under {str(self.root)!r} no longer match the "
-                "dataset this object was pickled from; sample indices and "
-                "targets would be inconsistent. Recreate the dataset from "
-                "the current files."
+                f"font files under {str(self.root)!r} no longer have the same "
+                "dataset structure as when this object was pickled; sample "
+                "indices and targets would be inconsistent. Recreate the "
+                "dataset from the current files."
             )
             raise RuntimeError(msg)
         self._backend = backend


### PR DESCRIPTION
## Summary

Clarify that the pickle fingerprint protects the dataset sample-to-label structure, not font file contents.

## Context

PR #273 deliberately hashes entry order, paths, faces, code points, and variation instance counts. It intentionally does not hash outlines or metadata because current files on disk remain the source of truth and full content hashing adds substantial worker startup cost.

This PR preserves that design, makes the contract explicit, improves the mismatch error, and adds a regression test showing that a same-structure font replacement is loaded successfully.

## Verification

- `uv run --no-sync pytest tests/test_dataset.py` (57 passed)