### PR TITLE
[codex] reject non-finite jitter standard deviations

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -317,8 +317,8 @@ types, coords = random_coord_jitter(types, coords, std=0.005)
 
 Adds independent Gaussian noise to each active value in the outline coordinates.
 
-- `std`: standard deviation in UPM-normalised units; `0.005` ≈ 5 font-units in
-  a 1000-UPM font
+- `std`: non-negative, finite standard deviation in UPM-normalised units;
+  `0.005` ≈ 5 font-units in a 1000-UPM font
 - only active `coords` columns are perturbed (zero-coordinate element types
   CLOSE, END, PAD and unused zero-padding columns are left unchanged)
 - `generator`: optional `torch.Generator` for reproducibility

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -315,8 +315,8 @@ types, coords = random_coord_jitter(types, coords, std=0.005)
 
 各アクティブな outline 座標に独立したガウスノイズを加算します。
 
-- `std`: UPM 正規化単位での標準偏差。`0.005` は 1000-UPM フォントで
-  約 5 フォントユニットに相当します
+- `std`: UPM 正規化単位での有限な非負の標準偏差。`0.005` は
+  1000-UPM フォントで約 5 フォントユニットに相当します
 - 座標が 0 の element type（CLOSE、END、PAD）と未使用の座標列は変更しません
 - `generator`: 再現性のためのオプション `torch.Generator`
 

--- a/tests/transforms/geometric/test_random_coord_jitter.py
+++ b/tests/transforms/geometric/test_random_coord_jitter.py
@@ -70,12 +70,14 @@ def test_random_coord_jitter_does_not_modify_types(
     assert torch.equal(out_types, types)
 
 
-def test_random_coord_jitter_negative_std_raises(
+@pytest.mark.parametrize("std", [-0.1, float("nan"), float("inf")])
+def test_random_coord_jitter_invalid_std_raises(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
+    std: float,
 ) -> None:
     types, coords = simple_outline
-    with pytest.raises(ValueError, match="std must be non-negative"):
-        random_coord_jitter(types, coords, std=-0.1)
+    with pytest.raises(ValueError, match="std must be non-negative and finite"):
+        random_coord_jitter(types, coords, std=std)
 
 
 def test_random_coord_jitter_deterministic_with_generator(

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -384,7 +384,7 @@ def random_coord_jitter(
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
         std: Standard deviation of the Gaussian noise in UPM-normalised units.
-            Must be non-negative.
+            Must be non-negative and finite.
         generator: Optional ``torch.Generator`` for reproducible sampling.
 
     Returns:
@@ -392,8 +392,8 @@ def random_coord_jitter(
         ``types`` is returned unchanged (same object).
 
     """
-    if std < 0:
-        msg = "std must be non-negative"
+    if not math.isfinite(std) or std < 0:
+        msg = "std must be non-negative and finite"
         raise ValueError(msg)
     if std == 0.0:
         return types, coords


### PR DESCRIPTION
## Summary

Reject `NaN` and infinite `std` values in `random_coord_jitter`.

## Root cause

The existing validation only checked `std < 0`, allowing positive infinity to generate infinite outline coordinates and leaving `NaN` handling to PyTorch.

The transform now requires a non-negative, finite standard deviation and consistently raises `ValueError`. English and Japanese documentation are updated together.

## Verification

- `uvx --from ruff==0.15.12 ruff format --check`
- `uvx --from ruff==0.15.12 ruff check`
- `uv run --no-sync pytest tests/transforms/geometric/test_random_coord_jitter.py` (10 passed)
- `npm run docs:build`