### PR TITLE
[codex] pin Ruff in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: "true"
-      - run: uvx ruff format --check
-      - run: uvx ruff check
+      - run: uv sync --locked --only-group lint --no-install-project
+      - run: uv run --no-sync ruff format --check
+      - run: uv run --no-sync ruff check
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo check --all-targets --all-features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ build-backend = "maturin"
 
 [dependency-groups]
 dev = [
+    { include-group = "lint" },
     "fonttools>=4.63.0",
     "lightning>=2.6.0",
     "maturin[patchelf]>=1.10.2; sys_platform == 'linux'",
@@ -51,12 +52,12 @@ dev = [
     "numpy>=2.2.6",
     "pytest>=8.4.2",
     "pytest-benchmark>=5.1.0",
-    "ruff>=0.12.4",
     "skia-pathops>=0.9.2",
     "tqdm>=4.67.1",
     "ty>=0.0.12",
     "types-tqdm>=4.67.0.20250809",
 ]
+lint = ["ruff>=0.12.4"]
 
 [tool.uv.sources]
 torch = [{ index = "pytorch-cpu" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1413,6 +1413,9 @@ dev = [
     { name = "ty" },
     { name = "types-tqdm" },
 ]
+lint = [
+    { name = "ruff" },
+]
 
 [package.metadata]
 requires-dist = [{ name = "torch", specifier = ">=2.3.0", index = "https://download.pytorch.org/whl/cpu" }]
@@ -1432,6 +1435,7 @@ dev = [
     { name = "ty", specifier = ">=0.0.12" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
 ]
+lint = [{ name = "ruff", specifier = ">=0.12.4" }]
 
 [[package]]
 name = "torchmetrics"


### PR DESCRIPTION
## Summary

Run CI lint from a dedicated `lint` dependency group locked by `uv.lock`.

## Dependency isolation

The development group includes the lint group, so local development keeps the same tool set without duplicating the Ruff requirement. CI syncs only `lint` with `--no-install-project`, then executes Ruff with `--no-sync`.

An empty-environment dry run and real sync both install exactly one package: `ruff==0.15.12`. Torch and the project package are not installed.

## Verification

- `UV_PROJECT_ENVIRONMENT=/tmp/torchfont-lint-venv uv sync --locked --only-group lint --no-install-project --dry-run`
- `UV_PROJECT_ENVIRONMENT=/tmp/torchfont-lint-venv uv sync --locked --only-group lint --no-install-project`
- `UV_PROJECT_ENVIRONMENT=/tmp/torchfont-lint-venv uv run --no-sync ruff format --check`
- `UV_PROJECT_ENVIRONMENT=/tmp/torchfont-lint-venv uv run --no-sync ruff check`