### PR TITLE
[codex] clarify em-normalized coordinate terminology

### DIFF
--- a/docs/en/guide/glyph-data-format.md
+++ b/docs/en/guide/glyph-data-format.md
@@ -114,7 +114,8 @@ Which dimensions are used depends on the element type:
 - **`Close` / `End` / `Pad`**: all zeros
 
 ::: info
-Coordinates are normalized by the font `units_per_em`.
+Coordinates are in em units: font design units divided by the font's
+`unitsPerEm`.
 :::
 
 Quadratic curves are emitted as `QuadTo` without conversion to cubic. To keep tensor shape fixed, `QuadTo` uses `[cx0, cy0, 0, 0, x, y]`.

--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -94,7 +94,7 @@ sample = dataset[idx]
 
 `sample.post` stores `(italic_angle, is_fixed_pitch, underline_position,
 underline_thickness)`. The italic angle is in degrees, `is_fixed_pitch` is
-`0.0` or `1.0`, and the two underline metrics are UPM-normalised.
+`0.0` or `1.0`, and the two underline metrics are in em units.
 
 Without `transform`, `sample` is a `GlyphSample`. With `transform`, the
 dataset item type is inferred from the transform return type.

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -223,7 +223,7 @@ centre, then applies `translate`. All active control points and endpoints are
 transformed; zero-coordinate element types (CLOSE, END, PAD) are not modified.
 
 - `angle`: counter-clockwise rotation in degrees (default: `0.0`)
-- `translate`: translation `(tx, ty)` in UPM-normalised units (default: `(0.0, 0.0)`)
+- `translate`: translation `(tx, ty)` in em units (default: `(0.0, 0.0)`)
 - `scale`: uniform scale factor, must be positive and finite (default: `1.0`)
 - `shear`: x-shear angle in degrees (default: `0.0`)
 
@@ -293,8 +293,8 @@ types, coords = random_affine(
 Applies a random affine transformation sampled uniformly from the given ranges.
 
 - `degrees`: rotation range in degrees; a single float `d` gives `[-d, d]`
-- `translate`: maximum absolute translation `(max_dx, max_dy)` in UPM-normalised
-  units; each axis is sampled from `[-max_d, max_d]` (default: no translation)
+- `translate`: maximum absolute translation `(max_dx, max_dy)` in em units;
+  each axis is sampled from `[-max_d, max_d]` (default: no translation)
 - `scale`: scale range `(min, max)`; both values must be positive and finite
   (default: no scaling)
 - `shear`: x-shear range in degrees; same format as `degrees` (default: `0.0`)
@@ -317,7 +317,7 @@ types, coords = random_coord_jitter(types, coords, std=0.005)
 
 Adds independent Gaussian noise to each active value in the outline coordinates.
 
-- `std`: non-negative, finite standard deviation in UPM-normalised units;
+- `std`: non-negative, finite standard deviation in em units;
   `0.005` ≈ 5 font-units in a 1000-UPM font
 - only active `coords` columns are perturbed (zero-coordinate element types
   CLOSE, END, PAD and unused zero-padding columns are left unchanged)
@@ -342,7 +342,7 @@ Renders a glyph outline to a greyscale bitmap tensor. `mode` controls how
 coordinates are mapped to the output bitmap.
 
 - `size` must be between 1 and 4096 (default: 64)
-- `mode="fixed"` maps the fixed UPM-normalised range `[-0.25, 1.25] x [-0.25, 1.25]`
+- `mode="fixed"` maps the fixed em-unit range `[-0.25, 1.25] x [-0.25, 1.25]`
 - `mode="bbox"` keeps the fixed-mode scale and returns a variable-size bitmap
   cropped to the tight glyph bounding box
 - `mode="bbox_square"` scales the tight glyph bounding box uniformly and centres

--- a/docs/ja/guide/glyph-data-format.md
+++ b/docs/ja/guide/glyph-data-format.md
@@ -116,7 +116,8 @@ tensor([cx0, cy0, cx1, cy1, x, y])
 - **`Close` / `End` / `Pad`**: すべて 0
 
 ::: info
-Coordinates はフォントの `units_per_em` で正規化されています。
+Coordinates は em 単位です。フォントの design units を `unitsPerEm` で
+割った値として表されます。
 :::
 
 2 次ベジェは 3 次ベジェへの変換をせず `QuadTo` としてそのまま出力されます。テンソル形状を固定するため、`QuadTo` の Coordinates は `[cx0, cy0, 0, 0, x, y]` です。

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -94,7 +94,7 @@ sample = dataset[idx]
 
 `sample.post` は `(italic_angle, is_fixed_pitch, underline_position,
 underline_thickness)` を保持します。`italic_angle` の単位は度、
-`is_fixed_pitch` は `0.0` または `1.0`、下線の2値は UPM 正規化済みです。
+`is_fixed_pitch` は `0.0` または `1.0`、下線の2値は em 単位です。
 
 `transform` なしでは `sample` 自体の型は `GlyphSample` です。`transform`
 ありでは、dataset item の型は transform の返り値型から推論されます。

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -221,7 +221,7 @@ tight bounding-box の中心を基準に一様スケール・x-shear・回転を
 座標が 0 の element type（CLOSE、END、PAD）は変更しません。
 
 - `angle`: 反時計回りの回転角度（単位: 度、デフォルト: `0.0`）
-- `translate`: UPM 正規化単位での平行移動 `(tx, ty)`（デフォルト: `(0.0, 0.0)`）
+- `translate`: em 単位での平行移動 `(tx, ty)`（デフォルト: `(0.0, 0.0)`）
 - `scale`: 一様スケール係数（正かつ有限の値が必須、デフォルト: `1.0`）
 - `shear`: x-shear 角度（単位: 度、デフォルト: `0.0`）
 
@@ -291,7 +291,7 @@ types, coords = random_affine(
 指定した範囲から一様サンプリングしたランダムなアフィン変換を適用します。
 
 - `degrees`: 回転範囲（度）。単一の float `d` を指定すると `[-d, d]` になります
-- `translate`: UPM 正規化単位での最大絶対平行移動 `(max_dx, max_dy)`。
+- `translate`: em 単位での最大絶対平行移動 `(max_dx, max_dy)`。
   各軸を `[-max_d, max_d]` からサンプリングします（デフォルト: 平行移動なし）
 - `scale`: スケール範囲 `(min, max)`。両値は正かつ有限の値が必須
   （デフォルト: スケールなし）
@@ -315,7 +315,7 @@ types, coords = random_coord_jitter(types, coords, std=0.005)
 
 各アクティブな outline 座標に独立したガウスノイズを加算します。
 
-- `std`: UPM 正規化単位での有限な非負の標準偏差。`0.005` は
+- `std`: em 単位での有限な非負の標準偏差。`0.005` は
   1000-UPM フォントで約 5 フォントユニットに相当します
 - 座標が 0 の element type（CLOSE、END、PAD）と未使用の座標列は変更しません
 - `generator`: 再現性のためのオプション `torch.Generator`
@@ -339,7 +339,7 @@ bitmap = render_bitmap(types, coords, size=64, mode="bbox_square")
 `mode` に応じた座標変換で出力ビットマップへ配置します。
 
 - `size` は 1〜4096 の整数（デフォルト: 64）
-- `mode="fixed"` は UPM 正規化済みの固定範囲 `[-0.25, 1.25] x [-0.25, 1.25]` に配置
+- `mode="fixed"` は em 単位の固定範囲 `[-0.25, 1.25] x [-0.25, 1.25]` に配置
 - `mode="bbox"` は fixed と同じ座標スケールを保ち、tight bbox に合わせた可変サイズのビットマップを返します
 - `mode="bbox_square"` は tight bbox を縦横比を保って正方形内に中央配置（デフォルト）
 - patchify 前のクリップ済みアウトラインを渡すと元の形状を正確に再現できます

--- a/src/curves/mod.rs
+++ b/src/curves/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod quad_to_cubic;
 
 use crate::geom::Point;
 
-// Absolute tolerance for curve operations (normalized coords ≈ 1 font-unit in 1000 UPM).
+// Absolute tolerance in em units (≈ 1 font unit in a 1000-UPM font).
 pub(crate) const TOLERANCE: f32 = 1e-3;
 
 pub(crate) type Cubic = (Point, Point, Point, Point);

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -94,12 +94,13 @@ class GlyphSample:
         content_idx (int): Index into the dataset's ``content_classes`` list.
         head (Tensor): ``head`` table fields (8,): ``units_per_em``, ``flags``,
             ``x_min``, ``y_min``, ``x_max``, ``y_max``, ``mac_style``,
-            ``lowest_rec_ppem``. Bounding box values are UPM-normalised.
+            ``lowest_rec_ppem``. Bounding box values are in em units (font
+            design units divided by ``unitsPerEm``).
         hhea (Tensor): ``hhea`` table fields (10,): ``ascender``,
             ``descender``, ``line_gap``, ``advance_width_max``, ``min_lsb``,
             ``min_rsb``, ``x_max_extent``, ``caret_slope_rise``,
             ``caret_slope_run``, ``caret_offset``. Metric lengths are
-            UPM-normalised; ``caret_slope_rise`` and ``caret_slope_run`` are
+            in em units; ``caret_slope_rise`` and ``caret_slope_run`` are
             raw integers (dimensionless slope, not a length).
         os2 (Tensor): ``OS/2`` table fields (42,): ``weight_class``,
             ``width_class``, ``fs_type``, ``fs_selection``, typo/win metrics
@@ -108,7 +109,7 @@ class GlyphSample:
             subscript/superscript (8), strikeout (2),
             ``s_family_class``, panose (10), vend_id (4), first/last char
             index (2), ``x_height``, ``cap_height``, ``default_char``,
-            ``break_char``, ``max_context``. Metric values UPM-normalised;
+            ``break_char``, ``max_context``. Metric values are in em units;
             ``nan`` when absent. Note: ``win_descent`` is stored as a
             **positive** value (matching the OpenType spec's unsigned
             ``usWinDescent``), whereas ``typo_descender`` and
@@ -116,12 +117,12 @@ class GlyphSample:
         post (Tensor): ``post`` table fields (4,): ``italic_angle``,
             ``is_fixed_pitch`` (0.0 or 1.0), ``underline_position``,
             ``underline_thickness``. ``italic_angle`` is stored in degrees;
-            underline metrics are UPM-normalised.
+            underline metrics are in em units.
         maxp (Tensor): ``maxp`` table fields (14,) starting with
             ``num_glyphs``. TrueType-only fields are ``nan`` for CFF fonts.
-        hmtx (Tensor): ``advance_width``, ``lsb`` (2,). UPM-normalised.
+        hmtx (Tensor): ``advance_width``, ``lsb`` (2,). Values are in em units.
         bounds (Tensor): ``x_min``, ``y_min``, ``x_max``, ``y_max`` (4,).
-            UPM-normalised.
+            Values are in em units.
         name (NameRecord): Strings from the ``name`` table, one field
             per NameID 0-25. Each field is an empty string when absent.
         codepoint (int): Unicode code point of the glyph (e.g. ``0x0041`` for 'A').

--- a/torchfont/transforms/bitmap.py
+++ b/torchfont/transforms/bitmap.py
@@ -25,12 +25,12 @@ def render_bitmap(
     Args:
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)`` holding
-            UPM-normalised coordinates for each path element.
+            coordinates in em units for each path element.
         size: Output image side length in pixels for ``"fixed"`` and
             ``"bbox_square"``. For ``"bbox"``, this sets the `coords` scale
             using the same fixed ``[-0.25, 1.25]`` range, then crops the output to
             the tight glyph bounding box. Must be between 1 and 4096.
-        mode: `coords` mapping mode. ``"fixed"`` maps the fixed UPM-normalised
+        mode: `coords` mapping mode. ``"fixed"`` maps the fixed em-unit
             range ``[-0.25, 1.25] x [-0.25, 1.25]`` to the canvas. ``"bbox"`` scales
             with the fixed-mode scale and returns a variable-size bitmap
             cropped to the tight glyph bounding box. ``"bbox_square"`` scales

--- a/torchfont/transforms/curves.py
+++ b/torchfont/transforms/curves.py
@@ -46,7 +46,7 @@ def cubic_to_quad(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Convert ``ElementType.CURVE_TO`` entries to ``ElementType.QUAD_TO`` sequences.
 
     Each cubic Bezier segment is replaced by the minimum number of quadratic
-    Bezier segments needed to approximate it within ~1e-3 normalised UPM units
+    Bezier segments needed to approximate it within ~1e-3 em units
     (roughly 1 font-unit in a 1000-UPM font), following the fonttools cu2qu
     approach. Consecutive quadratics share implicit on-curve points at the
     midpoints of adjacent off-curve control points (TrueType spline).
@@ -84,7 +84,7 @@ def merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     collinear and the segments run in the same direction. Unlike the fonttools
     ``merge_curves`` helper this transform also handles line segments.
 
-    The comparison tolerance is ~1e-3 in normalised UPM coordinates (roughly
+    The comparison tolerance is ~1e-3 em units (roughly
     1 font-unit in a 1000-UPM font), matching the precision typically used by
     fonttools.
 

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -12,7 +12,8 @@ Coordinates layout (``coords`` shape ``(N, 6)``)::
     Pair 1 (cx1, cy1): off-curve control point 2 — active for CURVE_TO only
     Pair 2 (x,   y  ): on-curve endpoint        — active for all drawing path elements
 
-All coordinates are UPM-normalised. The glyph body typically occupies
+All coordinates are in em units: font design units divided by ``unitsPerEm``.
+The glyph body typically occupies
 ``[0, 1] x [0, 1]`` inside the full canvas ``[-0.25, 1.25] x [-0.25, 1.25]``.
 """
 
@@ -182,7 +183,7 @@ def affine(
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
         angle: Counter-clockwise rotation in degrees.
-        translate: Translation ``(tx, ty)`` in UPM-normalised units applied
+        translate: Translation ``(tx, ty)`` in em units applied
             after rotation and scaling.
         scale: Uniform scale factor (must be positive and finite).
         shear: x-shear angle in degrees.
@@ -322,8 +323,8 @@ def random_affine(
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
         degrees: Rotation range in degrees. A single float ``d`` gives
             ``[-d, d]``; a ``(min, max)`` tuple is used directly.
-        translate: Maximum absolute translation ``(max_dx, max_dy)`` in
-            UPM-normalised units. Each axis is sampled uniformly from
+        translate: Maximum absolute translation ``(max_dx, max_dy)`` in em
+            units. Each axis is sampled uniformly from
             ``[-max_d, max_d]``. Default: no translation.
         scale: Scale range ``(min, max)``. Values must be positive and finite,
             and satisfy ``min <= max``. Default: no scaling.
@@ -372,7 +373,7 @@ def random_coord_jitter(
     """Add independent Gaussian noise to each active value in the outline coordinates.
 
     Noise is sampled per scalar value in ``coords`` with standard deviation
-    ``std`` in UPM-normalised units. Non-active zero-coordinate element types
+    ``std`` in em units. Non-active zero-coordinate element types
     (CLOSE, END, PAD) and unused zero-padding columns (e.g. ``cx1, cy1`` for
     QUAD_TO) are not perturbed.
 
@@ -383,7 +384,7 @@ def random_coord_jitter(
     Args:
         types: 1-D ``torch.int64`` tensor of element types.
         coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
-        std: Standard deviation of the Gaussian noise in UPM-normalised units.
+        std: Standard deviation of the Gaussian noise in em units.
             Must be non-negative and finite.
         generator: Optional ``torch.Generator`` for reproducible sampling.
 


### PR DESCRIPTION
## Summary

Clarify how TorchFont represents font coordinates and metrics after normalization.

- define values as font design units divided by `unitsPerEm`
- describe normalized values consistently as being in em units
- remove ambiguous phrases such as `UPM-normalised units` and `UPM 正規化単位`
- retain `1000-UPM font` where UPM correctly describes the number of design units per em
- align English and Japanese documentation and Python docstrings

This is a terminology-only change; coordinate calculations and public APIs are unchanged.

## Verification

- `uvx ruff format --check`
- `uvx ruff check`
- `uv run --no-sync ty check`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --all-features`
- `npm run docs:build`