### PR TITLE
[codex] fix random transform generator devices

### DIFF
--- a/tests/transforms/geometric/test_random_affine.py
+++ b/tests/transforms/geometric/test_random_affine.py
@@ -128,3 +128,21 @@ def test_random_affine_quad_pair1_stays_zero(
     quad_idx = types.tolist().index(ElementType.QUAD_TO.value)
     assert out[quad_idx, 2].item() == pytest.approx(0.0)
     assert out[quad_idx, 3].item() == pytest.approx(0.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_random_affine_accepts_cpu_generator_for_cuda_input(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in simple_outline)
+    generator = torch.Generator().manual_seed(5)
+
+    out_types, out_coords = random_affine(
+        types,
+        coords,
+        degrees=45.0,
+        generator=generator,
+    )
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/tests/transforms/geometric/test_random_coord_jitter.py
+++ b/tests/transforms/geometric/test_random_coord_jitter.py
@@ -89,3 +89,21 @@ def test_random_coord_jitter_deterministic_with_generator(
     _, out1 = random_coord_jitter(types, coords, std=0.05, generator=g1)
     _, out2 = random_coord_jitter(types, coords, std=0.05, generator=g2)
     assert torch.equal(out1, out2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_random_coord_jitter_accepts_cpu_generator_for_cuda_input(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in simple_outline)
+    generator = torch.Generator().manual_seed(99)
+
+    out_types, out_coords = random_coord_jitter(
+        types,
+        coords,
+        std=0.05,
+        generator=generator,
+    )
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/tests/transforms/geometric/test_random_horizontal_flip.py
+++ b/tests/transforms/geometric/test_random_horizontal_flip.py
@@ -41,3 +41,21 @@ def test_random_horizontal_flip_rejects_invalid_probability(
 
     with pytest.raises(ValueError, match="p must be between 0 and 1"):
         random_horizontal_flip(types, coords, p=p)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_random_horizontal_flip_accepts_cpu_generator_for_cuda_input(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in simple_outline)
+    generator = torch.Generator().manual_seed(0)
+
+    out_types, out_coords = random_horizontal_flip(
+        types,
+        coords,
+        p=1.0,
+        generator=generator,
+    )
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/tests/transforms/geometric/test_random_vertical_flip.py
+++ b/tests/transforms/geometric/test_random_vertical_flip.py
@@ -36,3 +36,21 @@ def test_random_vertical_flip_rejects_invalid_probability(
 
     with pytest.raises(ValueError, match="p must be between 0 and 1"):
         random_vertical_flip(types, coords, p=p)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_random_vertical_flip_accepts_cpu_generator_for_cuda_input(
+    simple_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in simple_outline)
+    generator = torch.Generator().manual_seed(0)
+
+    out_types, out_coords = random_vertical_flip(
+        types,
+        coords,
+        p=1.0,
+        generator=generator,
+    )
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/torchfont/transforms/geometric.py
+++ b/torchfont/transforms/geometric.py
@@ -38,6 +38,10 @@ def _active_pairs(types: Tensor) -> tuple[Tensor, Tensor, Tensor]:
     return pair0, pair1, pair2
 
 
+def _random_device(generator: torch.Generator | None, fallback: Tensor) -> torch.device:
+    return generator.device if generator is not None else fallback.device
+
+
 def _bbox_center(types: Tensor, coords: Tensor) -> Tensor:
     """Return the tight bounding-box centre via the Rust ``tight_bbox`` implementation.
 
@@ -233,7 +237,14 @@ def random_horizontal_flip(
 
     """
     _validate_probability(p)
-    if torch.rand(1, generator=generator).item() < p:
+    if (
+        torch.rand(
+            1,
+            device=_random_device(generator, coords),
+            generator=generator,
+        ).item()
+        < p
+    ):
         return horizontal_flip(types, coords, preserve_winding=preserve_winding)
     return types, coords
 
@@ -261,7 +272,14 @@ def random_vertical_flip(
 
     """
     _validate_probability(p)
-    if torch.rand(1, generator=generator).item() < p:
+    if (
+        torch.rand(
+            1,
+            device=_random_device(generator, coords),
+            generator=generator,
+        ).item()
+        < p
+    ):
         return vertical_flip(types, coords, preserve_winding=preserve_winding)
     return types, coords
 
@@ -342,7 +360,11 @@ def random_affine(
         msg = "translate values must be finite"
         raise ValueError(msg)
 
-    r = torch.rand(5, generator=generator)
+    r = torch.rand(
+        5,
+        device=_random_device(generator, coords),
+        generator=generator,
+    )
 
     def _u(lo: float, hi: float, i: int) -> float:
         return lo + (hi - lo) * r[i].item()
@@ -400,5 +422,10 @@ def random_coord_jitter(
         return types, coords
     active = torch.stack(list(_active_pairs(types)), dim=1).unsqueeze(-1)
     pts = coords.reshape(-1, 3, 2)
-    noise = torch.empty_like(pts).normal_(std=std, generator=generator)
+    noise = torch.empty(
+        pts.shape,
+        dtype=pts.dtype,
+        device=_random_device(generator, coords),
+    ).normal_(std=std, generator=generator)
+    noise = noise.to(device=coords.device)
     return types, torch.where(active, pts + noise, pts).reshape_as(coords)

--- a/torchfont/transforms/subpath.py
+++ b/torchfont/transforms/subpath.py
@@ -42,7 +42,11 @@ def randomize_subpath_start_points(
     """
     types = types.cpu().contiguous()
     coords = coords.cpu().contiguous()
-    random_values = torch.rand(types.size(0), generator=generator)
+    random_values = torch.rand(
+        types.size(0),
+        device=generator.device if generator is not None else types.device,
+        generator=generator,
+    ).cpu()
     out_types, out_coords = _torchfont.randomize_subpath_start_points(
         types.numpy(),
         coords.reshape(-1).numpy(),


### PR DESCRIPTION
## Summary

- generate random values on the explicitly supplied `torch.Generator` device
- transfer generated values to the transform input device before tensor operations
- cover CPU generators used with CUDA outline tensors across random geometric transforms

## Root cause

Random transforms did not share a consistent device policy. Most sampled on CPU, while coordinate jitter sampled directly on the input tensor device, causing generator/device mismatches for CUDA workflows.

## Validation

- `mise run python-check`
- `mise run test` (`239 passed`, `13 skipped`; CUDA and Google Fonts tests skipped in this environment)