### PR TITLE
chore: release v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ignore",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from 0.10.1 to 0.10.2

## What's Changed since v0.10.1

* strip padding after outline end (#285)
* fix uniform subpath start randomization (#286)
* reject non-finite affine scales (#287)
* reject outline elements outside subpaths (#288)
* reject non-finite affine parameters (#289)
* fix render bitmap return type stub (#290)
* reject non-finite jitter standard deviations (#293)
* clarify dataset fingerprint contract (#292)
* clarify em-normalized coordinate terminology (#295)
* fix random transform generator devices (#296)
* [codex] validate dataset codepoints (#297)
* remove excess validation and fallbacks per AGENTS.md policy (#298)