### PR TITLE
[codex] Ignore large data submodules in searches

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,6 @@
+# Large optional data submodules. Keep them out of default repository searches;
+# search them explicitly with `rg -u` or a direct path when needed.
+data/adobe/source-han-code-jp/
+data/fortawesome/font-awesome/
+data/google/fonts/
+data/google/material_design_icons/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "files.associations": {
+        ".ignore": "ignore"
+    },
     "ruff.nativeServer": "on",
     "ruff.configuration": "./pyproject.toml"
 }


### PR DESCRIPTION
## Summary

- Add a top-level `.ignore` so broad `rg`/compatible searches skip large optional data submodules by default.
- Associate `.ignore` files with the VS Code built-in Ignore language mode for highlighting.

## Validation

- `rg --files | rg '^data/' | wc -l` -> `0`
- `rg --files data/google/material_design_icons | head -5` still returns explicit-path results
- `uv run python -m json.tool .vscode/settings.json`
