### PR TITLE
[codex] Make tooling dirs visible to ripgrep

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -4,3 +4,8 @@ data/adobe/source-han-code-jp/
 data/fortawesome/font-awesome/
 data/google/fonts/
 data/google/material_design_icons/
+
+# Keep shared repository tooling discoverable in default ripgrep file searches.
+!/.devcontainer/
+!/.github/
+!/.vscode/


### PR DESCRIPTION
## Summary
- Whitelist shared tooling directories in `.ignore` so default `rg --files` discovers them without `--hidden`
- Include `.devcontainer`, `.github`, and `.vscode` because they contain repository, CI, and editor configuration that should not be missed during code search

## Why
`ripgrep` skips hidden directories by default. That caused `.vscode/settings.json` to be missed during repository exploration even though the file is tracked and relevant. Whitelisting these small configuration directories keeps large data submodules ignored while making shared tooling discoverable.

## Validation
- `rg --files -g 'settings.json'`\n- `rg --files -g '*.yml' -g '*.json' -g '*.sh' | rg '^\\.(github|devcontainer|vscode)/'`