### PR TITLE
[codex] Update Ruff VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,12 @@
     "files.associations": {
         ".ignore": "ignore"
     },
-    "ruff.nativeServer": "on",
-    "ruff.configuration": "./pyproject.toml"
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll.ruff": "explicit",
+            "source.organizeImports.ruff": "explicit"
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Update VS Code Python settings to use the Ruff extension as the default formatter.
- Enable format-on-save and Ruff-scoped save actions for fix-all and import organization.
- Remove explicit Ruff native server/configuration settings that are covered by current defaults and project discovery.

## Validation

- `uv run ruff --version`
