### PR TITLE
Add instance-level variable font augmentation

### DIFF
--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -25,6 +25,12 @@ Structured label metadata returned by `GlyphDataset.metadata`.
 
 ```python
 from torchfont.datasets import GlyphDataset
+from torchfont.variation import (
+    DefaultInstantiation,
+    GridInstantiation,
+    NamedInstantiation,
+    VariationInstantiation,
+)
 ```
 
 ### Constructor (`GlyphDataset`)
@@ -35,9 +41,12 @@ GlyphDataset(
     *,
     codepoints: Sequence[SupportsIndex] | None = None,
     patterns: Sequence[str] | None = None,
+    variation: VariationInstantiation | None = None,
     transform: Callable[[GlyphSample], T] | None = None,
 )
 ```
+
+Variation instantiation classes are exported from `torchfont.variation`.
 
 `T` is the transform return type and therefore the dataset item type.
 
@@ -46,6 +55,7 @@ GlyphDataset(
 | `root`             | `Path \| str`                     | root directory for font discovery   |
 | `codepoints` | `Sequence[SupportsIndex] \| None` | restrict indexed Unicode codepoints |
 | `patterns`         | `Sequence[str] \| None`           | gitignore-style path filtering      |
+| `variation` | `VariationInstantiation \| None` | variable-font instantiation policy |
 | `transform`        | `Callable \| None`                | sample-first preprocessing (`GlyphSample -> T`) |
 
 ### Behavior
@@ -53,6 +63,19 @@ GlyphDataset(
 - supported extensions: `.ttf` / `.otf` / `.ttc` / `.otc`
 - `root` is resolved to an absolute `Path` during initialization
 - `codepoints` are normalized to sorted unique integers before indexing
+- static fonts are always indexed as one static style; variable fonts use
+  `variation` in `fvar` user coordinate space
+- `variation=None` is equivalent to `NamedInstantiation()`;
+  `DefaultInstantiation()` uses the `fvar` default location;
+  `NamedInstantiation()` uses named instances when present and otherwise falls
+  back to the default location
+- `GridInstantiation(axes={"wght": 7, "wdth": 3})` samples each listed axis on
+  an evenly spaced grid (the given number of points, from axis minimum to
+  maximum) and takes the Cartesian product across those axes; axes that are not
+  listed are pinned to their `fvar` default. The instance count is the product
+  of the listed point counts and is therefore independent of the font's total
+  axis count. `axes` must list at least one axis, and every point count must be
+  greater than zero
 - no implicit ignore rules are applied (hidden directories, `.gitignore`,
   `.ignore`, global gitignore, and git exclude files are all ignored for
   discovery); use `patterns` for path selection
@@ -65,6 +88,7 @@ GlyphDataset(
 - `dataset.root`: resolved root `Path`
 - `dataset.patterns`: tuple of path-filter patterns, or `None`
 - `dataset.codepoints`: tuple of sorted unique codepoints, or `None`
+- `dataset.variation`: instantiation policy as passed, or `None`
 
 ### Return value
 
@@ -126,9 +150,8 @@ Mapping from character to content index.
 #### `style_classes -> list[str]`
 
 Style class names. Static fonts use family/subfamily names. Variable fonts use
-named instances when available, otherwise they fall back to family/subfamily
-(or family-only) names. If a named instance exists but its subfamily name is
-empty, the family name is used.
+the family name plus the selected variation location, such as
+`Roboto wght=400,wdth=100`.
 
 ### Example (`GlyphDataset`)
 

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -25,6 +25,12 @@ from torchfont.datasets import DatasetMetadata
 
 ```python
 from torchfont.datasets import GlyphDataset
+from torchfont.variation import (
+    DefaultInstantiation,
+    GridInstantiation,
+    NamedInstantiation,
+    VariationInstantiation,
+)
 ```
 
 ### コンストラクタ（`GlyphDataset`）
@@ -35,9 +41,12 @@ GlyphDataset(
     *,
     codepoints: Sequence[SupportsIndex] | None = None,
     patterns: Sequence[str] | None = None,
+    variation: VariationInstantiation | None = None,
     transform: Callable[[GlyphSample], T] | None = None,
 )
 ```
+
+Variation Instantiation クラスは `torchfont.variation` からエクスポートされます。
 
 `T` は transform の返り値型であり、そのまま dataset item の型になります。
 
@@ -46,6 +55,7 @@ GlyphDataset(
 | `root`             | `Path \| str`                     | フォント探索の起点ディレクトリ     |
 | `codepoints` | `Sequence[SupportsIndex] \| None` | 対象 Unicode codepoint を制限      |
 | `patterns`         | `Sequence[str] \| None`           | gitignore 互換パターンでパスを絞る |
+| `variation` | `VariationInstantiation \| None` | バリアブルフォントのインスタンス化方針 |
 | `transform`        | `Callable \| None`                | sample-first 前処理（`GlyphSample -> T`） |
 
 ### 振る舞い
@@ -53,6 +63,18 @@ GlyphDataset(
 - 走査対象拡張子: `.ttf` / `.otf` / `.ttc` / `.otc`
 - `root` は初期化時に絶対 `Path` へ解決される
 - `codepoints` は index 化前に sort 済み・重複なしの整数列へ正規化される
+- 静的フォントは常に 1 つの静的なスタイルとして扱い、
+  バリアブルフォントは `variation` に従って `fvar` user
+  coordinate space でインスタンス化する
+- `variation=None` は `NamedInstantiation()` と同義。
+  `DefaultInstantiation()` は `fvar` default location、
+  `NamedInstantiation()` は名前付きインスタンスがあればそれらを使い、なければ
+  default location にフォールバックする
+- `GridInstantiation(axes={"wght": 7, "wdth": 3})` は、指定した各軸を等間隔の
+  グリッド（軸の最小値〜最大値を指定点数）でサンプリングし、それらの軸間で直積を
+  取る。指定しなかった軸は `fvar` default に固定される。インスタンス数は指定した
+  点数の積であり、フォントの総軸数には依存しない。`axes` は最低 1 軸を指定し、
+  すべての点数は 0 より大きい必要がある
 - `ignore` crate の standard filters（hidden directory / `.gitignore` / `.ignore` /
   グローバル gitignore / git exclude など）による暗黙の ignore ルールは使わず、
   パス選択は `patterns` に寄せる
@@ -65,6 +87,7 @@ GlyphDataset(
 - `dataset.root`: 解決済みの root `Path`
 - `dataset.patterns`: パスフィルタの tuple、または `None`
 - `dataset.codepoints`: sort 済み・重複なし codepoint の tuple、または `None`
+- `dataset.variation`: 渡されたインスタンス化方針、または `None`
 
 ### 戻り値
 
@@ -125,7 +148,7 @@ underline_thickness)` を保持します。`italic_angle` の単位は度、
 
 #### `style_classes -> list[str]`
 
-スタイル名の配列。静的フォントは family/subfamily 名を使います。可変フォントは named instance があればそれを使い、ない場合は family/subfamily（または family のみ）へフォールバックします。named instance があっても名前が空の場合は family 名のみを使います。
+スタイル名の配列。静的フォントは family/subfamily 名を使います。バリアブルフォントは family 名に `Roboto wght=400,wdth=100` のような選択された variation location を加えた名前を使います。
 
 ### 例（`GlyphDataset`）
 

--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 from torchfont.datasets import GlyphDataset, GlyphSample
 from torchfont.glyphsets import LATIN_CORE
 from torchfont.transforms import patchify, quad_to_cubic, remove_overlaps, render_bitmap
+from torchfont.variation import GridInstantiation
 
 
 def transform(sample: GlyphSample) -> tuple[Tensor, Tensor, Tensor]:
@@ -37,6 +38,9 @@ def main() -> None:
             "ofl/*/*.ttf",
             "ufl/*/*.ttf",
             "!ofl/adobeblank/*.ttf",
+        ),
+        variation=GridInstantiation(
+            axes={"wght": 7, "wdth": 3, "opsz": 3, "slnt": 2},
         ),
         transform=transform,
     )

--- a/src/dataset/index.rs
+++ b/src/dataset/index.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::font::FontEntry;
+use crate::font::{FontEntry, VariationInstantiation};
 use std::path::PathBuf;
 
 pub(crate) struct DatasetIndex {
@@ -19,12 +19,13 @@ impl DatasetIndex {
 pub(crate) fn load_entries_and_index(
     files: Vec<PathBuf>,
     filter: Option<&[u32]>,
+    variation_instantiation: &VariationInstantiation,
 ) -> Result<(Vec<FontEntry>, DatasetIndex), Error> {
     let mut entries = Vec::new();
     let mut all_cps = Vec::new();
 
     for path in files {
-        for entry in FontEntry::load_faces(&path, filter)?
+        for entry in FontEntry::load_faces(&path, filter, variation_instantiation)?
             .into_iter()
             .filter(|e| e.codepoint_count() > 0)
         {

--- a/src/font/entry.rs
+++ b/src/font/entry.rs
@@ -3,11 +3,12 @@ use std::{fs, path::Path, sync::Arc};
 use memmap2::Mmap;
 use skrifa::raw::types::NameId;
 use skrifa::raw::{FileRef, TableProvider};
-use skrifa::{GlyphId, MetadataProvider, instance::Location};
+use skrifa::{GlyphId, MetadataProvider};
 
 use super::glyph::Hmtx;
 use super::reader::GlyphReader;
 use super::table::{Head, Hhea, Maxp, Name, Os2, Post};
+use super::variation::{StyleSpace, VariationInstantiation};
 use crate::error::Error;
 use crate::geom::{Bounds, Outline};
 
@@ -25,12 +26,15 @@ pub(crate) struct FontEntry {
     pub(crate) post: Post,
     pub(crate) maxp: Maxp,
     pub(crate) name: Name,
-    locations: Vec<Location>,
-    style_axes: Vec<Vec<(String, f32)>>,
+    style_space: StyleSpace,
 }
 
 impl FontEntry {
-    pub(crate) fn load_faces(path: &Path, filter: Option<&[u32]>) -> Result<Vec<Self>, Error> {
+    pub(crate) fn load_faces(
+        path: &Path,
+        filter: Option<&[u32]>,
+        variation_instantiation: &VariationInstantiation,
+    ) -> Result<Vec<Self>, Error> {
         let mapped = Arc::new(map_font(path)?);
         let parsed = FileRef::new(&mapped[..])
             .map_err(|err| Error::Parse(format!("failed to parse '{}': {err}", path.display())))?;
@@ -45,7 +49,14 @@ impl FontEntry {
                         path.display()
                     ))
                 })?;
-                Self::from_face(path, face_index as u32, Arc::clone(&mapped), &font, filter)
+                Self::from_face(
+                    path,
+                    face_index as u32,
+                    Arc::clone(&mapped),
+                    &font,
+                    filter,
+                    variation_instantiation,
+                )
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
@@ -65,20 +76,20 @@ impl FontEntry {
     ) -> Result<(Outline, Hmtx, Bounds, String), Error> {
         let glyph_idx = self.lookup_glyph_index(codepoint)?;
         let glyph_id = self.index.glyph_ids[glyph_idx];
-        self.reader.draw_glyph(
-            glyph_id,
-            self.head.units_per_em,
-            &self.locations,
-            instance_index,
-        )
+        let user_location = match instance_index {
+            Some(index) => self.style_space.user_coords(index),
+            None => Vec::new(),
+        };
+        self.reader
+            .draw_glyph(glyph_id, self.head.units_per_em, &user_location)
     }
 
     pub(crate) fn instance_count(&self) -> usize {
-        self.style_axes.len()
+        self.style_space.len()
     }
 
     pub(crate) fn is_variable(&self) -> bool {
-        !self.locations.is_empty()
+        self.style_space.is_variable()
     }
 
     pub(crate) fn path(&self) -> &Path {
@@ -97,15 +108,8 @@ impl FontEntry {
         self.index.codepoints.len()
     }
 
-    pub(crate) fn named_instance_names(&self) -> Vec<Option<String>> {
-        if !self.is_variable() {
-            return vec![];
-        }
-        self.reader.named_instance_names()
-    }
-
-    pub(crate) fn style_axes(&self) -> &[Vec<(String, f32)>] {
-        &self.style_axes
+    pub(crate) fn style_axes_at(&self, instance_index: usize) -> Vec<(String, f32)> {
+        self.style_space.user_coords(instance_index)
     }
 
     fn from_face(
@@ -114,6 +118,7 @@ impl FontEntry {
         data: Arc<Mmap>,
         font: &skrifa::FontRef<'_>,
         filter: Option<&[u32]>,
+        variation_instantiation: &VariationInstantiation,
     ) -> Result<Self, Error> {
         let (head, hhea, os2, post, maxp, name) = parse_font_tables(font, base_path, face_index)?;
 
@@ -129,29 +134,7 @@ impl FontEntry {
         mappings.sort_unstable_by_key(|entry| entry.0);
         let (codepoints, glyph_ids): (Vec<_>, Vec<_>) = mappings.into_iter().unzip();
 
-        let axis_tags: Vec<String> = font
-            .axes()
-            .iter()
-            .map(|axis| axis.tag().to_string())
-            .collect();
-        let named_instances = font.named_instances();
-        let locations: Vec<Location> = named_instances.iter().map(|inst| inst.location()).collect();
-        let style_axes = if locations.is_empty() {
-            vec![vec![]]
-        } else {
-            named_instances
-                .iter()
-                .map(|inst| {
-                    debug_assert_eq!(
-                        axis_tags.len(),
-                        inst.user_coords().count(),
-                        "font '{}' (face {face_index}) reported mismatched axis metadata",
-                        base_path.display(),
-                    );
-                    axis_tags.iter().cloned().zip(inst.user_coords()).collect()
-                })
-                .collect()
-        };
+        let style_space = variation_instantiation.instantiate(font, base_path, face_index)?;
 
         Ok(Self {
             index: GlyphIndex {
@@ -165,8 +148,7 @@ impl FontEntry {
             post,
             maxp,
             name,
-            locations,
-            style_axes,
+            style_space,
         })
     }
 

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -3,6 +3,8 @@ mod extract;
 pub(crate) mod glyph;
 mod reader;
 pub(crate) mod table;
+mod variation;
 
 pub(crate) use entry::FontEntry;
 pub(crate) use extract::extract_glyph_outline;
+pub(crate) use variation::VariationInstantiation;

--- a/src/font/reader.rs
+++ b/src/font/reader.rs
@@ -6,7 +6,7 @@ use std::{
 use memmap2::Mmap;
 use skrifa::{
     GlyphId, MetadataProvider,
-    instance::{Location, LocationRef, Size},
+    instance::{LocationRef, Size},
     outline::DrawSettings,
     raw::TableProvider,
 };
@@ -44,8 +44,7 @@ impl GlyphReader {
         &self,
         glyph_id: GlyphId,
         units_per_em: u16,
-        locations: &[Location],
-        instance_index: Option<usize>,
+        user_location: &[(String, f32)],
     ) -> Result<(Outline, Hmtx, Bounds, String), Error> {
         self.with_font_ref(|font| {
             let glyph = font.outline_glyphs().get(glyph_id).ok_or_else(|| {
@@ -56,7 +55,12 @@ impl GlyphReader {
                 ))
             })?;
 
-            let location_ref = self.location_ref(locations, instance_index)?;
+            let location = font.axes().location(
+                user_location
+                    .iter()
+                    .map(|(tag, value)| (tag.as_str(), *value)),
+            );
+            let location_ref = LocationRef::from(&location);
 
             let outline = extract_glyph_outline(
                 &glyph,
@@ -102,21 +106,6 @@ impl GlyphReader {
         })
     }
 
-    pub(super) fn named_instance_names(&self) -> Vec<Option<String>> {
-        self.with_font_ref(|font| {
-            Ok(font
-                .named_instances()
-                .iter()
-                .map(|inst| {
-                    font.localized_strings(inst.subfamily_name_id())
-                        .english_or_first()
-                        .map(|s| s.to_string())
-                })
-                .collect())
-        })
-        .unwrap_or_default()
-    }
-
     fn with_font_ref<T>(
         &self,
         f: impl FnOnce(skrifa::FontRef<'_>) -> Result<T, Error>,
@@ -130,24 +119,6 @@ impl GlyphReader {
             ))
         })?;
         f(font)
-    }
-
-    fn location_ref<'a>(
-        &self,
-        locations: &'a [Location],
-        index: Option<usize>,
-    ) -> Result<LocationRef<'a>, Error> {
-        index.map_or(Ok(LocationRef::default()), |idx| {
-            locations
-                .get(idx)
-                .ok_or_else(|| {
-                    Error::OutOfRange(format!(
-                        "instance index {idx} out of range for '{}'",
-                        self.path.display()
-                    ))
-                })
-                .map(LocationRef::from)
-        })
     }
 }
 

--- a/src/font/variation.rs
+++ b/src/font/variation.rs
@@ -1,0 +1,216 @@
+use std::{collections::HashMap, path::Path};
+
+use skrifa::MetadataProvider;
+
+use crate::error::Error;
+
+#[derive(Clone)]
+pub(crate) enum VariationInstantiation {
+    Default,
+    Named,
+    Grid { axes: HashMap<String, u32> },
+}
+
+/// Lazily enumerable set of variable-font instances.
+///
+/// Rather than materializing every instance up front, this keeps only the
+/// per-axis candidate values (for Cartesian policies such as `Default`/`Grid`)
+/// or the explicit named-instance coordinate list, and derives the i-th
+/// instance on demand. This keeps memory proportional to the axis description
+/// instead of the combinatorial instance count.
+pub(crate) struct StyleSpace {
+    axis_tags: Vec<String>,
+    kind: StyleSpaceKind,
+}
+
+enum StyleSpaceKind {
+    /// Cartesian product of per-axis candidate values.
+    Cartesian { axis_points: Vec<Vec<f32>> },
+    /// Explicit list of full user-coordinate tuples (named instances).
+    Explicit { instances: Vec<Vec<f32>> },
+}
+
+impl StyleSpace {
+    fn static_single() -> Self {
+        Self {
+            axis_tags: Vec::new(),
+            kind: StyleSpaceKind::Cartesian {
+                axis_points: Vec::new(),
+            },
+        }
+    }
+
+    pub(crate) fn is_variable(&self) -> bool {
+        !self.axis_tags.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match &self.kind {
+            StyleSpaceKind::Cartesian { axis_points } => axis_points.iter().map(Vec::len).product(),
+            StyleSpaceKind::Explicit { instances } => instances.len(),
+        }
+    }
+
+    /// User-space axis coordinates of the `index`-th instance.
+    ///
+    /// For the Cartesian kind the instance index is decomposed mixed-radix
+    /// across the axes (first axis most significant), matching the order in
+    /// which a fully materialized grid would have been enumerated.
+    pub(crate) fn user_coords(&self, index: usize) -> Vec<(String, f32)> {
+        match &self.kind {
+            StyleSpaceKind::Cartesian { axis_points } => {
+                let mut radix: usize = axis_points.iter().map(Vec::len).product();
+                let mut remainder = index;
+                let mut coords = Vec::with_capacity(self.axis_tags.len());
+                for (tag, points) in self.axis_tags.iter().zip(axis_points) {
+                    radix /= points.len();
+                    let digit = remainder / radix;
+                    remainder %= radix;
+                    coords.push((tag.clone(), points[digit]));
+                }
+                coords
+            }
+            StyleSpaceKind::Explicit { instances } => self
+                .axis_tags
+                .iter()
+                .cloned()
+                .zip(instances[index].iter().copied())
+                .collect(),
+        }
+    }
+}
+
+impl VariationInstantiation {
+    pub(crate) fn instantiate(
+        &self,
+        font: &skrifa::FontRef<'_>,
+        path: &Path,
+        face_index: u32,
+    ) -> Result<StyleSpace, Error> {
+        let axis_info: Vec<AxisInfo> = font
+            .axes()
+            .iter()
+            .map(|axis| AxisInfo {
+                tag: axis.tag().to_string(),
+                min: axis.min_value(),
+                default: axis.default_value(),
+                max: axis.max_value(),
+            })
+            .collect();
+
+        if axis_info.is_empty() {
+            return Ok(StyleSpace::static_single());
+        }
+
+        let axis_tags: Vec<String> = axis_info.iter().map(|axis| axis.tag.clone()).collect();
+        let kind = match self {
+            Self::Default => StyleSpaceKind::Cartesian {
+                axis_points: default_points(&axis_info),
+            },
+            Self::Named => match named_instance_coords(font, &axis_tags, path, face_index)? {
+                Some(instances) => StyleSpaceKind::Explicit { instances },
+                None => StyleSpaceKind::Cartesian {
+                    axis_points: default_points(&axis_info),
+                },
+            },
+            Self::Grid { axes } => StyleSpaceKind::Cartesian {
+                axis_points: axis_info
+                    .iter()
+                    .map(|axis| axis_grid_points(axis, axis_sample_count(axis, axes)))
+                    .collect(),
+            },
+        };
+
+        Ok(StyleSpace { axis_tags, kind })
+    }
+}
+
+struct AxisInfo {
+    tag: String,
+    min: f32,
+    default: f32,
+    max: f32,
+}
+
+fn default_points(axes: &[AxisInfo]) -> Vec<Vec<f32>> {
+    axes.iter().map(|axis| vec![axis.default]).collect()
+}
+
+fn named_instance_coords(
+    font: &skrifa::FontRef<'_>,
+    axis_tags: &[String],
+    path: &Path,
+    face_index: u32,
+) -> Result<Option<Vec<Vec<f32>>>, Error> {
+    let named_instances = font.named_instances();
+    if named_instances.is_empty() {
+        return Ok(None);
+    }
+    let instances = named_instances
+        .iter()
+        .map(|inst| {
+            let coords: Vec<f32> = inst.user_coords().collect();
+            if coords.len() != axis_tags.len() {
+                return Err(Error::Parse(format!(
+                    "font '{}' (face {face_index}) reported mismatched axis metadata",
+                    path.display(),
+                )));
+            }
+            Ok(coords)
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    Ok(Some(dedup_coords(instances)))
+}
+
+fn dedup_coords(coords: Vec<Vec<f32>>) -> Vec<Vec<f32>> {
+    let mut unique = Vec::new();
+    for coord in coords {
+        if !unique.contains(&coord) {
+            unique.push(coord);
+        }
+    }
+    unique
+}
+
+/// Number of grid points for an axis: the explicitly requested count, or `1`
+/// (pinned to the axis default) for axes the caller did not list.
+fn axis_sample_count(axis: &AxisInfo, axes: &HashMap<String, u32>) -> u32 {
+    axes.get(&axis.tag).copied().unwrap_or(1)
+}
+
+fn axis_grid_points(axis: &AxisInfo, count: u32) -> Vec<f32> {
+    match count {
+        1 => vec![axis.default],
+        n => (0..n)
+            .map(|i| {
+                let t = i as f32 / (n - 1) as f32;
+                lerp(axis.min, axis.max, t)
+            })
+            .collect(),
+    }
+}
+
+fn lerp(min: f32, max: f32, t: f32) -> f32 {
+    min + (max - min) * t
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dedup_coords;
+
+    #[test]
+    fn dedup_coords_removes_duplicates() {
+        let coords = vec![
+            vec![100.0, 400.0],
+            vec![100.0, 700.0],
+            vec![100.0, 400.0],
+            vec![75.0, 400.0],
+            vec![100.0, 700.0],
+        ];
+
+        assert_eq!(
+            dedup_coords(coords),
+            vec![vec![100.0, 400.0], vec![100.0, 700.0], vec![75.0, 400.0],],
+        );
+    }
+}

--- a/src/py/dataset.rs
+++ b/src/py/dataset.rs
@@ -1,12 +1,92 @@
 use numpy::{IntoPyArray as _, PyArray1};
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyTuple};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::dataset::{
     DatasetIndex, FontEntry, canonicalize_root, discover_font_files, load_entries_and_index,
     structure_fingerprint,
 };
+use crate::font::VariationInstantiation;
+
+#[pyclass(module = "torchfont._torchfont")]
+pub(crate) struct DefaultInstantiation;
+
+#[pymethods]
+impl DefaultInstantiation {
+    #[new]
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn __getnewargs__<'py>(&self, py: Python<'py>) -> Bound<'py, PyTuple> {
+        PyTuple::empty(py)
+    }
+}
+
+#[pyclass(module = "torchfont._torchfont")]
+pub(crate) struct NamedInstantiation;
+
+#[pymethods]
+impl NamedInstantiation {
+    #[new]
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn __getnewargs__<'py>(&self, py: Python<'py>) -> Bound<'py, PyTuple> {
+        PyTuple::empty(py)
+    }
+}
+
+#[pyclass(module = "torchfont._torchfont")]
+pub(crate) struct GridInstantiation {
+    #[pyo3(get)]
+    pub axes: HashMap<String, u32>,
+}
+
+#[pymethods]
+impl GridInstantiation {
+    #[new]
+    pub fn new(axes: HashMap<String, u32>) -> PyResult<Self> {
+        if axes.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "GridInstantiation requires at least one axis in axes; \
+                 use DefaultInstantiation to pin every axis to its default",
+            ));
+        }
+        if axes.values().any(|&count| count == 0) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "GridInstantiation axis densities must be greater than zero",
+            ));
+        }
+        Ok(Self { axes })
+    }
+
+    pub fn __getnewargs__(&self) -> (HashMap<String, u32>,) {
+        (self.axes.clone(),)
+    }
+}
+
+#[derive(FromPyObject)]
+pub(crate) enum PyVariationInstantiation<'py> {
+    Default(PyRef<'py, DefaultInstantiation>),
+    Named(PyRef<'py, NamedInstantiation>),
+    Grid(PyRef<'py, GridInstantiation>),
+}
+
+impl From<PyVariationInstantiation<'_>> for VariationInstantiation {
+    fn from(value: PyVariationInstantiation<'_>) -> Self {
+        match value {
+            PyVariationInstantiation::Default(_inst) => Self::Default,
+            PyVariationInstantiation::Named(_inst) => Self::Named,
+            PyVariationInstantiation::Grid(grid) => Self::Grid {
+                axes: grid.axes.clone(),
+            },
+        }
+    }
+}
 
 #[pyclass(get_all)]
 pub(crate) struct GlyphItem {
@@ -41,6 +121,7 @@ impl GlyphDatasetBackend {
         root: String,
         codepoints: Option<Vec<u32>>,
         patterns: Option<Vec<String>>,
+        variation_instantiation: Option<PyVariationInstantiation<'_>>,
     ) -> PyResult<Self> {
         let filter = codepoints.map(|mut values| {
             values.sort_unstable();
@@ -50,7 +131,12 @@ impl GlyphDatasetBackend {
 
         let root_path = canonicalize_root(&root)?;
         let files = discover_font_files(&root_path, patterns.as_deref())?;
-        let (entries, index) = load_entries_and_index(files, filter.as_deref())?;
+        let variation_instantiation = match variation_instantiation {
+            Some(value) => value.into(),
+            None => VariationInstantiation::Named,
+        };
+        let (entries, index) =
+            load_entries_and_index(files, filter.as_deref(), &variation_instantiation)?;
         let fingerprint = structure_fingerprint(&entries);
 
         Ok(Self {
@@ -101,10 +187,10 @@ impl GlyphDatasetBackend {
     pub fn style_metadata_rows(&self) -> PyResult<Vec<(String, String)>> {
         self.style_rows()
             .into_iter()
-            .map(|(name, path, face_idx, instance_idx)| {
+            .map(|(name, path, face_idx, instance_label)| {
                 Ok((
                     name,
-                    style_label_id(&self.root, &path, face_idx, instance_idx)?,
+                    style_label_id(&self.root, &path, face_idx, instance_label)?,
                 ))
             })
             .collect()
@@ -114,7 +200,9 @@ impl GlyphDatasetBackend {
     pub fn style_axes(&self) -> Vec<Vec<(String, f32)>> {
         self.entries
             .iter()
-            .flat_map(|e| e.style_axes().iter().cloned())
+            .flat_map(|entry| {
+                (0..entry.instance_count()).map(move |index| entry.style_axes_at(index))
+            })
             .collect()
     }
 
@@ -286,7 +374,7 @@ impl GlyphDatasetBackend {
 }
 
 impl GlyphDatasetBackend {
-    fn style_rows(&self) -> Vec<(String, PathBuf, u32, Option<usize>)> {
+    fn style_rows(&self) -> Vec<(String, PathBuf, u32, Option<String>)> {
         let mut rows = Vec::new();
         for entry in self.entries.iter() {
             let path = entry.path().to_owned();
@@ -297,14 +385,16 @@ impl GlyphDatasetBackend {
             } else {
                 &n.family_name
             };
-            let instance_names = entry.named_instance_names();
-            if !instance_names.is_empty() {
-                for (inst_idx, name_opt) in instance_names.iter().enumerate() {
-                    let display_name = match name_opt.as_deref().filter(|s| !s.is_empty()) {
-                        Some(name) => format!("{family} {name}"),
-                        None => family.clone(),
+            if entry.is_variable() {
+                for index in 0..entry.instance_count() {
+                    let axes = entry.style_axes_at(index);
+                    let location = axes_label(&axes);
+                    let display_name = if location.is_empty() {
+                        family.clone()
+                    } else {
+                        format!("{family} {location}")
                     };
-                    rows.push((display_name, path.clone(), face_idx, Some(inst_idx)));
+                    rows.push((display_name, path.clone(), face_idx, Some(location)));
                 }
             } else {
                 let sub = if !n.typographic_subfamily_name.is_empty() {
@@ -370,7 +460,7 @@ fn style_label_id(
     root: &Path,
     font_path: &Path,
     face_idx: u32,
-    instance_idx: Option<usize>,
+    instance_label: Option<String>,
 ) -> PyResult<String> {
     let relative_path = font_path.strip_prefix(root).map_err(|_| {
         pyo3::exceptions::PyValueError::new_err(format!(
@@ -386,8 +476,27 @@ fn style_label_id(
         })
         .collect::<Vec<_>>()
         .join("/");
-    let instance_value = instance_idx.map_or_else(|| "static".to_string(), |idx| idx.to_string());
+    let instance_value = instance_label.unwrap_or_else(|| "static".to_string());
     Ok(format!(
-        "style:path={quoted_path};face={face_idx};instance={instance_value}"
+        "style:path={quoted_path};face={face_idx};instance={}",
+        urlencoding::encode(&instance_value),
     ))
+}
+
+fn axes_label(axes: &[(String, f32)]) -> String {
+    axes.iter()
+        .map(|(tag, value)| format!("{tag}={}", format_axis_value(*value)))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn format_axis_value(value: f32) -> String {
+    let mut formatted = format!("{value:.6}");
+    while formatted.contains('.') && formatted.ends_with('0') {
+        formatted.pop();
+    }
+    if formatted.ends_with('.') {
+        formatted.pop();
+    }
+    formatted
 }

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -7,6 +7,9 @@ use pyo3::{Bound, PyResult, types::PyModule, types::PyModuleMethods};
 pub(crate) fn register_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<dataset::GlyphDatasetBackend>()?;
     m.add_class::<dataset::GlyphItem>()?;
+    m.add_class::<dataset::DefaultInstantiation>()?;
+    m.add_class::<dataset::NamedInstantiation>()?;
+    m.add_class::<dataset::GridInstantiation>()?;
     glyphsets::register(m)?;
     transforms::register(m)?;
     Ok(())

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -16,6 +16,7 @@ from torch.utils.data import DataLoader
 
 import torchfont
 import torchfont.datasets as datasets_module
+import torchfont.variation as variation_module
 from torchfont import _torchfont
 from torchfont.datasets import (
     DatasetMetadata,
@@ -26,6 +27,7 @@ from torchfont.datasets import (
 )
 from torchfont.io import ElementType
 from torchfont.metadata import build_dataset_metadata
+from torchfont.variation import DefaultInstantiation, GridInstantiation
 
 
 def _to_pair(sample: GlyphSample) -> tuple[torch.Tensor, torch.Tensor]:
@@ -199,6 +201,9 @@ def test_datasets_public_api_is_glyphdataset_centered() -> None:
     assert datasets_module.DatasetMetadata is DatasetMetadata
     assert datasets_module.GlyphDataset is GlyphDataset
     assert datasets_module.GlyphSample is GlyphSample
+    assert not hasattr(datasets_module, "DefaultInstantiation")
+    assert not hasattr(datasets_module, "NamedInstantiation")
+    assert not hasattr(datasets_module, "GridInstantiation")
     assert not hasattr(datasets_module, "FontFolder")
     assert not hasattr(datasets_module, "FontRepo")
     assert not hasattr(datasets_module, "GoogleFonts")
@@ -214,6 +219,12 @@ def test_package_root_stays_thin() -> None:
 def test_native_dataset_backend_is_not_public_dataset_api() -> None:
     assert hasattr(_torchfont, "GlyphDatasetBackend")
     assert not hasattr(_torchfont, "GlyphDataset")
+
+
+def test_variation_module_reexports_native_instantiations() -> None:
+    assert variation_module.DefaultInstantiation is _torchfont.DefaultInstantiation
+    assert variation_module.NamedInstantiation is _torchfont.NamedInstantiation
+    assert variation_module.GridInstantiation is _torchfont.GridInstantiation
 
 
 def test_glyph_dataset_is_primary_local_api() -> None:
@@ -831,18 +842,91 @@ def test_variable_font_style_axes_are_exposed_in_metadata() -> None:
 
     labels_by_name = {label.name: label for label in dataset.metadata.styles}
 
-    assert labels_by_name["Roboto Thin"].axes == (
+    assert labels_by_name["Roboto wght=100,wdth=100"].axes == (
         StyleAxis(tag="wght", value=100.0),
         StyleAxis(tag="wdth", value=100.0),
     )
-    assert labels_by_name["Roboto Regular"].axes == (
+    assert labels_by_name["Roboto wght=400,wdth=100"].axes == (
         StyleAxis(tag="wght", value=400.0),
         StyleAxis(tag="wdth", value=100.0),
     )
-    assert labels_by_name["Roboto Condensed Regular"].axes == (
+    assert labels_by_name["Roboto wght=400,wdth=75"].axes == (
         StyleAxis(tag="wght", value=400.0),
         StyleAxis(tag="wdth", value=75.0),
     )
+
+
+def test_variable_font_default_instantiation_uses_one_default_style() -> None:
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("roboto/Roboto*.ttf",),
+        codepoints=range(0x41, 0x44),
+        variation=DefaultInstantiation(),
+    )
+
+    assert len(dataset.style_classes) == 1
+    assert dataset.metadata.styles[0].axes == (
+        StyleAxis(tag="wght", value=400.0),
+        StyleAxis(tag="wdth", value=100.0),
+    )
+
+
+def test_grid_instantiation_uses_density_product() -> None:
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("roboto/Roboto*.ttf",),
+        codepoints=range(0x41, 0x44),
+        variation=GridInstantiation(
+            axes={"wght": 2, "wdth": 2},
+        ),
+    )
+
+    assert len(dataset.style_classes) == 4
+    assert len(dataset) == 12
+
+
+def test_unlisted_axes_are_pinned_to_default() -> None:
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("roboto/Roboto*.ttf",),
+        codepoints=[0x41],
+        variation=GridInstantiation(
+            axes={"wght": 3, "missing": 99},
+        ),
+    )
+
+    assert len(dataset.style_classes) == 3
+    assert {
+        axis.value
+        for label in dataset.metadata.styles
+        for axis in label.axes
+        if axis.tag == "wdth"
+    } == {100.0}
+
+
+def test_grid_instantiation_requires_at_least_one_axis() -> None:
+    with pytest.raises(ValueError, match="at least one axis"):
+        GridInstantiation(axes={})
+
+
+def test_grid_instantiation_requires_positive_axis_densities() -> None:
+    with pytest.raises(ValueError, match="greater than zero"):
+        GridInstantiation(axes={"wght": 0})
+
+
+def test_variation_survives_pickle() -> None:
+    dataset = GlyphDataset(
+        root="tests/fonts",
+        patterns=("roboto/Roboto*.ttf",),
+        codepoints=[0x41],
+        variation=GridInstantiation(axes={"wght": 2}),
+    )
+
+    restored = pickle.loads(pickle.dumps(dataset))  # noqa: S301
+
+    assert isinstance(restored.variation, GridInstantiation)
+    assert restored.variation.axes == {"wght": 2}
+    assert restored.style_classes == dataset.style_classes
 
 
 @pytest.mark.parametrize("start_method", [None, *mp.get_all_start_methods()])

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -54,12 +54,26 @@ class GlyphItem:
     codepoint: int
     glyph_name: str
 
+class DefaultInstantiation:
+    def __init__(self) -> None: ...
+
+class NamedInstantiation:
+    def __init__(self) -> None: ...
+
+class GridInstantiation:
+    axes: dict[str, int]
+
+    def __init__(self, axes: dict[str, int]) -> None: ...
+
 class GlyphDatasetBackend:
     def __init__(
         self,
         root: str,
         codepoints: Sequence[int] | None = ...,
         patterns: Sequence[str] | None = ...,
+        variation_instantiation: (
+            DefaultInstantiation | NamedInstantiation | GridInstantiation | None
+        ) = ...,
     ) -> None: ...
 
     sample_count: int

--- a/torchfont/datasets.py
+++ b/torchfont/datasets.py
@@ -36,6 +36,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 
 from torchfont import _torchfont
+from torchfont import variation as _variation
 from torchfont.io import COORD_DIM
 from torchfont.metadata import (
     DatasetMetadata,
@@ -182,6 +183,7 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         *,
         codepoints: Sequence[SupportsIndex] | None = None,
         patterns: Sequence[str] | None = None,
+        variation: _variation.VariationInstantiation | None = None,
         transform: None = None,
     ) -> None: ...
 
@@ -192,6 +194,7 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         *,
         codepoints: Sequence[SupportsIndex] | None = None,
         patterns: Sequence[str] | None = None,
+        variation: _variation.VariationInstantiation | None = None,
         transform: Callable[[GlyphSample], _T],
     ) -> None: ...
 
@@ -201,6 +204,7 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         *,
         codepoints: Sequence[SupportsIndex] | None = None,
         patterns: Sequence[str] | None = None,
+        variation: _variation.VariationInstantiation | None = None,
         transform: (Callable[[GlyphSample], _T] | None) = None,
     ) -> None:
         """Initialize the dataset by scanning font files and indexing samples.
@@ -219,6 +223,9 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
                 ``.ignore``, global gitignore, or git exclude rules) is applied;
                 all such behavior must be expressed via ``patterns``. VCS metadata
                 directories such as ``.git`` remain excluded.
+            variation (VariationInstantiation): Variable-font instantiation
+                policy. Static fonts are always indexed as one static style.
+                ``None`` is equivalent to ``NamedInstantiation()``.
             transform (Callable[[GlyphSample], _T] | None): Optional
                 transformation applied to each sample before the item is returned.
                 When provided, ``_T`` is inferred from the transform return type
@@ -241,11 +248,13 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
             else None
         )
         self.codepoints = self._normalize_codepoints(codepoints)
+        self.variation = variation
 
         self._backend = _torchfont.GlyphDatasetBackend(
             str(self.root),
             self.codepoints,
             self.patterns,
+            self.variation,
         )
         self._fingerprint: int = self._backend.fingerprint
 
@@ -370,6 +379,7 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
             str(self.root),
             self.codepoints,
             self.patterns,
+            self.variation,
         )
         if backend.fingerprint != self._fingerprint:
             msg = (
@@ -494,7 +504,7 @@ class GlyphDataset(Dataset[_T], Generic[_T]):
         """List of style variation instance names in the dataset.
 
         Returns class names sorted by their index. For variable fonts, names
-        come from the font's named instances. For static fonts, names are
+        include the selected variation location. For static fonts, names are
         derived from the font's family and subfamily names.
 
         Returns:

--- a/torchfont/variation.py
+++ b/torchfont/variation.py
@@ -1,0 +1,20 @@
+"""Variation instantiation policies for variable fonts."""
+
+from typing import TypeAlias
+
+from torchfont._torchfont import (
+    DefaultInstantiation,
+    GridInstantiation,
+    NamedInstantiation,
+)
+
+VariationInstantiation: TypeAlias = (
+    DefaultInstantiation | NamedInstantiation | GridInstantiation
+)
+
+__all__ = [
+    "DefaultInstantiation",
+    "GridInstantiation",
+    "NamedInstantiation",
+    "VariationInstantiation",
+]


### PR DESCRIPTION
Closes #311 (sub-issue of #301).

Adds **instance-level augmentation** for variable fonts: the dataset can sample a variable font's design space into a fixed set of discrete style instances, each treated as an additional style. This is the simpler of the two augmentation directions discussed in #301; glyph-level augmentation is tracked separately in #312.

## API

`GlyphDataset` gains a `variation` keyword accepting a `VariationInstantiation` policy (`torchfont.variation`):

- **`NamedInstantiation()`** — enumerate the font's named instances. Current behavior; used when `variation=None`, so existing callers are unaffected.
- **`DefaultInstantiation()`** — pin every axis to its default, yielding a single instance per face.
- **`GridInstantiation({axis: count, ...})`** — Cartesian product of per-axis sample counts. Unlisted axes are pinned to their default; listed axes are sampled evenly from min to max.

Static fonts are always indexed as a single static style regardless of policy.

## Implementation notes

- `StyleSpace` (Rust) stores the compact axis description instead of materializing every Cartesian coordinate tuple. When a dataset item is fetched, the instance index is decomposed mixed-radix to compute that instance's coordinates deterministically and without mutable runtime state.
- Named-instance coordinates are de-duplicated.
- Style labels now encode the resolved axis location (e.g. `wght=700,wdth=75`), URL-encoded in the style id.
- `GridInstantiation` validates at construction: at least one axis, all counts > 0.

## Docs

`docs/en` and `docs/ja` reference pages updated and kept aligned.

## Tests

`tests/test_dataset.py` covers the three policies, label encoding, and validation. Full suite passes (234 passed, 13 skipped).
