### PR TITLE
Fix VS Code uv detection in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,7 @@
 	],
 	"containerEnv": {
 		"MISE_TRUSTED_CONFIG_PATHS": "/workspaces",
+		"MISE_UV_VERSION": "latest",
 		"UV_LINK_MODE": "copy"
 	},
 	"onCreateCommand": "sudo chown -R vscode:vscode /mise /home/vscode/.cache/uv .venv target node_modules data",


### PR DESCRIPTION
## Summary

- set `MISE_UV_VERSION=latest` in the Dev Container environment
- make the mise uv shim resolvable by VS Code extension-host processes regardless of their working directory
- prevent the Python Environments extension from falling back to the intentionally absent `pip` module

## Root cause

TorchFont's uv environment intentionally does not contain pip. After an editable build, the VS Code Python Environments extension refreshes its package list. It first probes `uv --version`, but uv was configured only by the workspace-local `mise.toml`. When the probe ran outside that configuration context, the mise shim reported that no uv version was set. The extension then fell back to `python -m pip list`, producing repeated notifications because pip is not installed.

## Impact

The extension host can now discover uv consistently and use `uv pip list` / `uv pip tree` for package refreshes. This preserves the pip-free uv environment and removes the build-time VS Code error popups.

A Dev Container rebuild is required for the environment variable to take effect.

## Validation

- rebuilt the Dev Container and verified `MISE_UV_VERSION=latest` is present in the extension-host environment
- verified `uv --version` succeeds outside the workspace
- verified `uv pip list` and `uv pip tree` succeed against `.venv`
- verified the latest Python Environments log contains no pip fallback or package-refresh errors
- successfully ran:
  - `uv run maturin develop`
  - `uv run maturin develop --release`
  - `uv sync --reinstall-package torchfont`
  - `uv build --wheel`
  - `mise run --force build`
- validated `.devcontainer/devcontainer.json` syntax
