### PR TITLE
Move random location sampling to transforms

### DIFF
--- a/docs/en/reference/datasets.md
+++ b/docs/en/reference/datasets.md
@@ -124,7 +124,6 @@ from torchfont.instance_fn import (
     grid_instance_count,
     named_instances,
     named_instance_count,
-    random_location,
 )
 ```
 
@@ -133,13 +132,12 @@ Built-ins:
 - `named_instances(font)`: fvar named instances, deduplicated; falls back to default
 - `default_instance(font)`: one default location
 - `grid_instances({"wght": 7, "wdth": 3})`: evenly spaced fixed grid; axes absent from a font are ignored, unlisted axes use their defaults, and static fonts use one default instance
-- `random_location(font, generator=None)`: one location for transform-time sampling
 - `named_instance_count(font)`: instance count matching `named_instances`
 - `default_instance_count(font)`: one instance slot
 - `grid_instance_count({"wght": 7, "wdth": 3})`: instance count matching `grid_instances`
 
-Randomness uses the optional `torch.Generator`; datasets do not have a
-dataset-level seed.
+For transform-time variation sampling, see `random_location` in
+[Transform Utilities](./transforms.md). Datasets do not have a dataset-level seed.
 
 Custom instance functions may return zero locations. Unknown axes and duplicate
 locations after normalization raise `ValueError` during dataset construction.

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -1,7 +1,7 @@
 # Transform Utilities
 
 `torchfont.transforms` provides small utility functions for adapting glyph
-tensors. Keep dataset item shaping in your own preprocessing code.
+samples and tensors. Keep dataset item shaping in your own preprocessing code.
 
 ## load_glyph
 
@@ -20,7 +20,7 @@ inside a `GlyphDataset`/`VariableGlyphDataset` `transform`. It returns
 For `VariableGlyphRef`, pass a location explicitly:
 
 ```python
-from torchfont.instance_fn import random_location
+from torchfont.transforms import random_location
 
 sample = variable_dataset[0]
 location = random_location(sample.ref.font)
@@ -29,6 +29,18 @@ types, coords = load_glyph(sample.ref, location)
 
 For explicit locations, unknown axes, out-of-range values, and NaN/inf values
 raise `ValueError`. Missing axes use the font default.
+
+## random_location
+
+```python
+from torchfont.transforms import random_location
+
+location = random_location(sample.ref.font, generator=None)
+```
+
+Samples each variation axis independently and uniformly over its user-space
+minimum and maximum. Static fonts return an empty dictionary. Randomness uses
+the optional `torch.Generator`.
 
 ## quad_to_cubic
 

--- a/docs/ja/reference/datasets.md
+++ b/docs/ja/reference/datasets.md
@@ -124,7 +124,6 @@ from torchfont.instance_fn import (
     grid_instance_count,
     named_instances,
     named_instance_count,
-    random_location,
 )
 ```
 
@@ -133,12 +132,12 @@ from torchfont.instance_fn import (
 - `named_instances(font)`: fvar named instance を dedupe して返す。なければ default
 - `default_instance(font)`: default location 1 つ
 - `grid_instances({"wght": 7, "wdth": 3})`: 等間隔の固定 grid。フォントに存在しない軸は無視し、指定されなかった軸は default を使い、静的フォントは default 1 枠
-- `random_location(font, generator=None)`: transform 時 sampling 用の location 1 つ
 - `named_instance_count(font)`: `named_instances` と同じ多重度
 - `default_instance_count(font)`: instance slot 1 つ
 - `grid_instance_count({"wght": 7, "wdth": 3})`: `grid_instances` と同じ多重度
 
-ランダム性は任意の `torch.Generator` で管理します。dataset-level seed はありません。
+transform 時の variation sampling には [Transform Utilities](./transforms.md) の
+`random_location` を使います。dataset-level seed はありません。
 
 カスタム instance function は 0 個の location を返せます。未知の軸や、正規化後に
 重複する location は Dataset 構築時に `ValueError` になります。

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -1,6 +1,6 @@
 # トランスフォーム Utility
 
-`torchfont.transforms` は glyph tensor を調整するための小さな utility 関数を提供します。
+`torchfont.transforms` は glyph sample と tensor を調整するための小さな utility 関数を提供します。
 dataset item の整形は利用側の前処理コードで行います。
 
 ## load_glyph
@@ -20,7 +20,7 @@ types, coords = load_glyph(sample.ref)
 `VariableGlyphRef` では location を明示的に渡します。
 
 ```python
-from torchfont.instance_fn import random_location
+from torchfont.transforms import random_location
 
 sample = variable_dataset[0]
 location = random_location(sample.ref.font)
@@ -29,6 +29,17 @@ types, coords = load_glyph(sample.ref, location)
 
 明示的な location では、未知の軸、範囲外の値、NaN/inf は `ValueError` になります。
 指定されなかった軸はフォントの default を使います。
+
+## random_location
+
+```python
+from torchfont.transforms import random_location
+
+location = random_location(sample.ref.font, generator=None)
+```
+
+各 variation axis を user-space の最小値と最大値の間で独立に一様サンプリングします。
+静的フォントでは空の辞書を返します。ランダム性は任意の `torch.Generator` で管理します。
 
 ## quad_to_cubic
 

--- a/src/py/instance_fn/mod.rs
+++ b/src/py/instance_fn/mod.rs
@@ -9,18 +9,8 @@ use pyo3::{
     wrap_pyfunction,
 };
 
-use crate::font::{axis_info, default_location, map_font, parse_font_ref};
+use crate::font::{default_location, map_font, parse_font_ref};
 use crate::instance_fn::{grid_location_count, grid_locations, named_locations};
-
-#[pyfunction]
-fn variation_axes(path: PathBuf, ttc_index: u32) -> PyResult<Vec<(String, f32, f32, f32)>> {
-    with_font_ref(&path, ttc_index, |font| {
-        Ok(axis_info(&font)
-            .into_iter()
-            .map(|axis| (axis.tag, axis.min, axis.default, axis.max))
-            .collect())
-    })
-}
 
 #[pyfunction]
 fn default_location_for_font(path: PathBuf, ttc_index: u32) -> PyResult<Vec<(String, f32)>> {
@@ -70,7 +60,6 @@ fn with_font_ref<T>(
 }
 
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(variation_axes, m)?)?;
     m.add_function(wrap_pyfunction!(default_location_for_font, m)?)?;
     m.add_function(wrap_pyfunction!(named_instance_locations_for_font, m)?)?;
     m.add_function(wrap_pyfunction!(grid_locations_for_font, m)?)?;

--- a/src/py/transform/load.rs
+++ b/src/py/transform/load.rs
@@ -3,9 +3,23 @@ use pyo3::prelude::*;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use crate::font::{axis_info, map_font, parse_font_ref};
 use crate::transform::load::load_glyph_outline;
 
 type GlyphOutlineArrays = (Py<PyArray1<i64>>, Py<PyArray1<f32>>);
+
+#[pyfunction]
+pub(crate) fn variation_axes(
+    path: PathBuf,
+    ttc_index: u32,
+) -> PyResult<Vec<(String, f32, f32, f32)>> {
+    let data = map_font(&path)?;
+    let font = parse_font_ref(&data[..], &path, ttc_index)?;
+    Ok(axis_info(&font)
+        .into_iter()
+        .map(|axis| (axis.tag, axis.min, axis.default, axis.max))
+        .collect())
+}
 
 #[pyfunction]
 pub(crate) fn load_glyph(

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -179,6 +179,7 @@ pub(crate) fn render_bitmap(
 
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(load::load_glyph, m)?)?;
+    m.add_function(wrap_pyfunction!(load::variation_axes, m)?)?;
     m.add_function(wrap_pyfunction!(quad_to_cubic, m)?)?;
     m.add_function(wrap_pyfunction!(cubic_to_quad, m)?)?;
     m.add_function(wrap_pyfunction!(merge_curves, m)?)?;

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -33,10 +33,9 @@ from torchfont.instance_fn import (
     grid_instances,
     named_instance_count,
     named_instances,
-    random_location,
 )
 from torchfont.io import ElementType
-from torchfont.transforms import load_glyph
+from torchfont.transforms import load_glyph, random_location
 
 
 def _to_pair(sample: GlyphSample) -> tuple[torch.Tensor, torch.Tensor]:
@@ -437,8 +436,9 @@ def test_datasets_public_api_is_ref_centered() -> None:
     assert datasets_module.VariableGlyphDataset is VariableGlyphDataset
 
 
-def test_transforms_module_exports_load_glyph() -> None:
+def test_transforms_module_exports_dataset_transforms() -> None:
     assert transforms_module.load_glyph is load_glyph
+    assert transforms_module.random_location is random_location
 
 
 def test_native_dataset_helpers_are_available() -> None:
@@ -454,7 +454,6 @@ def test_instance_fn_module_exports_instance_functions() -> None:
     assert instance_fn_module.named_instance_count is named_instance_count
     assert instance_fn_module.grid_instances is grid_instances
     assert instance_fn_module.grid_instance_count is grid_instance_count
-    assert instance_fn_module.random_location is random_location
 
 
 def test_location_validation_rejects_unknown_axis_range_and_nan() -> None:

--- a/torchfont/instance_fn.py
+++ b/torchfont/instance_fn.py
@@ -4,8 +4,6 @@ from collections.abc import Callable, Mapping, Sequence
 from operator import index
 from typing import TYPE_CHECKING, TypeAlias
 
-import torch
-
 from torchfont import _torchfont
 
 if TYPE_CHECKING:
@@ -47,24 +45,6 @@ def grid_instances(axes: Mapping[str, int]) -> InstanceLocationsFn:
     return instances
 
 
-def random_location(
-    font: "FontRef",
-    *,
-    generator: torch.Generator | None = None,
-) -> dict[str, float]:
-    """Sample one random user-space location inside the font's variation axes."""
-    location: dict[str, float] = {}
-    for tag, min_value, _default_value, max_value in _torchfont.variation_axes(
-        font.path,
-        font.ttc_index,
-    ):
-        t = torch.rand((), generator=generator).item()
-        location[str(tag)] = (
-            float(min_value) + (float(max_value) - float(min_value)) * t
-        )
-    return location
-
-
 def default_instance_count(_font: "FontRef") -> int:
     """Return one instance slot for a font."""
     return 1
@@ -104,5 +84,4 @@ __all__ = [
     "grid_instances",
     "named_instance_count",
     "named_instances",
-    "random_location",
 ]

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -1,4 +1,4 @@
-"""Glyph outline transform utilities.
+"""Glyph sample and outline transform utilities.
 
 Most functions accept ``(types, coords)`` and return a transformed
 ``(types, coords)`` pair without modifying the inputs. ``load_glyph`` is the
@@ -23,7 +23,7 @@ from torchfont.transforms.geometric import (
     random_vertical_flip,
     vertical_flip,
 )
-from torchfont.transforms.load import load_glyph
+from torchfont.transforms.load import load_glyph, random_location
 from torchfont.transforms.outline import patchify, remove_overlaps
 from torchfont.transforms.subpath import (
     normalize_subpath_start_points,
@@ -43,6 +43,7 @@ __all__ = [
     "random_affine",
     "random_coord_jitter",
     "random_horizontal_flip",
+    "random_location",
     "random_vertical_flip",
     "randomize_subpath_start_points",
     "remove_overlaps",

--- a/torchfont/transforms/load.py
+++ b/torchfont/transforms/load.py
@@ -15,6 +15,26 @@ if TYPE_CHECKING:
 
     from torch import Tensor
 
+    from torchfont.datasets import FontRef
+
+
+def random_location(
+    font: FontRef,
+    *,
+    generator: torch.Generator | None = None,
+) -> dict[str, float]:
+    """Sample one random user-space location inside the font's variation axes."""
+    location: dict[str, float] = {}
+    for tag, min_value, _default_value, max_value in _torchfont.variation_axes(
+        font.path,
+        font.ttc_index,
+    ):
+        t = torch.rand((), generator=generator).item()
+        location[str(tag)] = (
+            float(min_value) + (float(max_value) - float(min_value)) * t
+        )
+    return location
+
 
 @overload
 def load_glyph(ref: GlyphRef) -> tuple[Tensor, Tensor]: ...


### PR DESCRIPTION
## Summary

- move `random_location` from `torchfont.instance_fn` to `torchfont.transforms`
- move its native `variation_axes` binding from the Rust instance-function bindings to transform bindings
- update public exports, tests, and English/Japanese reference documentation

## Why

`random_location` samples one variation location at transform time. It is not compatible with either dataset `instance_fn` contract: fixed datasets expect a sequence of locations, while variable datasets expect an instance count. Keeping it in `instance_fn` made the module's public API misleading.

The actual instance functions remain in `torchfont.instance_fn`. Existing random tensor and outline operations were already under transforms and required no changes.

This PR intentionally does not include the variable glyph dataset example or example-gallery documentation; those changes remain separate work.

## Validation

- `mise run format`
- `mise run test` (213 passed, 13 skipped)
- `mise run docs-build`
