### PR TITLE
Add variable glyph dataset example

### DIFF
--- a/docs/en/examples/index.md
+++ b/docs/en/examples/index.md
@@ -17,6 +17,7 @@ Some scripts use `num_workers=8`. If you set `num_workers=0`, also remove
 |Use case|Script (`examples/`)|Summary|
 |---|---|---|
 |Pipeline|`local_fonts.py`|Offline local-font pipeline with `GlyphDataset` + local `collate_fn`|
+|Variable glyphs|`variable_glyphs.py`|Uniformly sample variation-axis locations on every access|
 |Corpus checkout|`google_fonts.py`|Google Fonts checkout + transforms + DataLoader|
 |Corpus checkout|`font_awesome.py`|Font Awesome checkout|
 |Corpus checkout|`material_design_icons.py`|Material Design Icons checkout|
@@ -26,5 +27,6 @@ Some scripts use `num_workers=8`. If you set `num_workers=0`, also remove
 
 1. `local_fonts.py`
 2. `google_fonts.py`
+3. `variable_glyphs.py`
 4. `font_awesome.py` / `material_design_icons.py` / `source_han_code_jp.py` as
    needed

--- a/docs/ja/examples/index.md
+++ b/docs/ja/examples/index.md
@@ -18,6 +18,7 @@
 |用途|スクリプト (`examples/`)|要点|
 |---|---|---|
 |Pipeline|`local_fonts.py`|`GlyphDataset` + ローカルな `collate_fn` のオフライン例|
+|Variable glyph|`variable_glyphs.py`|アクセスごとに variation axis の location を一様ランダムサンプリング|
 |Corpus checkout|`google_fonts.py`|Google Fonts checkout + Transform + DataLoader|
 |Corpus checkout|`font_awesome.py`|Font Awesome の checkout|
 |Corpus checkout|`material_design_icons.py`|Material Design Icons の checkout|
@@ -27,5 +28,6 @@
 
 1. `local_fonts.py`
 2. `google_fonts.py`
+3. `variable_glyphs.py`
 4. 必要なリポジトリ向けの `font_awesome.py` / `material_design_icons.py` /
    `source_han_code_jp.py`

--- a/examples/font_awesome.py
+++ b/examples/font_awesome.py
@@ -35,8 +35,9 @@ def main() -> None:
     )
 
     print(f"{len(dataset)=}")
-    print(f"{len(dataset.character_classes)=}")
+    print(f"{len(dataset.font_classes)=}")
     print(f"{len(dataset.style_classes)=}")
+    print(f"{len(dataset.character_classes)=}")
 
     for batch in dataloader:
         print(batch)

--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -60,8 +60,9 @@ def main() -> None:
     )
 
     print(f"{len(dataset)=}")
-    print(f"{len(dataset.character_classes)=}")
+    print(f"{len(dataset.font_classes)=}")
     print(f"{len(dataset.style_classes)=}")
+    print(f"{len(dataset.character_classes)=}")
 
     for batch in tqdm(dataloader, desc="Iterating over datasets"):
         _ = batch

--- a/examples/local_fonts.py
+++ b/examples/local_fonts.py
@@ -37,8 +37,9 @@ def main() -> None:
     types_t, coords_t = next(iter(dataloader))
 
     print(f"{len(dataset)=}")
-    print(f"{len(dataset.character_classes)=}")
+    print(f"{len(dataset.font_classes)=}")
     print(f"{len(dataset.style_classes)=}")
+    print(f"{len(dataset.character_classes)=}")
     print(f"{types_t.shape=}")
     print(f"{coords_t.shape=}")
 

--- a/examples/material_design_icons.py
+++ b/examples/material_design_icons.py
@@ -35,8 +35,9 @@ def main() -> None:
     )
 
     print(f"{len(dataset)=}")
-    print(f"{len(dataset.character_classes)=}")
+    print(f"{len(dataset.font_classes)=}")
     print(f"{len(dataset.style_classes)=}")
+    print(f"{len(dataset.character_classes)=}")
 
     for batch in dataloader:
         print(batch)

--- a/examples/source_han_code_jp.py
+++ b/examples/source_han_code_jp.py
@@ -35,8 +35,9 @@ def main() -> None:
     )
 
     print(f"{len(dataset)=}")
-    print(f"{len(dataset.character_classes)=}")
+    print(f"{len(dataset.font_classes)=}")
     print(f"{len(dataset.style_classes)=}")
+    print(f"{len(dataset.character_classes)=}")
 
     for batch in dataloader:
         print(batch)

--- a/examples/subset_by_targets.py
+++ b/examples/subset_by_targets.py
@@ -12,6 +12,9 @@ def main() -> None:
     )
 
     print(f"{len(dataset)=}")
+    print(f"{len(dataset.font_classes)=}")
+    print(f"{len(dataset.style_classes)=}")
+    print(f"{len(dataset.character_classes)=}")
     print(f"{dataset.style_targets.shape=}")
     print(f"{dataset.character_targets.shape=}")
 

--- a/examples/variable_glyphs.py
+++ b/examples/variable_glyphs.py
@@ -1,0 +1,58 @@
+from torch import Tensor
+from torch.nn.utils.rnn import pad_sequence
+from torch.utils.data import DataLoader
+
+from torchfont.datasets import VariableGlyphDataset, VariableGlyphSample
+from torchfont.instance_fn import grid_instance_count
+from torchfont.transforms import load_glyph, random_location
+
+
+def transform(
+    sample: VariableGlyphSample,
+) -> tuple[Tensor, Tensor, dict[str, float]]:
+    location = random_location(sample.ref.font)
+    types, coords = load_glyph(sample.ref, location)
+    return types[:512], coords[:512], location
+
+
+def collate_fn(
+    batch: list[tuple[Tensor, Tensor, dict[str, float]]],
+) -> tuple[Tensor, Tensor, list[dict[str, float]]]:
+    types = pad_sequence([types for types, _, _ in batch], batch_first=True)
+    coords = pad_sequence([coords for _, coords, _ in batch], batch_first=True)
+    locations = [location for _, _, location in batch]
+    return types, coords, locations
+
+
+def main() -> None:
+    dataset = VariableGlyphDataset(
+        root="data/google/fonts",
+        patterns=(
+            "apache/*/*.ttf",
+            "ofl/*/*.ttf",
+            "ufl/*/*.ttf",
+            "!ofl/adobeblank/*.ttf",
+        ),
+        instance_fn=grid_instance_count({"wght": 7, "wdth": 3, "opsz": 3, "slnt": 2}),
+        transform=transform,
+    )
+
+    dataloader = DataLoader(
+        dataset,
+        batch_size=8,
+        shuffle=True,
+        collate_fn=collate_fn,
+    )
+
+    types_t, coords_t, locations = next(iter(dataloader))
+
+    print(f"{len(dataset)=}")
+    print(f"{len(dataset.font_classes)=}")
+    print(f"{len(dataset.character_classes)=}")
+    print(f"{types_t.shape=}")
+    print(f"{coords_t.shape=}")
+    print(f"{locations=}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,6 +13,7 @@ EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
         "local_fonts.py",
         "source_han_code_jp.py",
         "subset_by_targets.py",
+        "variable_glyphs.py",
         "font_awesome.py",
         "material_design_icons.py",
     ],


### PR DESCRIPTION
## Summary

- add a Google Fonts-backed `VariableGlyphDataset` example
- use `grid_instance_count` to match the sampling density configured by `google_fonts.py`
- sample a fresh variation location in the transform and load the resulting glyph outline
- list the new script in the English and Japanese example galleries
- show font, style, and character class counts consistently across existing examples
- include the new script in import-safety coverage

## Why

The existing examples demonstrate fixed variation locations through `GlyphDataset`, but do not show transform-time random sampling with `VariableGlyphDataset`. This adds a runnable end-to-end example covering random location sampling, outline loading, collation, and mixed static/variable Google Fonts.

## Validation

- `mise run python-check`
- `uv run pytest tests/test_examples.py` (9 passed)
- `uv run examples/variable_glyphs.py`
- `mise run docs-build`
