### PR TITLE
Preserve devices in native outline transforms

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -17,6 +17,10 @@ inside a `GlyphDataset`/`VariableGlyphDataset` `transform`. It returns
 `(types, coords)`, where `types` is a 1-D `LongTensor` and `coords` is a 2-D
 `FloatTensor` of shape `(N, 6)`.
 
+Outline-to-outline transforms preserve their input devices. Native outline
+operations run in Rust on CPU and move their results back to the corresponding
+input devices before returning.
+
 For `VariableGlyphRef`, pass a location explicitly:
 
 ```python

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -17,6 +17,9 @@ types, coords = load_glyph(sample.ref)
 `(types, coords)` を返し、`types` は 1-D `LongTensor`、`coords` は shape
 `(N, 6)` の 2-D `FloatTensor` です。
 
+outline から outline への transform は入力 device を維持します。native outline
+演算は CPU 上の Rust で実行し、結果を対応する入力 device に戻してから返します。
+
 `VariableGlyphRef` では location を明示的に渡します。
 
 ```python

--- a/tests/transforms/curves/test_quad_to_cubic.py
+++ b/tests/transforms/curves/test_quad_to_cubic.py
@@ -120,3 +120,15 @@ def test_quad_to_cubic_merge_curves_runs_even_without_quadratics() -> None:
     out_types, _out_coords = quad_to_cubic(types, coords, merge_curves=True)
 
     assert out_types.tolist().count(ElementType.LINE_TO.value) == 1
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_quad_to_cubic_preserves_cuda_device(
+    quad_outline: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in quad_outline)
+
+    out_types, out_coords = quad_to_cubic(types, coords)
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/tests/transforms/subpath/test_randomize_subpath_start_points.py
+++ b/tests/transforms/subpath/test_randomize_subpath_start_points.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torchfont.transforms import randomize_subpath_start_points
@@ -44,3 +45,20 @@ def test_randomize_subpath_start_points_leaves_open_subpaths_unchanged(
 
     assert torch.equal(out_types, types)
     assert torch.equal(out_coords, coords)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_randomize_subpath_start_points_accepts_cpu_generator_for_cuda_input(
+    square: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = (tensor.cuda() for tensor in square)
+    generator = torch.Generator().manual_seed(5)
+
+    out_types, out_coords = randomize_subpath_start_points(
+        types,
+        coords,
+        generator=generator,
+    )
+
+    assert out_types.device.type == "cuda"
+    assert out_coords.device.type == "cuda"

--- a/torchfont/transforms/curves.py
+++ b/torchfont/transforms/curves.py
@@ -20,14 +20,16 @@ def quad_to_cubic(
     in the same Rust call after conversion. The output length may differ from
     the input in this mode.
     """
+    types_device = types.device
+    coords_device = coords.device
     types = types.cpu().contiguous()
     coords = coords.cpu().contiguous()
     out_types, out_coords = _torchfont.quad_to_cubic(
         types.numpy(), coords.reshape(-1).numpy(), merge_curves
     )
     return (
-        torch.from_numpy(out_types),
-        torch.from_numpy(out_coords).view(-1, 6),
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
     )
 
 
@@ -53,14 +55,16 @@ def cubic_to_quad(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
         Non-cubic path elements are passed through unchanged.
 
     """
+    types_device = types.device
+    coords_device = coords.device
     types = types.cpu().contiguous()
     coords = coords.cpu().contiguous()
     out_types, out_coords = _torchfont.cubic_to_quad(
         types.numpy(), coords.reshape(-1).numpy()
     )
     return (
-        torch.from_numpy(out_types),
-        torch.from_numpy(out_coords).view(-1, 6),
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
     )
 
 
@@ -86,12 +90,14 @@ def merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
         adjacent segments collapsed.
 
     """
+    types_device = types.device
+    coords_device = coords.device
     types = types.cpu().contiguous()
     coords = coords.cpu().contiguous()
     out_types, out_coords = _torchfont.merge_curves(
         types.numpy(), coords.reshape(-1).numpy()
     )
     return (
-        torch.from_numpy(out_types),
-        torch.from_numpy(out_coords).view(-1, 6),
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
     )

--- a/torchfont/transforms/outline.py
+++ b/torchfont/transforms/outline.py
@@ -48,12 +48,14 @@ def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
         is returned unchanged.
 
     """
+    types_device = types.device
+    coords_device = coords.device
     types = types.cpu().contiguous()
     coords = coords.cpu().contiguous()
     out_types, out_coords = _torchfont.remove_overlaps(
         types.numpy(), coords.reshape(-1).numpy()
     )
     return (
-        torch.from_numpy(out_types),
-        torch.from_numpy(out_coords).view(-1, 6),
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
     )

--- a/torchfont/transforms/subpath.py
+++ b/torchfont/transforms/subpath.py
@@ -17,14 +17,16 @@ def normalize_subpath_start_points(
     returned unchanged. When rotation crosses the old closing edge, that implicit
     edge is materialised as ``LINE_TO`` so the represented geometry is preserved.
     """
+    types_device = types.device
+    coords_device = coords.device
     types = types.cpu().contiguous()
     coords = coords.cpu().contiguous()
     out_types, out_coords = _torchfont.normalize_subpath_start_points(
         types.numpy(), coords.reshape(-1).numpy()
     )
     return (
-        torch.from_numpy(out_types),
-        torch.from_numpy(out_coords).view(-1, 6),
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
     )
 
 
@@ -40,6 +42,8 @@ def randomize_subpath_start_points(
     element types are returned unchanged. Pass a ``torch.Generator`` to make the
     independent per-subpath choices reproducible.
     """
+    types_device = types.device
+    coords_device = coords.device
     types = types.cpu().contiguous()
     coords = coords.cpu().contiguous()
     random_values = torch.rand(
@@ -53,6 +57,6 @@ def randomize_subpath_start_points(
         random_values.numpy(),
     )
     return (
-        torch.from_numpy(out_types),
-        torch.from_numpy(out_coords).view(-1, 6),
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
     )


### PR DESCRIPTION
## Summary

- remember the input devices before transferring outline tensors to the CPU Rust backend
- construct transform results on their corresponding original devices
- document device preservation in English and Japanese
- add focused CUDA coverage for a representative native transform and CPU-generator/CUDA-input behavior

## Root cause

Native outline transforms copied their inputs to CPU for Rust processing and always constructed their result tensors on CPU. This unexpectedly moved CUDA pipelines back to the host.

## Impact

Outline-to-outline transforms now preserve the device of each input tensor. Native computation remains CPU-backed.

## Validation

- `mise run format`
- `mise run check`
- `mise run test` (`214 passed, 15 skipped`; CUDA-only tests skipped on this host)