### PR TITLE
Support CUDA generators in random locations

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -40,7 +40,7 @@ location = random_location(sample.ref.font, generator=None)
 
 Samples each variation axis independently and uniformly over its user-space
 minimum and maximum. Static fonts return an empty dictionary. Randomness uses
-the optional `torch.Generator`.
+the optional `torch.Generator`, including a CUDA generator when provided.
 
 ## quad_to_cubic
 

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -39,7 +39,8 @@ location = random_location(sample.ref.font, generator=None)
 ```
 
 各 variation axis を user-space の最小値と最大値の間で独立に一様サンプリングします。
-静的フォントでは空の辞書を返します。ランダム性は任意の `torch.Generator` で管理します。
+静的フォントでは空の辞書を返します。ランダム性は任意の `torch.Generator` で管理し、
+CUDA generator も利用できます。
 
 ## quad_to_cubic
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -313,6 +313,19 @@ def test_variable_glyph_dataset_transform_can_sample_location() -> None:
     assert coords.shape[1] == 6
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_random_location_accepts_cuda_generator() -> None:
+    font = FontRef(
+        path="tests/fonts/roboto/Roboto[wdth,wght].ttf",
+        ttc_index=0,
+    )
+    generator = torch.Generator(device="cuda").manual_seed(5)
+
+    location = random_location(font, generator=generator)
+
+    assert location.keys() == {"wght", "wdth"}
+
+
 @pytest.mark.parametrize("codepoint", [1.5, "A"])
 def test_glyph_dataset_rejects_non_integer_codepoints(codepoint: object) -> None:
     with pytest.raises(TypeError, match="cannot be interpreted as an integer"):

--- a/torchfont/transforms/load.py
+++ b/torchfont/transforms/load.py
@@ -29,7 +29,11 @@ def random_location(
         font.path,
         font.ttc_index,
     ):
-        t = torch.rand((), generator=generator).item()
+        t = torch.rand(
+            (),
+            device=generator.device if generator is not None else None,
+            generator=generator,
+        ).item()
         location[str(tag)] = (
             float(min_value) + (float(max_value) - float(min_value)) * t
         )


### PR DESCRIPTION
## Summary

- sample `random_location` values on the generator device
- allow CUDA-backed `torch.Generator` instances
- document CUDA generator support in English and Japanese
- add focused CUDA coverage

## Root cause

`random_location` always called `torch.rand` on CPU. PyTorch requires a generator and generated tensor to use matching device types, so passing a CUDA generator raised a device mismatch error.

## Impact

CPU generator behavior is unchanged. CUDA generators can now be used to control location sampling.

## Validation

- `mise run format`
- `mise run check`
- `mise run test` (`214 passed, 14 skipped`; CUDA-only test skipped on this host)