### PR TITLE
Preserve I/O error kinds in Python exceptions

### DIFF
--- a/src/dataset/discovery.rs
+++ b/src/dataset/discovery.rs
@@ -8,9 +8,9 @@ pub(crate) fn canonicalize_root(root: &str) -> Result<PathBuf, Error> {
     let expanded = shellexpand::tilde(root);
     let path = PathBuf::from(expanded.as_ref());
     std::fs::canonicalize(&path).map_err(|err| {
-        Error::Io(format!(
-            "failed to resolve font root '{}': {err}",
-            path.display()
+        Error::Io(std::io::Error::new(
+            err.kind(),
+            format!("failed to resolve font root '{}': {err}", path.display()),
         ))
     })
 }
@@ -28,8 +28,15 @@ pub(crate) fn discover_font_files(
     let mut files = Vec::new();
 
     for result in builder.build() {
-        let entry = result
-            .map_err(|err| Error::Io(format!("failed to walk '{}': {err}", root.display())))?;
+        let entry = result.map_err(|err| {
+            let kind = err
+                .io_error()
+                .map_or(std::io::ErrorKind::Other, std::io::Error::kind);
+            Error::Io(std::io::Error::new(
+                kind,
+                format!("failed to walk '{}': {err}", root.display()),
+            ))
+        })?;
 
         let path = entry.path();
 
@@ -58,9 +65,9 @@ fn build_overrides(root: &Path, patterns: &[String]) -> Result<ignore::overrides
     for pattern in patterns {
         builder
             .add(pattern)
-            .map_err(|err| Error::Io(format!("invalid pattern '{pattern}': {err}")))?;
+            .map_err(|err| Error::Parse(format!("invalid pattern '{pattern}': {err}")))?;
     }
     builder
         .build()
-        .map_err(|err| Error::Io(format!("failed to compile patterns: {err}")))
+        .map_err(|err| Error::Parse(format!("failed to compile patterns: {err}")))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,14 +3,15 @@ use std::fmt;
 #[derive(Debug)]
 pub enum Error {
     Parse(String),
-    Io(String),
+    Io(std::io::Error),
     OutOfRange(String),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Parse(msg) | Self::Io(msg) | Self::OutOfRange(msg) => write!(f, "{msg}"),
+            Self::Parse(msg) | Self::OutOfRange(msg) => write!(f, "{msg}"),
+            Self::Io(err) => write!(f, "{err}"),
         }
     }
 }

--- a/src/font/data.rs
+++ b/src/font/data.rs
@@ -5,12 +5,20 @@ use memmap2::Mmap;
 use crate::error::Error;
 
 pub(crate) fn map_font(path: &Path) -> Result<Mmap, Error> {
-    let file = fs::File::open(path)
-        .map_err(|err| Error::Io(format!("failed to open '{}': {err}", path.display())))?;
+    let file = fs::File::open(path).map_err(|err| {
+        Error::Io(std::io::Error::new(
+            err.kind(),
+            format!("failed to open '{}': {err}", path.display()),
+        ))
+    })?;
     // SAFETY: callers only access the map while parsing and TorchFont documents
     // modification of indexed font files during use as unsupported.
-    let mmap = unsafe { Mmap::map(&file) }
-        .map_err(|err| Error::Io(format!("failed to map '{}': {err}", path.display())))?;
+    let mmap = unsafe { Mmap::map(&file) }.map_err(|err| {
+        Error::Io(std::io::Error::new(
+            err.kind(),
+            format!("failed to map '{}': {err}", path.display()),
+        ))
+    })?;
     Ok(mmap)
 }
 

--- a/src/py/error.rs
+++ b/src/py/error.rs
@@ -6,9 +6,10 @@ impl From<Error> for pyo3::PyErr {
             Error::OutOfRange(_) => {
                 pyo3::PyErr::new::<pyo3::exceptions::PyIndexError, _>(error.to_string())
             }
-            Error::Parse(_) | Error::Io(_) => {
+            Error::Parse(_) => {
                 pyo3::PyErr::new::<pyo3::exceptions::PyValueError, _>(error.to_string())
             }
+            Error::Io(err) => err.into(),
         }
     }
 }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -127,6 +127,23 @@ def test_dataset_reports_corrupt_font_parse_error(tmp_path: Path) -> None:
         GlyphDataset(root=tmp_path)
 
 
+def test_dataset_reports_missing_root_as_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="failed to resolve font root"):
+        GlyphDataset(root=tmp_path / "missing")
+
+
+def test_load_glyph_reports_missing_font_as_file_not_found(tmp_path: Path) -> None:
+    ref = GlyphRef(FontRef(str(tmp_path / "missing.ttf"), 0), ord("A"), {})
+
+    with pytest.raises(FileNotFoundError, match="failed to open"):
+        load_glyph(ref)
+
+
+def test_dataset_reports_invalid_pattern_as_value_error() -> None:
+    with pytest.raises(ValueError, match="invalid pattern"):
+        GlyphDataset(root="tests/fonts", patterns=("[",))
+
+
 def test_glyph_dataset_transform_uses_sample_first_contract() -> None:
     calls: list[GlyphSample] = []
 


### PR DESCRIPTION
## Summary

- preserve Rust I/O error kinds across the Python boundary
- let PyO3 map them to `FileNotFoundError`, `PermissionError`, and other appropriate `OSError` subclasses
- keep malformed font data and invalid glob patterns as `ValueError`

## Why

The shared error conversion previously mapped both parsing failures and filesystem failures to `ValueError`. This made missing or unreadable paths indistinguishable from invalid user data.

## Validation

- `mise run check`
- `mise run test`
- `uv run pytest tests/test_dataset.py -q`
