### PR TITLE
Remove unused Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,8 +1256,6 @@ dependencies = [
  "skia-safe",
  "skrifa",
  "tiny-skia",
- "urlencoding",
- "walkdir",
 ]
 
 [[package]]
@@ -1271,12 +1269,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ tiny-skia = { version = "0.12.0", default-features = false, features = [
     "simd",
     "std",
 ] }
-urlencoding = "2.1.3"
-walkdir = "2.5.0"
 google-fonts-glyphsets = { git = "https://github.com/googlefonts/glyphsets" }
 
 [dependencies.pyo3]


### PR DESCRIPTION
## Summary

- remove the unused direct `urlencoding` dependency
- remove the unused direct `walkdir` dependency
- retain `walkdir` in the lockfile as a transitive dependency of `ignore`

## Motivation

These crates were listed as direct dependencies even though TorchFont does not use them directly. Removing them keeps the dependency manifest aligned with the code and removes `urlencoding` from the resolved dependency graph.

## Impact

No runtime behavior changes are expected.

## Validation

- `cargo check --all-targets --all-features`
- `mise run check`
- `mise run test`
- `git diff --check`