### PR TITLE
chore: release v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "google-fonts-glyphsets",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from 0.10.2 to 0.11.0

## What's Changed since v0.10.2

* Add glyphsets data (#299)
* chore(deps-dev): bump @types/node in the npm-dependencies group (#302)
* chore(deps-dev): bump @types/node in the npm-dependencies group (#304)
* chore(deps): bump the rust-dependencies group with 3 updates (#305)
* chore(deps): bump actions/checkout from 6 to 7 in the actions group (#303)
* chore: inline oncreate chown into devcontainer.json (#306)
* Ignore large data submodules in searches (#307)
* Remove maturin build workaround (#308)
* Make tooling dirs visible to ripgrep (#309)
* Update Ruff VS Code settings (#310)
* Add instance-level variable font augmentation (#313)
* chore(deps): bump google-fonts-glyphsets in the rust-dependencies group (#314)
* chore(deps-dev): bump @types/node in the npm-dependencies group (#315)
* chore(deps-dev): bump @types/node in the npm-dependencies group (#316)
* chore(deps): bump the rust-dependencies group with 2 updates (#317)
* Redesign glyph dataset variation API (#318)
* Refactor dataset internals and instance functions (#319)
* Fix VS Code uv detection in dev container (#320)
* Update project dependencies (#321)
* Remove negative API presence tests (#322)
* Move random location sampling to transforms (#323)
* Add variable glyph dataset example (#324)
* Return native outline arrays without copying (#325)
* Support CUDA generators in random locations (#327)
* Preserve devices in native outline transforms (#326)
* Preserve I/O error kinds in Python exceptions (#328)
* Normalize signed zero in location keys (#329)
* Remove unused Rust dependencies (#330)

## Validation

* `mise run check`
* `uv run maturin sdist --out <temp-dir>` (`torchfont-0.11.0.tar.gz`)
* Full test, wheel, free-threaded Python 3.14, docs, and Google Fonts corpus checks completed before the version bump

Closes #312