### PR TITLE
Add CITATION.cff for GitHub citation support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "TorchFont"
+abstract: "A Machine Learning Library for Vector Fonts"
+authors:
+  - family-names: "Fujioka"
+    given-names: "Takumu"
+    email: "fjktkm@gmail.com"
+    orcid: "https://orcid.org/0009-0005-0691-414X"
+version: 0.11.0
+date-released: 2026-07-18
+license: MIT
+repository-code: "https://github.com/torchfont/torchfont"
+url: "https://torchfont.readthedocs.io/"
+keywords:
+  - pytorch
+  - fonts
+  - vector-graphics
+  - machine-learning
+  - datasets


### PR DESCRIPTION
## Summary

- Add `CITATION.cff` (Citation File Format 1.2.0) at the repository root, enabling GitHub's **"Cite this repository"** button with APA and BibTeX output
- Follows the structure recommended by the [GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) and the [CFF project](https://citation-file-format.github.io/): includes `version` (0.11.0), `date-released` (2026-07-18, from the v0.11.0 GitHub release), author ORCID, license, repository, and docs URL

## Verification

Validated with `uvx cffconvert --validate` (schema 1.2.0). Rendered output:

```text
Fujioka T. (2026). TorchFont (version 0.11.0). URL: https://torchfont.readthedocs.io/
```

## Notes

- Future release PRs should bump `version` / `date-released` in `CITATION.cff` alongside `Cargo.toml`
- A `doi` field can be added later once the repository is linked to Zenodo

🤖 Generated with [Claude Code](https://claude.com/claude-code)