### PR TITLE
Add random subpath order transform

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -182,6 +182,23 @@ Chooses a uniformly random start endpoint for each subpath.
 - input: `types=(N,)`, `coords=(N, 6)`
 - output: `types=(M,)`, `coords=(M, 6)`
 
+## randomize_subpath_order
+
+```python
+from torchfont.transforms import randomize_subpath_order
+
+types, coords = randomize_subpath_order(types, coords, generator=None)
+```
+
+Randomly permutes complete subpaths while preserving every subpath's geometry,
+start point, winding, and open/closed state. This helps prevent sequence models
+from learning an arbitrary contour order.
+
+For an extracted monochrome outline, contour order does not determine holes:
+the winding/fill rule does. This transform intentionally does not operate on
+source-font point indices, TrueType instructions, variation deltas, composite
+components, or color-glyph layers, whose ordering can carry other semantics.
+
 ## patchify
 
 ```python

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -179,6 +179,22 @@ types, coords = randomize_subpath_start_points(types, coords)
 - 入力: `types=(N,)`, `coords=(N, 6)`
 - 出力: `types=(M,)`, `coords=(M, 6)`
 
+## randomize_subpath_order
+
+```python
+from torchfont.transforms import randomize_subpath_order
+
+types, coords = randomize_subpath_order(types, coords, generator=None)
+```
+
+各 subpath の形状、開始点、winding、open/closed 状態を保持したまま、subpath 全体の
+順序をランダムに入れ替えます。sequence model が任意の contour 順序に依存するのを
+防ぐために利用できます。
+
+抽出済みの単色 outline では、hole は contour の順序ではなく winding/fill rule で
+決まります。この transform は、別の意味を持ち得る元 font の point index、TrueType
+instruction、variation delta、composite component、color glyph layer の順序には作用しません。
+
 ## patchify
 
 ```python

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -122,6 +122,33 @@ pub(crate) fn randomize_subpath_start_points<'py>(
 }
 
 #[pyfunction]
+pub(crate) fn randomize_subpath_order<'py>(
+    py: Python<'py>,
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+    random_values: PyReadonlyArray1<'_, f32>,
+) -> PyResult<OutlineArrays<'py>> {
+    use crate::outline::ElementType;
+    let t = types.as_slice()?;
+    let r = random_values.as_slice()?;
+    let outline = decode(t, coords.as_slice()?)?;
+    if r.len() < t.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "random_values length must be at least types length",
+        ));
+    }
+    let subpath_random_values: Vec<f32> = t
+        .iter()
+        .zip(r)
+        .filter_map(|(&ty, &rv)| (ty == ElementType::MoveTo as i64).then_some(rv))
+        .collect();
+    Ok(encode(
+        py,
+        &subpath::randomize_subpath_order(&outline, &subpath_random_values),
+    ))
+}
+
+#[pyfunction]
 pub(crate) fn reverse_closed_subpaths<'py>(
     py: Python<'py>,
     types: PyReadonlyArray1<'_, i64>,
@@ -208,6 +235,7 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(merge_curves, m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(normalize_subpath_start_points, m)?)?;
+    m.add_function(wrap_pyfunction!(randomize_subpath_order, m)?)?;
     m.add_function(wrap_pyfunction!(randomize_subpath_start_points, m)?)?;
     m.add_function(wrap_pyfunction!(reverse_closed_subpaths, m)?)?;
     m.add_function(wrap_pyfunction!(tight_bbox, m)?)?;

--- a/src/transform/subpath.rs
+++ b/src/transform/subpath.rs
@@ -40,6 +40,24 @@ pub(crate) fn randomize_subpath_start_points(outline: &Outline, random_values: &
     })
 }
 
+pub(crate) fn randomize_subpath_order(outline: &Outline, random_values: &[f32]) -> Outline {
+    let mut keyed_subpaths: Vec<_> = outline
+        .subpaths()
+        .iter()
+        .cloned()
+        .zip(random_values.iter().copied())
+        .enumerate()
+        .collect();
+    keyed_subpaths
+        .sort_by(|(a_idx, (_, a)), (b_idx, (_, b))| a.total_cmp(b).then_with(|| a_idx.cmp(b_idx)));
+    Outline::new(
+        keyed_subpaths
+            .into_iter()
+            .map(|(_, (subpath, _))| subpath)
+            .collect(),
+    )
+}
+
 pub(crate) fn reverse_closed_subpaths(outline: &Outline) -> Outline {
     let subpaths = outline
         .subpaths()
@@ -233,6 +251,28 @@ mod tests {
     }
 
     // --- reverse_closed_subpaths ---
+
+    #[test]
+    fn randomize_subpath_order_uses_random_keys() {
+        let first = closed(pt(0.0, 0.0), vec![line(1.0, 0.0)]);
+        let second = closed(pt(10.0, 0.0), vec![line(11.0, 0.0)]);
+        let outline = Outline::new(vec![first.clone(), second.clone()]);
+
+        let result = randomize_subpath_order(&outline, &[0.9, 0.1]);
+
+        assert_eq!(result.subpaths(), &[second, first]);
+    }
+
+    #[test]
+    fn randomize_subpath_order_preserves_tie_order() {
+        let first = open(pt(0.0, 0.0), vec![]);
+        let second = open(pt(10.0, 0.0), vec![]);
+        let outline = Outline::new(vec![first.clone(), second.clone()]);
+
+        let result = randomize_subpath_order(&outline, &[0.5, 0.5]);
+
+        assert_eq!(result.subpaths(), &[first, second]);
+    }
 
     #[test]
     fn reverse_closed_subpaths_skips_open() {

--- a/tests/transforms/subpath/test_randomize_subpath_order.py
+++ b/tests/transforms/subpath/test_randomize_subpath_order.py
@@ -1,0 +1,86 @@
+import pytest
+import torch
+
+from torchfont.io import ElementType
+from torchfont.transforms import randomize_subpath_order, render_bitmap
+
+
+@pytest.fixture
+def two_squares() -> tuple[torch.Tensor, torch.Tensor]:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO.value,
+            ElementType.LINE_TO.value,
+            ElementType.LINE_TO.value,
+            ElementType.LINE_TO.value,
+            ElementType.CLOSE.value,
+            ElementType.MOVE_TO.value,
+            ElementType.LINE_TO.value,
+            ElementType.LINE_TO.value,
+            ElementType.LINE_TO.value,
+            ElementType.CLOSE.value,
+            ElementType.END.value,
+        ],
+    )
+    coords = torch.tensor(
+        [
+            [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 0.4, 0.0],
+            [0, 0, 0, 0, 0.4, 0.4],
+            [0, 0, 0, 0, 0.0, 0.4],
+            [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 0.6, 0.6],
+            [0, 0, 0, 0, 1.0, 0.6],
+            [0, 0, 0, 0, 1.0, 1.0],
+            [0, 0, 0, 0, 0.6, 1.0],
+            [0, 0, 0, 0, 0.0, 0.0],
+            [0, 0, 0, 0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    return types, coords
+
+
+def test_randomize_subpath_order_is_reproducible(
+    two_squares: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    first = torch.Generator().manual_seed(4)
+    second = torch.Generator().manual_seed(4)
+    output1 = randomize_subpath_order(*two_squares, generator=first)
+    output2 = randomize_subpath_order(*two_squares, generator=second)
+    assert torch.equal(output1[0], output2[0])
+    assert torch.equal(output1[1], output2[1])
+
+
+def test_randomize_subpath_order_preserves_rendering(
+    two_squares: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    output = randomize_subpath_order(
+        *two_squares,
+        generator=torch.Generator().manual_seed(4),
+    )
+    before = render_bitmap(*two_squares, size=64)
+    after = render_bitmap(*output, size=64)
+    assert torch.equal(after, before)
+
+
+def test_randomize_subpath_order_preserves_each_subpath(
+    two_squares: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    types, coords = two_squares
+    out_types, out_coords = randomize_subpath_order(
+        types,
+        coords,
+        generator=torch.Generator().manual_seed(4),
+    )
+    input_blocks = {
+        (tuple(types[:5].tolist()), tuple(coords[:5].flatten().tolist())),
+        (tuple(types[5:10].tolist()), tuple(coords[5:10].flatten().tolist())),
+    }
+    output_blocks = {
+        (tuple(out_types[:5].tolist()), tuple(out_coords[:5].flatten().tolist())),
+        (tuple(out_types[5:10].tolist()), tuple(out_coords[5:10].flatten().tolist())),
+    }
+    assert output_blocks == input_blocks
+    assert out_coords[0, 4:6].tolist() == pytest.approx([0.6, 0.6])
+    assert out_types[-1].item() == ElementType.END.value

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -23,6 +23,9 @@ def render_bitmap(
 def normalize_subpath_start_points(
     types: np.ndarray, coords: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]: ...
+def randomize_subpath_order(
+    types: np.ndarray, coords: np.ndarray, random_values: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]: ...
 def randomize_subpath_start_points(
     types: np.ndarray, coords: np.ndarray, random_values: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]: ...

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -27,6 +27,7 @@ from torchfont.transforms.load import load_glyph, random_location
 from torchfont.transforms.outline import patchify, remove_overlaps
 from torchfont.transforms.subpath import (
     normalize_subpath_start_points,
+    randomize_subpath_order,
     randomize_subpath_start_points,
 )
 
@@ -45,6 +46,7 @@ __all__ = [
     "random_horizontal_flip",
     "random_location",
     "random_vertical_flip",
+    "randomize_subpath_order",
     "randomize_subpath_start_points",
     "remove_overlaps",
     "render_bitmap",

--- a/torchfont/transforms/subpath.py
+++ b/torchfont/transforms/subpath.py
@@ -60,3 +60,34 @@ def randomize_subpath_start_points(
         torch.from_numpy(out_types).to(device=types_device),
         torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
     )
+
+
+def randomize_subpath_order(
+    types: Tensor,
+    coords: Tensor,
+    *,
+    generator: torch.Generator | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Randomly permute whole subpaths without changing their geometry.
+
+    This operates on an already extracted monochrome outline. Each subpath's
+    start point, elements, winding, and open/closed state are preserved.
+    """
+    types_device = types.device
+    coords_device = coords.device
+    types = types.cpu().contiguous()
+    coords = coords.cpu().contiguous()
+    random_values = torch.rand(
+        types.size(0),
+        device=generator.device if generator is not None else types.device,
+        generator=generator,
+    ).cpu()
+    out_types, out_coords = _torchfont.randomize_subpath_order(
+        types.numpy(),
+        coords.reshape(-1).numpy(),
+        random_values.numpy(),
+    )
+    return (
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
+    )


### PR DESCRIPTION
## Summary

- add a Rust transform that randomly permutes complete glyph subpaths using random keys supplied by PyTorch
- expose a thin, generator-aware Python `randomize_subpath_order` function while preserving input devices
- document the rendering semantics and limitations in English and Japanese
- test reproducibility, subpath preservation, actual reordering, and bitmap equivalence

## Why

Contour order does not affect the rendered result of an extracted monochrome outline: holes are determined by the winding/fill rule. Randomizing that otherwise arbitrary sequence order prevents sequence models from learning it as a spurious feature.

This operates only on extracted outlines. It does not reorder source-font point indices, TrueType instructions, variation deltas, composite components, or color-glyph layers.

## Validation

- `mise run check`
- `uv run pytest -q` — 220 passed, 16 skipped
- `mise run docs-build`
- `git diff --check`
