### PR TITLE
Isolate Ruff CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: "true"
-      - run: uvx ruff format --check
-      - run: uvx ruff check
+      - run: uv run --locked --only-group lint ruff format --check
+      - run: uv run --locked --only-group lint ruff check
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo check --all-targets --all-features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,18 +44,19 @@ build-backend = "maturin"
 
 [dependency-groups]
 dev = [
+    { include-group = "lint" },
     "fonttools>=4.63.0",
     "lightning>=2.6.0",
     "maturin[patchelf]>=1.12.6; sys_platform == 'linux'",
     "maturin>=1.12.6; sys_platform != 'linux'",
     "pytest>=8.4.2",
     "pytest-benchmark>=5.1.0",
-    "ruff>=0.16.0",
     "skia-pathops>=0.9.2",
     "tqdm>=4.67.1",
     "ty>=0.0.63",
     "types-tqdm>=4.67.0.20250809",
 ]
+lint = ["ruff>=0.16.0"]
 
 [tool.uv.sources]
 torch = [{ index = "pytorch-cpu" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1498,6 +1498,9 @@ dev = [
     { name = "ty" },
     { name = "types-tqdm" },
 ]
+lint = [
+    { name = "ruff" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1519,6 +1522,7 @@ dev = [
     { name = "ty", specifier = ">=0.0.63" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
 ]
+lint = [{ name = "ruff", specifier = ">=0.16.0" }]
 
 [[package]]
 name = "torchmetrics"


### PR DESCRIPTION
## Summary

- move Ruff into a dedicated `lint` dependency group
- include that group from `dev` so local development remains unchanged
- run Ruff in CI with `uv run --locked --only-group lint`

## Why

The CI check previously used `uvx ruff`, which could resolve a different Ruff
version from the project lockfile. Running Ruff through the project normally
would also install TorchFont and PyTorch, adding substantial unnecessary work
to the check job.

The dedicated group lets CI use the locked Ruff version while installing only
Ruff. The minimum Python and PyTorch test setup is intentionally unchanged.

## Validation

- isolated lint dependency tree contains only Ruff
- `uv run --isolated --locked --only-group lint ruff format --check`
- `uv run --isolated --locked --only-group lint ruff check`
- `mise run check`
- `actionlint`
- `git diff --check`
