### PR TITLE
chore: release v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "google-fonts-glyphsets",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the package version to 0.11.1
- update the corresponding Cargo.lock package entry

## Validation

- `mise run check`
- `mise exec -- uv run maturin sdist`
- `git diff --check`