### PR TITLE
Add random overlap removal transform

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -140,6 +140,29 @@ Merges overlapping glyph subpaths with Skia PathOps while preserving winding-bas
 - input: `types=(N,)`, `coords=(N, 6)`
 - output: `types=(M,)`, `coords=(M, 6)`
 
+## random_remove_overlaps
+
+```python
+from torchfont.transforms import random_remove_overlaps
+
+types, coords = random_remove_overlaps(types, coords, generator=None)
+```
+
+Randomly merges one or more groups of overlapping subpaths for augmentation.
+
+- tight bounding-box intersections approximate which closed subpaths overlap
+- bbox-connected subpaths form independent overlap groups
+- each group is selected independently with probability 0.5
+- each selected group is merged with one Skia PathOps call
+- at least one group is selected when overlap groups exist
+- leaves a selected group unchanged if PathOps cannot simplify it
+- pass a `torch.Generator` for reproducible selection
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(M,)`, `coords=(M, 6)`
+
 ## normalize_subpath_start_points
 
 ```python

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -137,6 +137,29 @@ Skia PathOps を使い、winding に基づく hole を保ったまま重なっ�
 - 入力: `types=(N,)`, `coords=(N, 6)`
 - 出力: `types=(M,)`, `coords=(M, 6)`
 
+## random_remove_overlaps
+
+```python
+from torchfont.transforms import random_remove_overlaps
+
+types, coords = random_remove_overlaps(types, coords, generator=None)
+```
+
+データ拡張のため、重なりのある subpath をランダムな 1 個以上のグループとして統合します。
+
+- closed subpath の tight bounding box の交差を overlap の近似として使います
+- bbox で連結した subpath を独立した overlap グループにします
+- 各グループを独立に確率 0.5 で選択します
+- 選択された各グループを 1 回の Skia PathOps 呼び出しで統合します
+- overlap グループがある場合は少なくとも 1 グループを選択します
+- PathOps が選択グループを簡約できない場合はそのグループを変更しません
+- `torch.Generator` を渡すと選択を再現できます
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(M,)`, `coords=(M, 6)`
+
 ## normalize_subpath_start_points
 
 ```python

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -172,6 +172,27 @@ pub(crate) fn remove_overlaps<'py>(
 }
 
 #[pyfunction]
+pub(crate) fn random_remove_overlaps<'py>(
+    py: Python<'py>,
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+    random_values: PyReadonlyArray1<'_, f32>,
+) -> PyResult<OutlineArrays<'py>> {
+    let types = types.as_slice()?;
+    let outline = decode(types, coords.as_slice()?)?;
+    let random_values = random_values.as_slice()?;
+    if random_values.len() < types.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "random_values length must be at least types length",
+        ));
+    }
+    Ok(encode(
+        py,
+        &crate::transform::remove_overlaps::random_remove_overlaps(&outline, random_values),
+    ))
+}
+
+#[pyfunction]
 pub(crate) fn tight_bbox(
     types: PyReadonlyArray1<'_, i64>,
     coords: PyReadonlyArray1<'_, f32>,
@@ -234,6 +255,7 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cubic_to_quad, m)?)?;
     m.add_function(wrap_pyfunction!(merge_curves, m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, m)?)?;
+    m.add_function(wrap_pyfunction!(random_remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(normalize_subpath_start_points, m)?)?;
     m.add_function(wrap_pyfunction!(randomize_subpath_order, m)?)?;
     m.add_function(wrap_pyfunction!(randomize_subpath_start_points, m)?)?;

--- a/src/transform/remove_overlaps.rs
+++ b/src/transform/remove_overlaps.rs
@@ -11,6 +11,115 @@ pub(crate) fn remove_overlaps(outline: &Outline) -> Outline {
     simplify(outline).unwrap_or_else(|| outline.clone())
 }
 
+pub(crate) fn random_remove_overlaps(outline: &Outline, random_values: &[f32]) -> Outline {
+    let subpaths = outline.subpaths();
+    let bounds: Vec<_> = subpaths.iter().map(bounds_from_subpath).collect();
+    let mut parent: Vec<_> = (0..subpaths.len()).collect();
+
+    for left in 0..subpaths.len() {
+        if !subpaths[left].is_closed() {
+            continue;
+        }
+        for right in left + 1..subpaths.len() {
+            if subpaths[right].is_closed()
+                && bounds[left]
+                    .zip(bounds[right])
+                    .is_some_and(|(a, b)| bounds_overlap(a, b))
+            {
+                union(&mut parent, left, right);
+            }
+        }
+    }
+    for index in 0..parent.len() {
+        parent[index] = find(&mut parent, index);
+    }
+
+    let groups: Vec<Vec<_>> = (0..subpaths.len())
+        .filter(|&root| parent[root] == root)
+        .map(|root| {
+            (0..subpaths.len())
+                .filter(|&index| parent[index] == root)
+                .collect()
+        })
+        .filter(|group: &Vec<_>| group.len() > 1)
+        .collect();
+
+    if groups.is_empty() {
+        return outline.clone();
+    }
+
+    let values = &random_values[..groups.len()];
+    let mut selected: Vec<_> = groups
+        .iter()
+        .enumerate()
+        .filter_map(|(index, _)| (values[index] < 0.5).then_some(index))
+        .collect();
+    if selected.is_empty() {
+        let index = values
+            .iter()
+            .enumerate()
+            .min_by(|(_, a), (_, b)| a.total_cmp(b))
+            .map_or(0, |(index, _)| index);
+        selected.push(index);
+    }
+
+    let mut result = Vec::new();
+    for index in 0..subpaths.len() {
+        let Some((group_index, group)) = groups
+            .iter()
+            .enumerate()
+            .find(|(_, group)| group.contains(&index))
+        else {
+            result.push(subpaths[index].clone());
+            continue;
+        };
+        if group[0] != index {
+            continue;
+        }
+        let component: Vec<_> = group.iter().map(|&other| subpaths[other].clone()).collect();
+        if selected.contains(&group_index) {
+            let component = Outline::new(component);
+            let simplified = simplify(&component).unwrap_or(component);
+            result.extend(simplified.subpaths().iter().cloned());
+        } else {
+            result.extend(component);
+        }
+    }
+    Outline::new(result)
+}
+
+fn bounds_from_subpath(subpath: &Subpath) -> Option<Bounds> {
+    let mut pen = BoundsPen::default();
+    pen.move_to(subpath.start());
+    for element in subpath.elements() {
+        pen.path_element(*element);
+    }
+    if subpath.is_closed() {
+        pen.close();
+    }
+    pen.finish()
+}
+
+fn bounds_overlap(a: Bounds, b: Bounds) -> bool {
+    a.x_min < b.x_max && b.x_min < a.x_max && a.y_min < b.y_max && b.y_min < a.y_max
+}
+
+fn find(parent: &mut [usize], index: usize) -> usize {
+    if parent[index] != index {
+        parent[index] = find(parent, parent[index]);
+    }
+    parent[index]
+}
+
+fn union(parent: &mut [usize], left: usize, right: usize) {
+    let left = find(parent, left);
+    let right = find(parent, right);
+    if left != right {
+        parent[right] = left.min(right);
+        parent[left] = left.min(right);
+    }
+}
+
 fn simplify(outline: &Outline) -> Option<Outline> {
     let (path, _) = build_skia_path(outline.subpaths(), false, PathFillType::Winding)?;
     let scaled = path.try_make_scale((PATHOPS_SCALE, PATHOPS_SCALE))?;

--- a/tests/google_fonts/test_random_remove_overlaps.py
+++ b/tests/google_fonts/test_random_remove_overlaps.py
@@ -1,0 +1,140 @@
+import logging
+from pathlib import Path
+
+import pytest
+import torch
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from torchfont.datasets import GlyphDataset, GlyphSample
+from torchfont.io import ElementType
+from torchfont.transforms import (
+    load_glyph,
+    random_remove_overlaps,
+    render_bitmap,
+)
+
+logger = logging.getLogger(__name__)
+
+GOOGLE_FONTS_ROOT = Path("data/google/fonts")
+
+# Skia PathOps has known edge-case bugs; allow up to this fraction of glyphs to fail.
+MAX_FAILURE_RATE = 0.001  # 0.1 %
+MIN_CHANGE_RATE = 0.1  # 10 %
+BITMAP_SIZE = 128
+
+
+def _hard_diff(a: Tensor, b: Tensor) -> Tensor:
+    return ((a == 255) & (b == 0)) | ((a == 0) & (b == 255))
+
+
+def _transform(sample: GlyphSample) -> Tensor:
+    types, coords = load_glyph(sample.ref)
+    generator = torch.Generator().manual_seed(sample.ref.codepoint)
+    simplified_types, simplified_coords = random_remove_overlaps(
+        types,
+        coords,
+        generator=generator,
+    )
+
+    original = render_bitmap(
+        types,
+        coords,
+        size=BITMAP_SIZE,
+        mode="fixed",
+        fill_rule="winding",
+    )
+    simplified = render_bitmap(
+        simplified_types,
+        simplified_coords,
+        size=BITMAP_SIZE,
+        mode="fixed",
+        fill_rule="winding",
+    )
+
+    failed = _hard_diff(original, simplified).any()
+    if failed:
+        logger.warning(
+            "random_remove_overlaps bitmap mismatch: %s U+%04X %s",
+            sample.ref.font.path,
+            sample.ref.codepoint,
+            sample.ref.location,
+        )
+    changed = not (
+        torch.equal(types, simplified_types) and torch.equal(coords, simplified_coords)
+    )
+    subpath_reduction = max(
+        0,
+        types.tolist().count(ElementType.MOVE_TO.value)
+        - simplified_types.tolist().count(ElementType.MOVE_TO.value),
+    )
+    return torch.tensor([failed, changed, subpath_reduction], dtype=torch.long)
+
+
+@pytest.mark.google_fonts
+def test_random_remove_overlaps_google_fonts(
+    request: pytest.FixtureRequest,
+) -> None:
+    if not GOOGLE_FONTS_ROOT.is_dir():
+        pytest.fail(f"Google Fonts checkout not available: {GOOGLE_FONTS_ROOT}")
+
+    limit: int | None = request.config.getoption("--limit")
+
+    dataset = GlyphDataset(
+        root=GOOGLE_FONTS_ROOT,
+        patterns=(
+            "apache/*/*.ttf",
+            "ofl/*/*.ttf",
+            "ufl/*/*.ttf",
+            "!ofl/adobeblank/*.ttf",
+        ),
+        transform=_transform,
+    )
+    dataloader = DataLoader(
+        dataset,
+        batch_size=256,
+        shuffle=True,
+        num_workers=8,
+        prefetch_factor=2,
+    )
+
+    total = 0
+    failures = 0
+    changed = 0
+    subpath_reduction = 0
+    next_progress = 10_000
+    for batch in dataloader:
+        failures += batch[:, 0].sum().item()
+        changed += batch[:, 1].sum().item()
+        subpath_reduction += batch[:, 2].sum().item()
+        total += batch.size(0)
+        if total >= next_progress:
+            logger.warning(
+                "random_remove_overlaps progress: %s glyphs, %s failures, "
+                "%s changed, %s subpaths removed",
+                f"{total:,}",
+                f"{failures:,}",
+                f"{changed:,}",
+                f"{subpath_reduction:,}",
+            )
+            next_progress = total + 10_000
+        if limit is not None and total >= limit:
+            break
+
+    failure_rate = failures / max(1, total)
+    change_rate = changed / max(1, total)
+    logger.warning(
+        "random_remove_overlaps result: %s/%s changed (%.4f%%), %s subpaths removed",
+        f"{changed:,}",
+        f"{total:,}",
+        change_rate * 100,
+        f"{subpath_reduction:,}",
+    )
+    assert failure_rate <= MAX_FAILURE_RATE, (
+        f"random_remove_overlaps failure rate {failure_rate:.4%} "
+        f"({failures}/{total}) exceeds threshold {MAX_FAILURE_RATE:.4%}"
+    )
+    assert change_rate >= MIN_CHANGE_RATE, (
+        f"random_remove_overlaps change rate {change_rate:.4%} "
+        f"({changed}/{total}) is below threshold {MIN_CHANGE_RATE:.4%}"
+    )

--- a/tests/transforms/outline/test_random_remove_overlaps.py
+++ b/tests/transforms/outline/test_random_remove_overlaps.py
@@ -1,0 +1,126 @@
+import numpy as np
+import pytest
+import torch
+
+from torchfont import _torchfont
+from torchfont.io import ElementType
+from torchfont.transforms import random_remove_overlaps
+
+
+def _rectangles(
+    rectangles: list[tuple[float, float]], *, closed: list[bool] | None = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    types: list[int] = []
+    coords: list[list[float]] = []
+    closed = closed or [True] * len(rectangles)
+    for (x0, x1), is_closed in zip(rectangles, closed, strict=True):
+        types.extend(
+            [
+                ElementType.MOVE_TO.value,
+                ElementType.LINE_TO.value,
+                ElementType.LINE_TO.value,
+                ElementType.LINE_TO.value,
+                ElementType.CLOSE.value if is_closed else ElementType.LINE_TO.value,
+            ]
+        )
+        coords.extend(
+            [
+                [0, 0, 0, 0, x0, 0],
+                [0, 0, 0, 0, x1, 0],
+                [0, 0, 0, 0, x1, 2],
+                [0, 0, 0, 0, x0, 2],
+                [0, 0, 0, 0, 0 if is_closed else x0, 0],
+            ]
+        )
+    types.append(ElementType.END.value)
+    coords.append([0, 0, 0, 0, 0, 0])
+    return torch.tensor(types), torch.tensor(coords, dtype=torch.float32)
+
+
+def _four_squares() -> tuple[torch.Tensor, torch.Tensor]:
+    return _rectangles([(0.0, 2.0), (1.0, 3.0), (10.0, 12.0), (11.0, 13.0)])
+
+
+def test_random_remove_overlaps_can_merge_multiple_groups() -> None:
+    types, coords = _four_squares()
+    generator = torch.Generator().manual_seed(3)
+
+    out_types, out_coords = random_remove_overlaps(types, coords, generator=generator)
+
+    assert out_types.tolist().count(ElementType.MOVE_TO.value) == 2
+    assert out_types.tolist().count(ElementType.CLOSE.value) == 2
+    assert out_coords[:, 4].min() == 0
+    assert out_coords[:, 4].max() == 13
+
+
+def test_random_remove_overlaps_can_select_only_one_group() -> None:
+    types, coords = _four_squares()
+    generator = torch.Generator().manual_seed(0)
+
+    out_types, _ = random_remove_overlaps(types, coords, generator=generator)
+
+    assert out_types.tolist().count(ElementType.MOVE_TO.value) == 3
+
+
+def test_random_remove_overlaps_selects_at_least_one_group() -> None:
+    types, coords = _four_squares()
+    # The first two values for this seed are both above the selection threshold.
+    generator = torch.Generator().manual_seed(4)
+
+    out_types, _ = random_remove_overlaps(types, coords, generator=generator)
+
+    assert out_types.tolist().count(ElementType.MOVE_TO.value) == 3
+
+
+def test_random_remove_overlaps_uses_connected_components() -> None:
+    # The first and third rectangles do not intersect, but both intersect the second.
+    types, coords = _rectangles([(0.0, 2.0), (1.0, 3.0), (2.5, 4.5)])
+
+    out_types, _ = random_remove_overlaps(types, coords)
+
+    assert out_types.tolist().count(ElementType.MOVE_TO.value) == 1
+
+
+def test_random_remove_overlaps_excludes_open_subpaths() -> None:
+    types, coords = _rectangles(
+        [(0.0, 2.0), (1.0, 3.0), (1.25, 1.75)], closed=[True, True, False]
+    )
+
+    out_types, _ = random_remove_overlaps(types, coords)
+
+    assert out_types.tolist().count(ElementType.MOVE_TO.value) == 2
+    assert out_types.tolist().count(ElementType.CLOSE.value) == 1
+
+
+def test_random_remove_overlaps_is_reproducible() -> None:
+    outline = _four_squares()
+    first = torch.Generator().manual_seed(0)
+    second = torch.Generator().manual_seed(0)
+
+    output1 = random_remove_overlaps(*outline, generator=first)
+    output2 = random_remove_overlaps(*outline, generator=second)
+
+    assert torch.equal(output1[0], output2[0])
+    assert torch.equal(output1[1], output2[1])
+
+
+def test_random_remove_overlaps_leaves_non_candidates_unchanged() -> None:
+    types, coords = _four_squares()
+    separated_types = torch.cat([types[:5], types[10:15], types[-1:]])
+    separated_coords = torch.cat([coords[:5], coords[10:15], coords[-1:]])
+
+    output = random_remove_overlaps(separated_types, separated_coords)
+
+    assert torch.equal(output[0], separated_types)
+    assert torch.equal(output[1], separated_coords)
+
+
+def test_random_remove_overlaps_native_rejects_too_few_random_values() -> None:
+    types, coords = _four_squares()
+
+    with pytest.raises(
+        ValueError, match="random_values length must be at least types length"
+    ):
+        _torchfont.random_remove_overlaps(
+            types.numpy(), coords.reshape(-1).numpy(), np.zeros(1, dtype=np.float32)
+        )

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -35,6 +35,9 @@ def reverse_closed_subpaths(
 def remove_overlaps(
     types: np.ndarray, coords: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]: ...
+def random_remove_overlaps(
+    types: np.ndarray, coords: np.ndarray, random_values: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]: ...
 def quad_to_cubic(
     types: np.ndarray, coords: np.ndarray, merge_curves: bool
 ) -> tuple[np.ndarray, np.ndarray]: ...

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -24,7 +24,11 @@ from torchfont.transforms.geometric import (
     vertical_flip,
 )
 from torchfont.transforms.load import load_glyph, random_location
-from torchfont.transforms.outline import patchify, remove_overlaps
+from torchfont.transforms.outline import (
+    patchify,
+    random_remove_overlaps,
+    remove_overlaps,
+)
 from torchfont.transforms.subpath import (
     normalize_subpath_start_points,
     randomize_subpath_order,
@@ -45,6 +49,7 @@ __all__ = [
     "random_coord_jitter",
     "random_horizontal_flip",
     "random_location",
+    "random_remove_overlaps",
     "random_vertical_flip",
     "randomize_subpath_order",
     "randomize_subpath_start_points",

--- a/torchfont/transforms/outline.py
+++ b/torchfont/transforms/outline.py
@@ -59,3 +59,36 @@ def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
         torch.from_numpy(out_types).to(device=types_device),
         torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
     )
+
+
+def random_remove_overlaps(
+    types: Tensor,
+    coords: Tensor,
+    *,
+    generator: torch.Generator | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Randomly merge one or more groups of potentially overlapping subpaths.
+
+    Tight bounding-box intersections are used as an inexpensive approximation of
+    overlap. Bbox-connected components form independent groups, each selected with
+    probability 0.5 and simplified with one Skia PathOps call. If overlap groups
+    exist, at least one is selected. If PathOps cannot simplify a selected group,
+    that group is returned unchanged. Pass a ``torch.Generator`` to make the
+    selection reproducible.
+    """
+    types_device = types.device
+    coords_device = coords.device
+    types = types.cpu().contiguous()
+    coords = coords.cpu().contiguous()
+    random_values = torch.rand(
+        types.size(0),
+        device=generator.device if generator is not None else types.device,
+        generator=generator,
+    ).cpu()
+    out_types, out_coords = _torchfont.random_remove_overlaps(
+        types.numpy(), coords.reshape(-1).numpy(), random_values.numpy()
+    )
+    return (
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
+    )


### PR DESCRIPTION
## Summary

- add `random_remove_overlaps` as a reproducible outline augmentation
- approximate overlap with tight bounding boxes and group closed subpaths by connected component
- independently select overlap groups with probability 0.5, while selecting at least one group when candidates exist
- simplify each selected group with one Skia PathOps call and preserve the original group if PathOps fails
- document the transform in English and Japanese

## Motivation

`remove_overlaps` always simplifies the complete outline. Training augmentation benefits from selectively simplifying independent overlap regions so that a glyph can retain some original subpath structure while other regions are merged.

The bbox graph keeps overlap discovery inexpensive and avoids repeated PathOps or bitmap-rendering validation inside the transform.

## Validation

- `mise run format`
- `mise run check`
- `mise run build`
- `mise run test` — 230 passed, 17 skipped
- `mise run docs-build`
- Google Fonts corpus test — 12,497,578 glyphs, 70.5414% changed, 25,971,861 subpaths removed, 404 bitmap mismatches (~0.00323%), passed
