### PR TITLE
Add random segment splitting transform

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -118,6 +118,39 @@ Collapses adjacent segments when they can be reconstructed as one parent shape.
 - input: `types=(N,)`, `coords=(N, 6)`
 - output: `types=(M,)`, `coords=(M, 6)`
 
+## random_split_segments
+
+```python
+from torchfont.transforms import random_split_segments
+
+types, coords = random_split_segments(
+    types,
+    coords,
+    split_probability=0.2,
+    split_range=(0.2, 0.8),
+    generator=None,
+)
+```
+
+Randomly subdivides drawing segments without changing their shape.
+
+- each `LINE_TO`, `QUAD_TO`, and `CURVE_TO` segment is independently selected
+  with `split_probability` (default: `0.2`)
+- `split_probability` must be between `0.0` and `1.0`
+- selected segments are split at an independently sampled parameter in
+  `split_range` (default: `(0.2, 0.8)`)
+- `split_range` must satisfy `0 < min <= max < 1`; equal bounds select a fixed
+  split parameter
+- selecting no segments is a valid no-op result
+- `MOVE_TO`, `CLOSE`, `END`, and `PAD` elements are unchanged
+- subpath boundaries and open/closed state are preserved
+- pass a `torch.Generator` for reproducible selection and split positions
+
+### I/O Shape
+
+- input: `types=(N,)`, `coords=(N, 6)`
+- output: `types=(M,)`, `coords=(M, 6)`, where `N <= M <= 2N`
+
 
 ## remove_overlaps
 

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -115,6 +115,39 @@ types, coords = merge_curves(types, coords)
 - 入力: `types=(N,)`, `coords=(N, 6)`
 - 出力: `types=(M,)`, `coords=(M, 6)`
 
+## random_split_segments
+
+```python
+from torchfont.transforms import random_split_segments
+
+types, coords = random_split_segments(
+    types,
+    coords,
+    split_probability=0.2,
+    split_range=(0.2, 0.8),
+    generator=None,
+)
+```
+
+形状を変えず、描画 segment をランダムに細分化します。
+
+- 各 `LINE_TO`、`QUAD_TO`、`CURVE_TO` segment を独立に
+  `split_probability`（デフォルト: `0.2`）で選択します
+- `split_probability` は `0.0` 以上 `1.0` 以下で指定します
+- 選択した segment は独立に `split_range`（デフォルト: `(0.2, 0.8)`）から
+  sample したパラメータ位置で分割します
+- `split_range` は `0 < min <= max < 1` を満たす必要があります。同じ値を指定すると
+  分割位置が固定されます
+- 1 本も選択されない no-op の結果もあります
+- `MOVE_TO`、`CLOSE`、`END`、`PAD` element は変更しません
+- subpath の境界と open/closed 状態を維持します
+- `torch.Generator` を渡すと選択と分割位置を再現できます
+
+### 入出力
+
+- 入力: `types=(N,)`, `coords=(N, 6)`
+- 出力: `types=(M,)`, `coords=(M, 6)`。`N <= M <= 2N`
+
 
 ## remove_overlaps
 

--- a/src/py/transform/mod.rs
+++ b/src/py/transform/mod.rs
@@ -82,6 +82,61 @@ pub(crate) fn merge_curves<'py>(
 }
 
 #[pyfunction]
+pub(crate) fn random_split_segments<'py>(
+    py: Python<'py>,
+    types: PyReadonlyArray1<'_, i64>,
+    coords: PyReadonlyArray1<'_, f32>,
+    selection_values: PyReadonlyArray1<'_, f32>,
+    position_values: PyReadonlyArray1<'_, f32>,
+    split_probability: f32,
+    split_range: (f32, f32),
+) -> PyResult<OutlineArrays<'py>> {
+    use crate::outline::ElementType;
+    if !(0.0..=1.0).contains(&split_probability) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "split_probability must be between 0 and 1",
+        ));
+    }
+    if !(0.0 < split_range.0 && split_range.0 <= split_range.1 && split_range.1 < 1.0) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "split_range must satisfy 0 < min <= max < 1",
+        ));
+    }
+    let types = types.as_slice()?;
+    let outline = decode(types, coords.as_slice()?)?;
+    let selection_values = selection_values.as_slice()?;
+    let position_values = position_values.as_slice()?;
+    if selection_values.len() < types.len() || position_values.len() < types.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "selection_values and position_values lengths must be at least types length",
+        ));
+    }
+    let mut segment_selection_values = Vec::new();
+    let mut segment_position_values = Vec::new();
+    for ((&element_type, &selection), &position) in
+        types.iter().zip(selection_values).zip(position_values)
+    {
+        if element_type == ElementType::LineTo as i64
+            || element_type == ElementType::QuadTo as i64
+            || element_type == ElementType::CurveTo as i64
+        {
+            segment_selection_values.push(selection);
+            segment_position_values.push(position);
+        }
+    }
+    Ok(encode(
+        py,
+        &curves::split_segments::random_split_segments(
+            &outline,
+            &segment_selection_values,
+            &segment_position_values,
+            split_probability,
+            split_range,
+        ),
+    ))
+}
+
+#[pyfunction]
 pub(crate) fn normalize_subpath_start_points<'py>(
     py: Python<'py>,
     types: PyReadonlyArray1<'_, i64>,
@@ -254,6 +309,7 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(quad_to_cubic, m)?)?;
     m.add_function(wrap_pyfunction!(cubic_to_quad, m)?)?;
     m.add_function(wrap_pyfunction!(merge_curves, m)?)?;
+    m.add_function(wrap_pyfunction!(random_split_segments, m)?)?;
     m.add_function(wrap_pyfunction!(remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(random_remove_overlaps, m)?)?;
     m.add_function(wrap_pyfunction!(normalize_subpath_start_points, m)?)?;

--- a/src/transform/curves/mod.rs
+++ b/src/transform/curves/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod cubic_to_quad;
 pub(crate) mod merge_curves;
 pub(crate) mod quad_to_cubic;
+pub(crate) mod split_segments;
 
 use crate::outline::Point;
 

--- a/src/transform/curves/split_segments.rs
+++ b/src/transform/curves/split_segments.rs
@@ -1,0 +1,87 @@
+use super::split_cubic_at;
+use crate::outline::{Outline, PathElement, Point, Subpath};
+
+pub(crate) fn random_split_segments(
+    outline: &Outline,
+    selection_values: &[f32],
+    position_values: &[f32],
+    split_probability: f32,
+    split_range: (f32, f32),
+) -> Outline {
+    let segment_count: usize = outline
+        .subpaths()
+        .iter()
+        .map(|subpath| subpath.elements().len())
+        .sum();
+    if segment_count == 0 {
+        return outline.clone();
+    }
+
+    let selection_values = &selection_values[..segment_count];
+    let position_values = &position_values[..segment_count];
+    let mut value_index = 0;
+    let subpaths = outline
+        .subpaths()
+        .iter()
+        .map(|subpath| {
+            let mut start = subpath.start();
+            let mut elements = Vec::with_capacity(subpath.elements().len() * 2);
+            for &element in subpath.elements() {
+                if selection_values[value_index] < split_probability {
+                    let t = split_range.0
+                        + (split_range.1 - split_range.0) * position_values[value_index];
+                    elements.extend(split_segment(start, element, t));
+                } else {
+                    elements.push(element);
+                }
+                start = element.end();
+                value_index += 1;
+            }
+            Subpath::new(subpath.start(), elements, subpath.is_closed())
+        })
+        .collect();
+    Outline::new(subpaths)
+}
+
+fn split_segment(start: Point, element: PathElement, t: f32) -> [PathElement; 2] {
+    match element {
+        PathElement::LineTo(end) => {
+            let split = start.lerp(end, t);
+            [PathElement::LineTo(split), PathElement::LineTo(end)]
+        }
+        PathElement::QuadTo { control, end } => {
+            let control0 = start.lerp(control, t);
+            let control1 = control.lerp(end, t);
+            let split = control0.lerp(control1, t);
+            [
+                PathElement::QuadTo {
+                    control: control0,
+                    end: split,
+                },
+                PathElement::QuadTo {
+                    control: control1,
+                    end,
+                },
+            ]
+        }
+        PathElement::CurveTo {
+            control0,
+            control1,
+            end,
+        } => {
+            let (left, right) = split_cubic_at(start, control0, control1, end, t);
+            [
+                PathElement::CurveTo {
+                    control0: left.1,
+                    control1: left.2,
+                    end: left.3,
+                },
+                PathElement::CurveTo {
+                    control0: right.1,
+                    control1: right.2,
+                    end: right.3,
+                },
+            ]
+        }
+    }
+}

--- a/tests/transforms/curves/test_random_split_segments.py
+++ b/tests/transforms/curves/test_random_split_segments.py
@@ -1,0 +1,167 @@
+import numpy as np
+import pytest
+import torch
+
+from torchfont import _torchfont
+from torchfont.io import ElementType
+from torchfont.transforms import random_split_segments
+
+
+def _mixed_segments() -> tuple[torch.Tensor, torch.Tensor]:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO.value,
+            ElementType.LINE_TO.value,
+            ElementType.MOVE_TO.value,
+            ElementType.QUAD_TO.value,
+            ElementType.MOVE_TO.value,
+            ElementType.CURVE_TO.value,
+            ElementType.END.value,
+        ]
+    )
+    coords = torch.tensor(
+        [
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 2, 0],
+            [0, 0, 0, 0, 0, 0],
+            [1, 2, 0, 0, 2, 0],
+            [0, 0, 0, 0, 0, 0],
+            [1, 3, 2, 3, 3, 0],
+            [0, 0, 0, 0, 0, 0],
+        ],
+        dtype=torch.float32,
+    )
+    return types, coords
+
+
+def test_random_split_segments_splits_each_segment_type_at_de_casteljau_midpoint() -> (
+    None
+):
+    types, coords = _mixed_segments()
+    selection_values = np.full(types.numel(), 0.1, dtype=np.float32)
+    position_values = np.full(types.numel(), 0.5, dtype=np.float32)
+
+    out_types, flat_coords = _torchfont.random_split_segments(
+        types.numpy(),
+        coords.reshape(-1).numpy(),
+        selection_values,
+        position_values,
+        0.2,
+        (0.2, 0.8),
+    )
+    out_coords = torch.from_numpy(flat_coords).view(-1, 6)
+
+    assert out_types.tolist() == [
+        ElementType.MOVE_TO.value,
+        ElementType.LINE_TO.value,
+        ElementType.LINE_TO.value,
+        ElementType.MOVE_TO.value,
+        ElementType.QUAD_TO.value,
+        ElementType.QUAD_TO.value,
+        ElementType.MOVE_TO.value,
+        ElementType.CURVE_TO.value,
+        ElementType.CURVE_TO.value,
+        ElementType.END.value,
+    ]
+    assert torch.equal(out_coords[1], torch.tensor([0, 0, 0, 0, 1, 0.0]))
+    assert torch.equal(out_coords[2], torch.tensor([0, 0, 0, 0, 2, 0.0]))
+    assert torch.equal(out_coords[4], torch.tensor([0.5, 1, 0, 0, 1, 1.0]))
+    assert torch.equal(out_coords[5], torch.tensor([1.5, 1, 0, 0, 2, 0.0]))
+    assert torch.equal(out_coords[7], torch.tensor([0.5, 1.5, 1, 2.25, 1.5, 2.25]))
+    assert torch.equal(out_coords[8], torch.tensor([2, 2.25, 2.5, 1.5, 3, 0.0]))
+
+
+def test_random_split_segments_can_leave_every_segment_unchanged() -> None:
+    types, coords = _mixed_segments()
+    selection_values = np.full(types.numel(), 0.9, dtype=np.float32)
+    position_values = np.full(types.numel(), 0.5, dtype=np.float32)
+
+    out_types, _ = _torchfont.random_split_segments(
+        types.numpy(),
+        coords.reshape(-1).numpy(),
+        selection_values,
+        position_values,
+        0.2,
+        (0.2, 0.8),
+    )
+
+    assert out_types.tolist().count(ElementType.LINE_TO.value) == 1
+    assert out_types.tolist().count(ElementType.QUAD_TO.value) == 1
+    assert out_types.tolist().count(ElementType.CURVE_TO.value) == 1
+
+
+def test_random_split_segments_probability_boundaries() -> None:
+    types, coords = _mixed_segments()
+
+    unchanged = random_split_segments(types, coords, split_probability=0.0)
+    split = random_split_segments(types, coords, split_probability=1.0)
+
+    assert torch.equal(unchanged[0], types)
+    assert torch.equal(unchanged[1], coords)
+    assert split[0].numel() == types.numel() + 3
+
+
+@pytest.mark.parametrize("split_probability", [-0.1, 1.1, float("nan")])
+def test_random_split_segments_rejects_invalid_probability(
+    split_probability: float,
+) -> None:
+    types, coords = _mixed_segments()
+
+    with pytest.raises(ValueError, match="split_probability must be between 0 and 1"):
+        random_split_segments(types, coords, split_probability=split_probability)
+
+
+@pytest.mark.parametrize(
+    "split_range",
+    [(0.0, 0.8), (0.2, 1.0), (0.8, 0.2), (float("nan"), 0.8)],
+)
+def test_random_split_segments_rejects_invalid_range(
+    split_range: tuple[float, float],
+) -> None:
+    types, coords = _mixed_segments()
+
+    with pytest.raises(ValueError, match="split_range must satisfy"):
+        random_split_segments(types, coords, split_range=split_range)
+
+
+def test_random_split_segments_accepts_fixed_split_parameter() -> None:
+    types, coords = _mixed_segments()
+
+    out_types, out_coords = random_split_segments(
+        types,
+        coords,
+        split_probability=1.0,
+        split_range=(0.5, 0.5),
+    )
+
+    assert out_types.numel() == types.numel() + 3
+    assert out_coords[1, 4].item() == pytest.approx(1.0)
+
+
+def test_random_split_segments_is_reproducible() -> None:
+    outline = _mixed_segments()
+    first = torch.Generator().manual_seed(0)
+    second = torch.Generator().manual_seed(0)
+
+    output1 = random_split_segments(*outline, generator=first)
+    output2 = random_split_segments(*outline, generator=second)
+
+    assert torch.equal(output1[0], output2[0])
+    assert torch.equal(output1[1], output2[1])
+
+
+def test_random_split_segments_native_rejects_too_few_selection_values() -> None:
+    types, coords = _mixed_segments()
+
+    with pytest.raises(
+        ValueError,
+        match="selection_values and position_values lengths",
+    ):
+        _torchfont.random_split_segments(
+            types.numpy(),
+            coords.reshape(-1).numpy(),
+            np.zeros(1, dtype=np.float32),
+            np.zeros(types.numel(), dtype=np.float32),
+            0.2,
+            (0.2, 0.8),
+        )

--- a/torchfont/_torchfont.pyi
+++ b/torchfont/_torchfont.pyi
@@ -13,6 +13,14 @@ def cubic_to_quad(
 def merge_curves(
     types: np.ndarray, coords: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]: ...
+def random_split_segments(
+    types: np.ndarray,
+    coords: np.ndarray,
+    selection_values: np.ndarray,
+    position_values: np.ndarray,
+    split_probability: float,
+    split_range: tuple[float, float],
+) -> tuple[np.ndarray, np.ndarray]: ...
 def render_bitmap(
     types: np.ndarray,
     coords: np.ndarray,

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -13,6 +13,7 @@ from torchfont.transforms.curves import (
     cubic_to_quad,
     merge_curves,
     quad_to_cubic,
+    random_split_segments,
 )
 from torchfont.transforms.geometric import (
     affine,
@@ -50,6 +51,7 @@ __all__ = [
     "random_horizontal_flip",
     "random_location",
     "random_remove_overlaps",
+    "random_split_segments",
     "random_vertical_flip",
     "randomize_subpath_order",
     "randomize_subpath_start_points",

--- a/torchfont/transforms/curves.py
+++ b/torchfont/transforms/curves.py
@@ -1,4 +1,4 @@
-"""Bezier curve format conversion and segment merging."""
+"""Bezier curve format conversion and segment transformation functions."""
 
 import torch
 from torch import Tensor
@@ -96,6 +96,45 @@ def merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     coords = coords.cpu().contiguous()
     out_types, out_coords = _torchfont.merge_curves(
         types.numpy(), coords.reshape(-1).numpy()
+    )
+    return (
+        torch.from_numpy(out_types).to(device=types_device),
+        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
+    )
+
+
+def random_split_segments(
+    types: Tensor,
+    coords: Tensor,
+    *,
+    split_probability: float = 0.2,
+    split_range: tuple[float, float] = (0.2, 0.8),
+    generator: torch.Generator | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Randomly split line or Bezier segments without changing their shape.
+
+    Each ``LINE_TO``, ``QUAD_TO``, and ``CURVE_TO`` segment is independently
+    selected with ``split_probability``. Its split parameter is independently
+    sampled from ``split_range``. It is valid for no segment to be selected.
+    ``MOVE_TO``, ``CLOSE``, ``END``, and ``PAD`` elements are left unchanged.
+    Pass a ``torch.Generator`` to make selection and split positions reproducible.
+    """
+    types_device = types.device
+    coords_device = coords.device
+    types = types.cpu().contiguous()
+    coords = coords.cpu().contiguous()
+    random_values = torch.rand(
+        (2, types.size(0)),
+        device=generator.device if generator is not None else types.device,
+        generator=generator,
+    ).cpu()
+    out_types, out_coords = _torchfont.random_split_segments(
+        types.numpy(),
+        coords.reshape(-1).numpy(),
+        random_values[0].numpy(),
+        random_values[1].numpy(),
+        split_probability,
+        split_range,
     )
     return (
         torch.from_numpy(out_types).to(device=types_device),


### PR DESCRIPTION
## Summary

- add `random_split_segments` for shape-preserving vector augmentation
- independently select line, quadratic, and cubic segments with a configurable probability
- split selected Bézier segments exactly with De Casteljau subdivision
- expose a configurable `split_range` for split-position sampling
- document the transform in English and Japanese

## Motivation

Equivalent outlines can use different segment subdivisions. Randomly splitting drawing segments teaches models not to depend on a particular path-element count or segmentation while preserving subpath structure and rendered geometry.

Selection and split-position sampling use independent random values. `MOVE_TO`, `CLOSE`, `END`, and `PAD` remain unchanged.

## API

```python
random_split_segments(
    types,
    coords,
    split_probability=0.2,
    split_range=(0.2, 0.8),
    generator=None,
)
```

`split_probability` accepts values from 0 through 1. `split_range` must satisfy `0 < min <= max < 1`; equal bounds provide a fixed split position.

## Validation

- `mise run format`
- `mise run check`
- `mise run build`
- `mise run test` — 243 passed, 17 skipped
- focused transform tests — 13 passed
- `mise run docs-build`
- `git diff --check`
