### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     given-names: "Takumu"
     email: "fjktkm@gmail.com"
     orcid: "https://orcid.org/0009-0005-0691-414X"
-version: 0.11.0
-date-released: 2026-07-18
+version: 0.12.0
+date-released: 2026-08-03
 license: MIT
 repository-code: "https://github.com/torchfont/torchfont"
 url: "https://torchfont.readthedocs.io/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "google-fonts-glyphsets",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the package version to 0.12.0
- update the corresponding Cargo.lock package entry
- update CITATION.cff with version 0.12.0 and the 2026-08-03 release date

## Validation

- mise run check
- mise exec -- uv run maturin sdist
- git diff --check
