### PR TITLE
Align transform parameter sharing with TorchVision

### DIFF
--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -41,7 +41,7 @@ data = transform(sample)
 outline = data.data
 ```
 
-`LoadGlyph` accepts a `GlyphSample` or `GlyphRef`. A sample becomes
+`LoadGlyph` loads one `GlyphSample` or `GlyphRef`. A sample becomes
 `GlyphData[Outline]`, while a bare reference becomes `Outline`.
 `LoadGlyph` uses the face's default location unless `location="random"` is set.
 The random policy samples one location for a `GlyphSample` or `GlyphRef` and
@@ -49,19 +49,16 @@ records it in `GlyphData.location`; on a static face it naturally uses an empty
 location. For dataset samples, it also resolves the parallel `weight`, `width`,
 `italic`, `slant`, and `optical_size` targets on the returned `GlyphData`.
 
-`Transform` flattens nested pytree inputs, samples parameters independently for
-each matching semantic leaf, and restores the input structure. Wrap a transform
-with `SameParams` when corresponding outlines, such as multiple glyphs from the
-same variable font at one location, must receive the same flip, affine parameters, or
-element-level random values. Random transforms use PyTorch's default RNG, so
+`Transform` flattens nested pytree inputs, samples parameters once for all
+matching semantic leaves, and restores the input structure. Thus corresponding
+outlines in one transform call receive the same flip, affine parameters, or
+element-level random values. Apply the transform separately to independent
+samples. Random transforms use PyTorch's default RNG, so
 `torch.manual_seed` and DataLoader worker seeding apply normally.
-`SameParams(LoadGlyph(location="random"))` may likewise select one location for
-multiple glyphs from the same font; sharing raw axis values across different
-fonts is rejected.
 Built-in transforms contain configuration only and remain pickle-friendly.
 `Compose` registers its children in a `torch.nn.ModuleList`, including when it
-is constructed from an ordinary list of modules. `RandomApply` and `SameParams`
-register the single module they wrap. Plain callables are intentionally
+is constructed from an ordinary list of modules. `RandomApply` registers the
+single module it wraps. Plain callables are intentionally
 unsupported: define a small `nn.Module` so its
 behavior, representation, and pickle requirements remain explicit. This keeps
 module traversal, state dictionaries, hooks, and configuration display
@@ -73,13 +70,13 @@ random transforms intentionally do not use the `training` flag: preprocessing
 and model mode are separate concerns. Select a deterministic pipeline explicitly
 for evaluation rather than relying on `eval()` to disable augmentation.
 
-Like `torchvision.transforms.v2`, transforms and containers accept either one pytree or
-multiple positional inputs. `check_inputs()` is available to custom transforms
-that need to check relationships between leaves before sampling parameters.
+Like `torchvision.transforms.v2`, `Transform` subclasses and containers accept
+either one pytree or multiple positional inputs. `check_inputs()` is available
+to custom transforms that need to check relationships between leaves before sampling parameters.
 `Compose` immediately materializes an iterable of `nn.Module` objects into an
 `nn.ModuleList`; an empty iterable is an identity transform. `RandomApply` wraps
-one `nn.Module`, while `SameParams` wraps one `Transform`. Use `Compose` inside
-`RandomApply` when grouping several transforms.
+one `nn.Module`. Use `Compose` inside `RandomApply` when grouping several
+transforms.
 
 `RandomApply(transform, p)` controls whether one transform is applied.
 Probabilities such as `RandomSplitSegments.split_probability` control behavior
@@ -90,7 +87,7 @@ inside an already-applied transform.
 | Category | Transforms |
 | --- | --- |
 | Loading | `LoadGlyph` |
-| Containers | `Compose`, `RandomApply`, `SameParams` |
+| Containers | `Compose`, `RandomApply` |
 | Curves | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | Outline | `RemoveOverlaps`, `RandomRemoveOverlaps` |
 | Subpaths | `NormalizeSubpathStartPoints`, `RandomizeSubpathStartPoints`, `RandomizeSubpathOrder` |

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -40,7 +40,7 @@ data = transform(sample)
 outline = data.data
 ```
 
-`LoadGlyph` は `GlyphSample` または `GlyphRef` を受け取ります。サンプルは
+`LoadGlyph` は一つの `GlyphSample` または `GlyphRef` を読み込みます。サンプルは
 `GlyphData[Outline]` に、参照単体は `Outline` になります。
 `LoadGlyph` は、`location="random"` を指定しない限り Face の Default Location を使います。
 Random Policy は `GlyphSample` または `GlyphRef` に対して位置を 1 点抽出し、
@@ -48,13 +48,12 @@ Random Policy は `GlyphSample` または `GlyphRef` に対して位置を 1 点
 Dataset Sample に対しては、返される `GlyphData` の並列な `weight`、`width`、`italic`、
 `slant`、`optical_size` Target も解決します。
 
-`Transform` はネストした PyTree を平坦化し、一致する意味的なリーフごとに独立して
-パラメーターを生成し、元の構造を復元します。同じバリアブルフォントの複数グリフを一つの
-位置で扱う場合など、対応する複数アウトラインに同じ反転、アフィンパラメーター、要素単位の
-乱数を適用する場合は、Transform を `SameParams` で包みます。確率的 Transform は PyTorch の
+`Transform` はネストした PyTree を平坦化し、一致するすべての意味的なリーフに対して
+パラメーターを一度だけ生成し、元の構造を復元します。そのため、一回の呼び出しに含まれる
+対応する複数アウトラインには、同じ反転、アフィンパラメーター、要素単位の乱数が適用されます。
+独立したサンプルには Transform を個別に適用します。確率的 Transform は PyTorch の
 デフォルト RNG を使うため、`torch.manual_seed` と `DataLoader` ワーカーのシードが通常どおり
-機能します。`SameParams(LoadGlyph(location="random"))` を使うと同じ Font の複数 Glyph に
-一つの位置を選べますが、異なる Font 間で未変換の Axis 値を共有することは拒否します。
+機能します。
 組み込み Transform は設定のみを保持し、`pickle` 可能です。`Compose` に通常のリストを
 渡した場合も、子 Transform は内部の `torch.nn.ModuleList` に登録されます。通常の
 `callable` には意図的に対応しません。小さな `nn.Module` を定義し、挙動、表示、`pickle`
@@ -66,12 +65,11 @@ Dataset Sample に対しては、返される `GlyphData` の並列な `weight`�
 `training` フラグを参照しません。前処理とモデルのモードは別の関心事なので、評価時は
 `eval()` でデータ拡張が止まることに依存せず、決定論的パイプラインを明示的に選びます。
 
-`torchvision.transforms.v2` と同様に、Transform とコンテナーは一つの PyTree または複数の
-位置引数を受け取れます。リーフ間の関係をパラメーターのサンプリング前に確認する
+`torchvision.transforms.v2` と同様に、`Transform` のサブクラスとコンテナーは一つの
+PyTree または複数の位置引数を受け取れます。リーフ間の関係をパラメーターのサンプリング前に確認する
 カスタム Transform のために `check_inputs()` を利用できます。`Compose` は
 `nn.Module` の `Iterable` を即座に `nn.ModuleList` へ具体化し、空の `Iterable` は
-恒等 Transform として扱います。`RandomApply` は一つの
-`nn.Module`、`SameParams` は一つの `Transform` を包みます。複数の Transform を
+恒等 Transform として扱います。`RandomApply` は一つの `nn.Module` を包みます。複数の Transform を
 `RandomApply` でまとめる場合は、内側に `Compose` を置きます。
 
 `RandomApply(transform, p)` は一つの Transform を適用するか制御します。
@@ -83,7 +81,7 @@ Dataset Sample に対しては、返される `GlyphData` の並列な `weight`�
 | 分類 | Transform |
 | --- | --- |
 | 読み込み | `LoadGlyph` |
-| コンテナ | `Compose`, `RandomApply`, `SameParams` |
+| コンテナ | `Compose`, `RandomApply` |
 | Curve | `QuadToCubic`, `CubicToQuad`, `MergeCurves`, `RandomSplitSegments` |
 | アウトライン | `RemoveOverlaps`, `RandomRemoveOverlaps` |
 | Subpath | `NormalizeSubpathStartPoints`, `RandomizeSubpathStartPoints`, `RandomizeSubpathOrder` |

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -171,6 +171,19 @@ def test_load_glyph_samples_one_location_reproducibly() -> None:
     assert first.location != LoadGlyph()(sample).location
 
 
+def test_load_glyph_resamples_location_on_each_call() -> None:
+    sample = GlyphDataset(
+        "tests/fonts", patterns="roboto/Roboto*.ttf", codepoints=[0x41]
+    )[0]
+    load = LoadGlyph(location="random")
+
+    torch.manual_seed(123)
+    first = load(sample)
+    second = load(sample)
+
+    assert first.location != second.location
+
+
 def test_load_glyph_random_location_on_static_face_is_empty() -> None:
     sample = GlyphDataset(
         "tests/fonts", patterns="lato/Lato-Regular.ttf", codepoints=[0x41]

--- a/tests/transforms/geometric/test_random_affine.py
+++ b/tests/transforms/geometric/test_random_affine.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from torchfont import Outline
-from torchfont.transforms import RandomAffine, SameParams
+from torchfont.transforms import RandomAffine
 
 
 def test_random_affine_is_reproducible_with_torch_seed(
@@ -23,12 +23,10 @@ def test_random_affine_preserves_padding_and_shares_parameters(
     close_end_zeros: Callable[[torch.Tensor, torch.Tensor], bool],
 ) -> None:
     outline = Outline(*simple_outline)
-    first, second = SameParams(
-        RandomAffine(
-            degrees=15.0,
-            translate=(0.05, 0.05),
-            scale=(0.9, 1.1),
-        )
+    first, second = RandomAffine(
+        degrees=15.0,
+        translate=(0.05, 0.05),
+        scale=(0.9, 1.1),
     )([outline, outline])
     assert torch.equal(first.coords, second.coords)
     assert close_end_zeros(first.types, first.coords)

--- a/tests/transforms/geometric/test_random_coord_jitter.py
+++ b/tests/transforms/geometric/test_random_coord_jitter.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from torchfont import ElementType, Outline
-from torchfont.transforms import RandomCoordJitter, SameParams
+from torchfont.transforms import RandomCoordJitter
 from torchfont.transforms.functional import coord_jitter
 
 
@@ -28,19 +28,11 @@ def test_random_coord_jitter_zero_std_is_identity(
     assert torch.equal(output.coords, outline.coords)
 
 
-def test_random_coord_jitter_samples_noise_independently_between_outlines(
+def test_random_coord_jitter_shares_noise_between_outlines(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     outline = Outline(*simple_outline)
     first, second = RandomCoordJitter(0.1)([outline, outline])
-    assert not torch.equal(first.coords, second.coords)
-
-
-def test_random_coord_jitter_can_share_noise_explicitly(
-    simple_outline: tuple[torch.Tensor, torch.Tensor],
-) -> None:
-    outline = Outline(*simple_outline)
-    first, second = SameParams(RandomCoordJitter(0.1))([outline, outline])
     assert torch.equal(first.coords, second.coords)
 
 

--- a/tests/transforms/geometric/test_random_horizontal_flip.py
+++ b/tests/transforms/geometric/test_random_horizontal_flip.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from torchfont import Outline
-from torchfont.transforms import RandomHorizontalFlip, SameParams
+from torchfont.transforms import RandomHorizontalFlip
 
 
 @pytest.mark.parametrize(("p", "changes"), [(0.0, False), (1.0, True)])
@@ -18,7 +18,7 @@ def test_random_horizontal_flip_shares_decision_between_outlines(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     outline = Outline(*simple_outline)
-    first, second = SameParams(RandomHorizontalFlip())([outline, outline])
+    first, second = RandomHorizontalFlip()([outline, outline])
     assert torch.equal(first.types, second.types)
     assert torch.equal(first.coords, second.coords)
 

--- a/tests/transforms/test_transform.py
+++ b/tests/transforms/test_transform.py
@@ -19,7 +19,6 @@ from torchfont.transforms import (
     RandomApply,
     RandomSplitSegments,
     RenderBitmap,
-    SameParams,
     Transform,
 )
 
@@ -166,35 +165,35 @@ def test_random_split_segments_handles_different_length_outlines() -> None:
     assert output[1].types.numel() == long.types.numel() + 3
 
 
-def test_same_params_shares_randomness_between_outlines() -> None:
+def test_transform_shares_randomness_between_outlines() -> None:
     transform = RandomSplitSegments(split_probability=0.5)
     outline = _line_outline(8)
 
-    first, second = SameParams(transform)([outline, outline])
+    first, second = transform([outline, outline])
 
     assert torch.equal(first.types, second.types)
     assert torch.equal(first.coords, second.coords)
 
 
-def test_same_params_calls_wrapped_module_hooks() -> None:
+def test_transform_calls_module_hooks_once() -> None:
     transform = AddToCoords(1.0)
     calls: list[object] = []
     transform.register_forward_hook(
         lambda _module, _inputs, output: calls.append(output)
     )
 
-    SameParams(transform)([_line_outline(), _line_outline()])
+    transform([_line_outline(), _line_outline()])
 
     assert len(calls) == 1
 
 
-def test_same_params_preserves_wrapped_module_pre_hook_inputs() -> None:
+def test_transform_preserves_module_pre_hook_inputs() -> None:
     transform = AddToCoords(1.0)
     outlines = [_line_outline(), _line_outline()]
     calls: list[tuple[object, ...]] = []
     transform.register_forward_pre_hook(lambda _module, inputs: calls.append(inputs))
 
-    SameParams(transform)(outlines)
+    transform(outlines)
 
     assert len(calls) == 1
     assert calls[0][0] is outlines
@@ -260,21 +259,6 @@ def test_load_and_outline_transforms_preserve_glyph_metadata() -> None:
     assert output.location == {}
 
 
-def test_glyph_metadata_is_not_reprocessed_as_pytree_data() -> None:
-    sample = _glyph_sample()
-    first = LoadGlyph()(sample)
-
-    second = LoadGlyph()(first)
-
-    assert isinstance(second, GlyphData)
-    assert second.ref is first.ref
-    assert second.font_idx == first.font_idx
-    assert second.character_idx == first.character_idx
-    assert second.weight == first.weight
-    assert second.location is first.location
-    assert second.data is first.data
-
-
 def test_type_changing_transforms_preserve_generic_glyph_container() -> None:
     sample = _glyph_sample()
     bitmap_output = Compose([LoadGlyph(), RenderBitmap(32)])(sample)
@@ -304,40 +288,3 @@ def test_load_glyph_returns_the_randomly_sampled_location() -> None:
     assert output.slant == 0.0
     assert math.isnan(output.optical_size)
     assert set(output.location) == {"wdth", "wght"}
-
-
-def test_load_glyph_samples_multiple_variable_glyphs_independently() -> None:
-    ref = GlyphRef(
-        FontRef("tests/fonts/roboto/Roboto[wdth,wght].ttf", 0),
-        ord("A"),
-    )
-
-    first, second = LoadGlyph(location="random")([ref, ref])
-
-    assert isinstance(first, Outline)
-    assert isinstance(second, Outline)
-
-
-def test_load_glyph_can_share_random_locations_within_one_font() -> None:
-    font = FontRef("tests/fonts/roboto/Roboto[wdth,wght].ttf", 0)
-    first_sample = GlyphSample(GlyphRef(font, ord("A")), 0, 0)
-    second_sample = GlyphSample(GlyphRef(font, ord("B")), 0, 1)
-
-    first, second = SameParams(LoadGlyph(location="random"))(
-        [first_sample, second_sample]
-    )
-
-    assert isinstance(first, GlyphData)
-    assert isinstance(second, GlyphData)
-    assert first.location == second.location
-
-
-def test_load_glyph_rejects_shared_random_locations_across_fonts() -> None:
-    first = GlyphRef(
-        FontRef("tests/fonts/roboto/Roboto[wdth,wght].ttf", 0),
-        ord("A"),
-    )
-    second = GlyphRef(FontRef("tests/fonts/lato/Lato-Regular.ttf", 0), ord("A"))
-
-    with pytest.raises(ValueError, match="only within one font"):
-        SameParams(LoadGlyph(location="random"))([first, second])

--- a/torchfont/transforms/__init__.py
+++ b/torchfont/transforms/__init__.py
@@ -2,7 +2,7 @@
 
 from torchfont.transforms import functional
 from torchfont.transforms._bitmap import RenderBitmap
-from torchfont.transforms._container import Compose, RandomApply, SameParams
+from torchfont.transforms._container import Compose, RandomApply
 from torchfont.transforms._curves import (
     CubicToQuad,
     MergeCurves,
@@ -47,7 +47,6 @@ __all__ = [
     "RandomizeSubpathStartPoints",
     "RemoveOverlaps",
     "RenderBitmap",
-    "SameParams",
     "Transform",
     "VerticalFlip",
     "functional",

--- a/torchfont/transforms/_container.py
+++ b/torchfont/transforms/_container.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, cast
 import torch
 from torch import nn
 
-from torchfont.transforms._transform import Transform, _share_params
-
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -72,20 +70,4 @@ class RandomApply(nn.Module):
         return f"p={self.p}"
 
 
-class SameParams(nn.Module):
-    """Apply one transform with parameters shared across semantic leaves."""
-
-    def __init__(self, transform: Transform) -> None:
-        super().__init__()
-        if not isinstance(transform, Transform):
-            msg = "transform must be a Transform"
-            raise TypeError(msg)
-        self.transform = transform
-
-    def forward(self, *inputs: object) -> object:
-        """Apply the wrapped transform with one shared parameter sample."""
-        with _share_params(self.transform):
-            return self.transform(*inputs)
-
-
-__all__ = ["Compose", "RandomApply", "SameParams"]
+__all__ = ["Compose", "RandomApply"]

--- a/torchfont/transforms/_geometry.py
+++ b/torchfont/transforms/_geometry.py
@@ -39,10 +39,7 @@ class VerticalFlip(Transform):
 
 
 class RandomHorizontalFlip(HorizontalFlip):
-    """Flip each outline independently with probability ``p``.
-
-    Wrap with :class:`SameParams` to share one decision across outlines.
-    """
+    """Flip outlines with probability ``p`` using one shared decision."""
 
     def __init__(self, p: float = 0.5, *, preserve_winding: bool = True) -> None:
         super().__init__(preserve_winding=preserve_winding)
@@ -59,10 +56,7 @@ class RandomHorizontalFlip(HorizontalFlip):
 
 
 class RandomVerticalFlip(VerticalFlip):
-    """Flip each outline independently with probability ``p``.
-
-    Wrap with :class:`SameParams` to share one decision across outlines.
-    """
+    """Flip outlines with probability ``p`` using one shared decision."""
 
     def __init__(self, p: float = 0.5, *, preserve_winding: bool = True) -> None:
         super().__init__(preserve_winding=preserve_winding)
@@ -119,10 +113,7 @@ def _symmetric_range(value: float | tuple[float, float]) -> tuple[float, float]:
 
 
 class RandomAffine(Transform):
-    """Apply independently sampled affine parameters to each outline.
-
-    Wrap with :class:`SameParams` to share one parameter sample across outlines.
-    """
+    """Apply one affine parameter sample to all outlines in the input."""
 
     def __init__(
         self,

--- a/torchfont/transforms/_glyph.py
+++ b/torchfont/transforms/_glyph.py
@@ -2,24 +2,22 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 import torch
+from torch import nn
 
 from torchfont import _torchfont
 from torchfont._font import VariationLocation
 from torchfont._glyph import GlyphData, GlyphRef, GlyphSample
 from torchfont.transforms import functional as _functional
-from torchfont.transforms._transform import Transform
 
 if TYPE_CHECKING:
     from torchfont._outline import Outline
 
 
-class LoadGlyph(Transform):
-    """Load glyphs at the default or a randomly sampled variation location."""
-
-    _transformed_types = (GlyphSample, GlyphRef)
+class LoadGlyph(nn.Module):
+    """Load one glyph at the default or a randomly sampled variation location."""
 
     def __init__(self, location: Literal["default", "random"] = "default") -> None:
         super().__init__()
@@ -28,56 +26,44 @@ class LoadGlyph(Transform):
             raise ValueError(msg)
         self.location = location
 
-    def check_same_params(self, selected_inputs: list[object]) -> None:
-        if self.location == "default":
-            return
-        refs: list[GlyphRef] = []
-        for item in selected_inputs:
-            if isinstance(item, GlyphSample):
-                refs.append(item.ref)
-            elif isinstance(item, GlyphRef):
-                refs.append(item)
-        if refs and any(ref.font != refs[0].font for ref in refs[1:]):
-            msg = "random locations can be shared only within one font"
-            raise ValueError(msg)
-
-    def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
-        if self.location == "default":
-            return {}
-        inpt = flat_inputs[0]
-        ref = inpt.ref if isinstance(inpt, GlyphSample) else inpt
-        location: dict[str, float] = {}
-        for tag, minimum, _default, maximum in _torchfont.variation_axes(
-            ref.font.path, ref.font.ttc_index
-        ):
-            location[str(tag)] = torch.empty(()).uniform_(minimum, maximum).item()
-        return {"location": location}
-
-    def transform(
-        self, inpt: GlyphSample | GlyphRef, params: dict[str, Any]
-    ) -> GlyphData | Outline:
+    def forward(self, inpt: GlyphSample | GlyphRef) -> GlyphData | Outline:
+        """Load the referenced glyph."""
         ref = inpt.ref if isinstance(inpt, GlyphSample) else inpt
         location = (
-            _default_location(ref) if self.location == "default" else params["location"]
+            _default_location(ref)
+            if self.location == "default"
+            else _random_location(ref)
         )
         outline = _functional.load_glyph(ref, location)
-        if isinstance(inpt, GlyphSample):
-            weight, width, italic, slant, optical_size = _torchfont.glyph_targets(
-                ref.font.path, ref.font.ttc_index, location
-            )
-            return GlyphData(
-                data=outline,
-                ref=ref,
-                location=VariationLocation(location),
-                font_idx=inpt.font_idx,
-                character_idx=inpt.character_idx,
-                weight=weight,
-                width=width,
-                italic=italic,
-                slant=slant,
-                optical_size=optical_size,
-            )
-        return outline
+        if not isinstance(inpt, GlyphSample):
+            return outline
+        weight, width, italic, slant, optical_size = _torchfont.glyph_targets(
+            ref.font.path, ref.font.ttc_index, location
+        )
+        return GlyphData(
+            data=outline,
+            ref=ref,
+            location=VariationLocation(location),
+            font_idx=inpt.font_idx,
+            character_idx=inpt.character_idx,
+            weight=weight,
+            width=width,
+            italic=italic,
+            slant=slant,
+            optical_size=optical_size,
+        )
+
+    def extra_repr(self) -> str:
+        return f"location={self.location}"
+
+
+def _random_location(ref: GlyphRef) -> dict[str, float]:
+    location: dict[str, float] = {}
+    for tag, minimum, _default, maximum in _torchfont.variation_axes(
+        ref.font.path, ref.font.ttc_index
+    ):
+        location[str(tag)] = torch.empty(()).uniform_(minimum, maximum).item()
+    return location
 
 
 def _default_location(ref: GlyphRef) -> dict[str, float]:

--- a/torchfont/transforms/_transform.py
+++ b/torchfont/transforms/_transform.py
@@ -2,32 +2,13 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from contextvars import ContextVar
 from enum import Enum
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from torch import nn
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
 from torchfont._outline import Outline
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-
-
-_SHARED_PARAMS_TARGET: ContextVar[object | None] = ContextVar(
-    "torchfont_shared_params_target", default=None
-)
-
-
-@contextmanager
-def _share_params(transform: object) -> Iterator[None]:
-    token = _SHARED_PARAMS_TARGET.set(transform)
-    try:
-        yield
-    finally:
-        _SHARED_PARAMS_TARGET.reset(token)
 
 
 class Transform(nn.Module):
@@ -37,9 +18,6 @@ class Transform(nn.Module):
 
     def check_inputs(self, _flat_inputs: list[object]) -> None:
         """Check relationships between all inputs before sampling parameters."""
-
-    def check_same_params(self, _selected_inputs: list[object]) -> None:
-        """Check inputs before explicitly sharing one parameter sample."""
 
     def make_params(self, _flat_inputs: list[Any]) -> dict[str, Any]:
         """Create parameters for selected inputs in one sampling group."""
@@ -51,9 +29,6 @@ class Transform(nn.Module):
 
     def forward(self, *inputs: object) -> object:
         """Transform semantic leaves and preserve the enclosing pytree."""
-        return self._forward(inputs, same_params=_SHARED_PARAMS_TARGET.get() is self)
-
-    def _forward(self, inputs: tuple[object, ...], *, same_params: bool) -> object:
         inpt = inputs if len(inputs) > 1 else inputs[0]
         flat_inputs, tree_spec = tree_flatten(inpt)
         self.check_inputs(flat_inputs)
@@ -63,17 +38,12 @@ class Transform(nn.Module):
             for item, selected in zip(flat_inputs, needs_transform, strict=True)
             if selected
         ]
-        if same_params:
-            self.check_same_params(selected)
-        shared_params = self.make_params(selected) if same_params and selected else None
+        params = self.make_params(selected) if selected else {}
         flat_outputs = []
         for item, selected in zip(flat_inputs, needs_transform, strict=True):
             if not selected:
                 flat_outputs.append(item)
                 continue
-            params = (
-                shared_params if shared_params is not None else self.make_params([item])
-            )
             flat_outputs.append(self.transform(item, params))
         return tree_unflatten(flat_outputs, tree_spec)
 


### PR DESCRIPTION
## Summary

- sample random transform parameters once per input pytree, matching TorchVision v2 semantics
- remove the redundant `SameParams` wrapper and its context-based implementation
- keep `LoadGlyph` focused on loading one glyph reference and resample random variation locations on every call
- update English and Japanese documentation and tests

## Why

A transform call represents one structured sample. Corresponding outline leaves should therefore receive the same stochastic parameters, while independent samples are transformed through separate calls. Glyph loading is an I/O boundary for one reference and does not need pytree-wide loading or cross-font sharing rules.

## Validation

- `mise run python-check`
- `mise exec -- uv run pytest tests` (272 passed, 16 skipped)
- `mise run docs-build`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --all-features`

`cargo test --all-targets --all-features` could not link locally because the host lacks `libpython3.12`; GitHub Actions will run it in the configured CI environment.
