### PR TITLE
Release v0.12.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     given-names: "Takumu"
     email: "fjktkm@gmail.com"
     orcid: "https://orcid.org/0009-0005-0691-414X"
-version: 0.12.0
-date-released: 2026-08-03
+version: 0.12.1
+date-released: 2026-08-04
 license: MIT
 repository-code: "https://github.com/torchfont/torchfont"
 url: "https://torchfont.readthedocs.io/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "google-fonts-glyphsets",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the TorchFont package version to `0.12.1` in `Cargo.toml` and `Cargo.lock`
- update `CITATION.cff` to version `0.12.1` with the 2026-08-04 release date

## Validation

- `mise run test` — 26 Rust tests and 300 Python tests passed; 16 Python tests skipped
- built and installed a `torchfont-0.12.1` wheel with maturin
- verified Cargo and Python package metadata both report `0.12.1`
- `git diff --check`