### PR TITLE
Add OutlineEmbedding.reset_parameters

### DIFF
--- a/tests/nn/test_embedding.py
+++ b/tests/nn/test_embedding.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from torchfont import ElementType
+from torchfont import COORD_DIM, TYPE_DIM, ElementType
 from torchfont.nn import OutlineEmbedding
 
 
@@ -86,6 +86,30 @@ def test_outline_embedding_registers_parameters() -> None:
         "coord_projection.weight",
     }
     assert repr(embedding).startswith("OutlineEmbedding(\n  embedding_dim=4")
+
+
+def test_outline_embedding_initializes_both_branches_from_one_bound() -> None:
+    embedding = OutlineEmbedding(1024)
+    bound = (TYPE_DIM + COORD_DIM) ** -0.5
+    expected_std = bound / 3**0.5
+    type_weight = embedding.type_embedding.weight.detach()[1:]
+    coord_weight = embedding.coord_projection.weight.detach()
+
+    assert type_weight.abs().max() <= bound
+    assert coord_weight.abs().max() <= bound
+    assert float(type_weight.std()) == pytest.approx(expected_std, rel=0.1)
+    assert float(coord_weight.std()) == pytest.approx(expected_std, rel=0.1)
+    assert torch.count_nonzero(embedding.type_embedding.weight[0]) == 0
+
+
+def test_outline_embedding_reset_parameters_redraws_and_keeps_padding_zero() -> None:
+    embedding = OutlineEmbedding(128)
+    before = embedding.type_embedding.weight.clone()
+
+    embedding.reset_parameters()
+
+    assert not torch.equal(embedding.type_embedding.weight[1:], before[1:])
+    assert torch.count_nonzero(embedding.type_embedding.weight[0]) == 0
 
 
 def test_outline_embedding_rejects_misaligned_shapes() -> None:

--- a/torchfont/nn/_embedding.py
+++ b/torchfont/nn/_embedding.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import torch
 from torch import Tensor, nn
 
@@ -40,6 +42,15 @@ class OutlineEmbedding(nn.Module):
             device=device,
             dtype=dtype,
         )
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Draw both branches from one uniform bound over the combined width."""
+        bound = 1 / math.sqrt(TYPE_DIM + COORD_DIM)
+        nn.init.uniform_(self.type_embedding.weight, -bound, bound)
+        nn.init.uniform_(self.coord_projection.weight, -bound, bound)
+        with torch.no_grad():
+            self.type_embedding.weight[ElementType.PAD.value].zero_()
 
     def forward(self, types: Tensor, coords: Tensor) -> Tensor:
         """Return the sum of element-type and coordinate embeddings."""


### PR DESCRIPTION
## Summary

`OutlineEmbedding` left both submodules to their own default initialization,
which put the two branches on incompatible scales. `nn.Embedding` draws from
`N(0, 1)`, while the bias-free `nn.Linear` over six coordinates draws from
`U(-1/sqrt(6), 1/sqrt(6))`. Since `forward` sums the two, the element-type
branch swamped the coordinate branch from the first step.

`reset_parameters` now draws both from the bound a joint projection over the
concatenated one-hot element type and coordinates would use, and re-zeroes the
`padding_idx` row that `uniform_` overwrites.

## Measurements

Measured on a glyph classification task (ModernBERT, `d_model=128`, 1 epoch,
3 seeds, paired by seed). Recovering the branch scales accounts for nearly all
of a large regression:

| initialization | accuracy |
| --- | --- |
| submodule defaults | 0.4381 ± 0.0376 |
| shared bound (this PR) | 0.7751 ± 0.0127 |

Two things this PR deliberately does **not** do, both checked and ruled out:

- **Scaling by `sqrt(embedding_dim)`.** Identical results to four decimals on
  every seed, with matching loss curves. A downstream input normalization
  absorbs it.
- **Adding a bias.** Exactly one element-type row is active per token, so a
  bias vector is absorbed into `type_embedding` without adding capacity.

The shared bound is not claimed to be optimal — on this dataset, weighting the
coordinate branch more heavily than the bound implies measured better still.
That correction depends on the coordinate distribution rather than on anything
the library can derive, so it is left to callers, who can re-initialize
`coord_projection` after construction.

## Test plan

- `mise run check`
- `mise run test` — 302 passed
- `mise run docs-build`

New tests assert both branches share one bound and that the `padding_idx` row
stays zero across a `reset_parameters` call. The previous assertion only bounded
`abs().max()`, which a zero or much smaller initialization would also satisfy;
the replacement checks the standard deviation and rejects both prior defaults
(off by 6.3x and 1.48x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)