### PR TITLE
Align glyph data model with PyTorch conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           - environment: minimum
             runner: ubuntu-latest
             python-version: "3.10"
-            torch-version: "2.3.*"
-            torchvision-version: "0.18.*"
+            torch-version: "2.4.*"
+            torchvision-version: "0.19.*"
           - environment: windows
             runner: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           - environment: minimum
             runner: ubuntu-latest
             python-version: "3.10"
-            torch-version: "2.4.*"
-            torchvision-version: "0.19.*"
+            torch-version: "2.5.*"
+            torchvision-version: "0.20.*"
           - environment: windows
             runner: windows-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/torchfont?period=total&units=INTERNATIONAL_SYSTEM&left_color=GRAY&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/torchfont)
 [![PyPI version](https://img.shields.io/pypi/v/torchfont)](https://pypi.org/project/torchfont/)
 [![Rust](https://img.shields.io/badge/Rust-2024-orange?logo=rust)](https://www.rust-lang.org/)
-[![PyTorch](https://img.shields.io/badge/PyTorch-2.3+-ee4c2c?logo=pytorch&logoColor=white)](https://pytorch.org/)
+[![PyTorch](https://img.shields.io/badge/PyTorch-2.4+-ee4c2c?logo=pytorch&logoColor=white)](https://pytorch.org/)
 
 TorchFont is an **unofficial** library based on PyTorch for deep learning with vector fonts.
 It is not affiliated with or endorsed by the PyTorch project.
@@ -27,7 +27,7 @@ in your transform pipeline when tensors are needed.
 
 ## Installation
 
-The package requires Python 3.10+ and PyTorch 2.3+.
+The package requires Python 3.10+ and PyTorch 2.4+.
 
 Install TorchFont with **uv**:
 
@@ -44,18 +44,30 @@ pip install torchfont
 ## Quickstart
 
 ```python
-from torch.utils.data import DataLoader
-from torch.nn.utils.rnn import pad_sequence
+import math
 
+import torch
+from torch.utils.data import DataLoader
+
+from torchfont import GlyphData, Outline, pad_outlines
 from torchfont.datasets import GlyphDataset
-from torchfont import GlyphData, Outline
 from torchfont.transforms import LoadGlyph
 
 
-def collate_fn(batch: list[GlyphData[Outline]]):
-    types = pad_sequence([item.data.types for item in batch], batch_first=True)
-    coords = pad_sequence([item.data.coords for item in batch], batch_first=True)
-    return types, coords
+def collate_fn(samples: list[GlyphData[Outline]]):
+    return {
+        "outline": pad_outlines([sample.data for sample in samples]),
+        "font_idx": torch.tensor(
+            [sample.font_idx for sample in samples], dtype=torch.long
+        ),
+        "weight": torch.tensor(
+            [
+                math.nan if sample.weight is None else sample.weight
+                for sample in samples
+            ],
+            dtype=torch.float32,
+        ),
+    }
 
 
 dataset = GlyphDataset(
@@ -65,19 +77,28 @@ dataset = GlyphDataset(
     transform=LoadGlyph(),
 )
 
-loader = DataLoader(dataset, batch_size=8, shuffle=True, collate_fn=collate_fn)
-types_t, coords_t = next(iter(loader))
+loader = DataLoader(
+    dataset,
+    batch_size=8,
+    shuffle=True,
+    collate_fn=collate_fn,
+)
+batch = next(iter(loader))
 
-print(types_t.shape)  # (8, L)
-print(coords_t.shape)  # (8, L, 6)
+print(batch["outline"].shape)  # (8, L)
+print(batch["outline"].coords.shape)  # (8, L, 6)
+print(batch["weight"].shape)  # (8,)
 ```
+
+Define `collate_fn` locally to choose the targets and missing-value representation
+required by your model. Use `pad_outlines` to pad variable-length outlines.
 
 ## What TorchFont Focuses On
 
 - local font directories and repository checkouts as the input boundary
-- Rust-backed indexing plus explicit outline loading through lightweight glyph references
+- local font indexing plus explicit outline loading through lightweight glyph references
 - `torchvision.transforms.v2`-style semantic pipelines for adapting glyph samples
-- PyTorch `DataLoader` integration through ordinary user-defined `collate_fn` functions
+- PyTorch `DataLoader` integration through an explicit, customizable `collate_fn`
 
 Manage font repository synchronization with Git or another tool, then point
 `GlyphDataset(root=...)` at the resulting directory.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/torchfont?period=total&units=INTERNATIONAL_SYSTEM&left_color=GRAY&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/torchfont)
 [![PyPI version](https://img.shields.io/pypi/v/torchfont)](https://pypi.org/project/torchfont/)
 [![Rust](https://img.shields.io/badge/Rust-2024-orange?logo=rust)](https://www.rust-lang.org/)
-[![PyTorch](https://img.shields.io/badge/PyTorch-2.4+-ee4c2c?logo=pytorch&logoColor=white)](https://pytorch.org/)
+[![PyTorch](https://img.shields.io/badge/PyTorch-2.5+-ee4c2c?logo=pytorch&logoColor=white)](https://pytorch.org/)
 
 TorchFont is an **unofficial** library based on PyTorch for deep learning with vector fonts.
 It is not affiliated with or endorsed by the PyTorch project.
@@ -27,7 +27,7 @@ in your transform pipeline when tensors are needed.
 
 ## Installation
 
-The package requires Python 3.10+ and PyTorch 2.4+.
+The package requires Python 3.10+ and PyTorch 2.5+.
 
 Install TorchFont with **uv**:
 

--- a/docs/en/guide/dataloader.md
+++ b/docs/en/guide/dataloader.md
@@ -34,10 +34,9 @@ dataset = GlyphDataset(
 )
 
 data: GlyphData[Outline] = dataset[0]
-types, coords = data.data.types, data.data.coords
 
-print(types.shape)
-print(coords.shape)
+print(data.data.shape)
+print(data.data.coords.shape)
 ```
 
 With `LoadGlyph`, `dataset[0]` returns `GlyphData[Outline]`. Its `data` field is
@@ -52,22 +51,35 @@ torch.Size([37, 6])
 
 ## Create a DataLoader
 
-Glyph outline sequences are variable-length, so batching requires a `collate_fn`.
-Use `pad_sequence` to align sequences within a batch. Run the following code:
+Glyph outline sequences are variable-length, so define a local `collate_fn` for
+the exact input contract of your model. Use `pad_outlines` for the payload and
+tensorize only the targets the model needs:
 
 ```python
-from torch.nn.utils.rnn import pad_sequence
+import math
+
+import torch
 from torch.utils.data import DataLoader
 
 from torchfont.datasets import GlyphDataset
-from torchfont import GlyphData, Outline
+from torchfont import GlyphData, Outline, pad_outlines
 from torchfont.transforms import LoadGlyph
 
 
-def collate_fn(batch: list[GlyphData[Outline]]):
-    types = pad_sequence([item.data.types for item in batch], batch_first=True)
-    coords = pad_sequence([item.data.coords for item in batch], batch_first=True)
-    return types, coords
+def collate_fn(samples: list[GlyphData[Outline]]):
+    return {
+        "outline": pad_outlines([sample.data for sample in samples]),
+        "font_idx": torch.tensor(
+            [sample.font_idx for sample in samples], dtype=torch.long
+        ),
+        "weight": torch.tensor(
+            [
+                math.nan if sample.weight is None else sample.weight
+                for sample in samples
+            ],
+            dtype=torch.float32,
+        ),
+    }
 
 
 dataset = GlyphDataset(
@@ -81,43 +93,108 @@ dataset = GlyphDataset(
     transform=LoadGlyph(),
 )
 
-loader = DataLoader(dataset, batch_size=64, shuffle=True, collate_fn=collate_fn)
-types_t, coords_t = next(iter(loader))
+loader = DataLoader(
+    dataset,
+    batch_size=64,
+    shuffle=True,
+    collate_fn=collate_fn,
+)
+batch = next(iter(loader))
 
-print(types_t.shape)
-print(coords_t.shape)
+print(batch["outline"].shape)
+print(batch["outline"].coords.shape)
+print(batch["weight"].shape)
 ```
 
-`collate_fn` pads each sequence to the length of the longest one in the batch.
-The first dimension is the batch size. The second dimension is the longest
-sequence length in the batch and varies per batch. You will see output like:
+Outlines are padded to the length of the longest one in the batch. The first
+dimension is the batch size; the second is the longest sequence length in the
+batch and varies per batch. Targets become 1-dimensional tensors of length
+`batch_size`. You will see output like:
 
 ```
 torch.Size([64, 369])
 torch.Size([64, 369, 6])
+torch.Size([64])
+```
+
+## Work with a padded batch
+
+Padded elements use `ElementType.PAD`. Rather than recovering them by comparing
+against that value, read `padding_mask`, which is exactly what attention modules
+expect as `key_padding_mask`:
+
+```python
+mask = batch["outline"].padding_mask  # (64, 369), True where padding
+```
+
+`unpad_outlines()` explicitly splits a padded batch back into the single
+outlines that went in. By contrast, `Outline.unbind()` preserves padding just
+like an ordinary tensor operation:
+
+```python
+from torchfont import unpad_outlines
+
+singles = unpad_outlines(batch["outline"])
+
+print(len(singles), singles[0].shape)
+```
+
+`torchfont.nn` modules take an `Outline`, batched or not, so a padded batch goes
+straight into a model:
+
+```python
+from torchfont.nn import OutlineEmbedding
+
+tokens = OutlineEmbedding(embedding_dim=256)(batch["outline"])
+
+print(tokens.shape)  # (64, 369, 256)
+```
+
+## Batch outlines without a DataLoader
+
+`pad_outlines` applies the same padding step directly:
+
+```python
+from torchfont import pad_outlines
+
+batched = pad_outlines([dataset[0].data, dataset[1].data])
+
+print(batched.shape)
 ```
 
 ## Multi-process loading
 
 Set `num_workers` and `prefetch_factor` to load data in parallel worker
-processes. Long sequences increase transfer overhead, so this example's
-`collate_fn` truncates each sequence to the first 512 elements. Use `tqdm` to
-iterate over all batches and measure throughput. Run the following code:
+processes.
+
+Each batch is padded to its longest outline, so a single very large glyph
+inflates the whole batch and the transfer to the training process with it. This
+example caps every outline at 512 elements in its local `collate_fn`. Define it
+at module level: worker processes pickle the `collate_fn`, so a lambda will not
+work.
+
+Use `tqdm` to iterate over all batches and measure throughput. Run the following
+code:
 
 ```python
+import torch
 from tqdm import tqdm
-from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 
+from torchfont import GlyphData, Outline, pad_outlines
 from torchfont.datasets import GlyphDataset
-from torchfont import GlyphData, Outline
 from torchfont.transforms import LoadGlyph
 
+MAX_ELEMENTS = 512
 
-def collate_fn(batch: list[GlyphData[Outline]]):
-    types = pad_sequence([item.data.types[:512] for item in batch], batch_first=True)
-    coords = pad_sequence([item.data.coords[:512] for item in batch], batch_first=True)
-    return types, coords
+
+def collate_fn(samples: list[GlyphData[Outline]]):
+    return {
+        "outline": pad_outlines([sample.data[:MAX_ELEMENTS] for sample in samples]),
+        "font_idx": torch.tensor(
+            [sample.font_idx for sample in samples], dtype=torch.long
+        ),
+    }
 
 
 dataset = GlyphDataset(
@@ -154,3 +231,9 @@ prefetch settings for your storage and training environment.
 len(dataset)=...
 100%|██████████| .../... [..., ...it/s]
 ```
+
+::: tip Padding without truncation
+Truncation drops geometry. To keep whole outlines and still avoid the padding
+cost, group glyphs of similar length with a length-aware `Sampler` instead of
+capping their length.
+:::

--- a/docs/en/guide/glyph-data-format.md
+++ b/docs/en/guide/glyph-data-format.md
@@ -38,7 +38,12 @@ print(data.optical_size)  # optical size in points
 
 The return value is `GlyphData[Outline]`. It keeps the semantic outline,
 deterministic glyph reference, and dataset-local targets in one shallow record.
-Registered-axis targets that are unavailable in the font are `NaN`.
+Registered-axis targets that are unavailable in the font are `None`.
+
+Indices are Python integers and continuous targets are floats. A continuous
+target unavailable in the font is `None`. A training application's local
+`collate_fn` can convert selected targets to tensors and choose its own missing
+value representation, such as `NaN` plus a mask.
 
 ## Outline model
 
@@ -89,7 +94,9 @@ MOVE_TO
 The seven types are `MoveTo`, `LineTo`, `QuadTo`, `CurveTo`, `Close`, `End`, and `Pad`.
 
 - `ElementType.END` marks the end of the sequence
-- `ElementType.PAD` is mainly introduced by `pad_sequence` or custom padding
+- `ElementType.PAD` marks rows introduced by padding a batch. Loading a font
+  never produces it, and a single glyph never contains it. Read
+  `outline.padding_mask` rather than comparing against the value.
 
 ## Coordinates
 

--- a/docs/en/reference/core-types.md
+++ b/docs/en/reference/core-types.md
@@ -2,9 +2,7 @@
 
 ## `torchfont`
 
-Immutable semantic records and shared outline-encoding types. These values carry
-font meaning through datasets and transform pipelines without adding tensor
-subclass behavior.
+Types for carrying font data through datasets and transform pipelines.
 
 ```python
 from torchfont import (
@@ -14,32 +12,91 @@ from torchfont import (
     GlyphRef,
     GlyphSample,
     Outline,
-    VariationLocation,
+    pad_outlines,
+    unpad_outlines,
 )
 ```
 
-`VariationLocation` is an immutable, hashable mapping. Axis tags are stored in
-deterministic sorted order, and iterable inputs with duplicate normalized tags
-are rejected rather than silently overwriting a value. `FontRef`, glyph
-references, and dataset samples are frozen dataclasses and remain pickle-friendly
-for multiprocessing data loaders.
+Variation locations use `dict[str, float]` values. Font references, glyph
+references, and dataset samples can be used with multiprocessing data loaders.
 
-`Outline` represents one variable-length, unbatched glyph. `types` has shape
-`(N,)`, `coords` has shape `(N, 6)`, and their rows correspond one-to-one.
-`types` uses `torch.long`, `coords` uses `torch.float32`, and both tensors are
-on the same device. These structural invariants are checked when an `Outline`
-is constructed. Coordinates that are inactive for an element type, including
-all coordinates for `CLOSE`, `END`, and `PAD`, have no semantic value.
-`GlyphData` is a shallow record containing a transformed payload, glyph
+### `Outline`
+
+`Outline` pairs two coupled tensors. `types` has shape `(*batch, N)`, `coords`
+has shape `(*batch, N, 6)`, and their rows correspond one-to-one. `types` uses
+`torch.long`, `coords` uses any floating point dtype, and both tensors are on the
+same device. Coordinates that are inactive for an element type,
+including all coordinates for `CLOSE`, `END`, and `PAD`, have no semantic value.
+
+A single glyph has an empty batch shape. [`pad_outlines`](#pad-outlines) stacks
+single glyphs into a batch. Most transforms operate on single glyphs and reject a
+batched `Outline` with an explicit error.
+
+These properties describe an outline without taking it apart:
+
+| Property | Meaning |
+| --- | --- |
+| `shape` | shape of `types`, that is `(*batch, N)` |
+| `batch_shape` | leading batch dimensions, empty for a single glyph |
+| `num_elements` | path elements per glyph, including padding |
+| `is_batched` | whether any batch dimension is present |
+| `dtype` | floating point dtype of `coords` |
+| `device` | device shared by both tensors |
+| `padding_mask` | boolean mask, `True` where an element is `PAD` |
+
+`to()` and `pin_memory()` apply to both tensors at once. A dtype passed to
+`to()` applies to `coords` only and must be floating point. Operate on `types`
+or `coords` directly for other tensor operations. Indexing addresses the
+logical `(*batch, N)` dimensions while
+always leaving the coordinate axis intact. An index may not remove the final
+element dimension. `len()` reports the first logical dimension. `unbind()`
+splits the first batch dimension without changing its contents.
+
+`Outline` objects compare by identity. Compare `types` and `coords` explicitly
+with `torch.equal()` when content equality is required. In-place changes to the
+input tensors are visible through the outline. Assigning a different tensor to
+either attribute raises an error.
+
+### `pad_outlines`
+
+```python
+pad_outlines(outlines: Sequence[Outline]) -> Outline
+```
+
+Stacks single outlines into one batch padded with `ElementType.PAD` and zero
+coordinates. Every input must be a single glyph sharing one device and one
+`coords` dtype. Recover the padding with `padding_mask`, and undo it with
+[`unpad_outlines`](#unpad-outlines).
+
+### `unpad_outlines`
+
+```python
+unpad_outlines(outline: Outline) -> tuple[Outline, ...]
+```
+
+Splits an `Outline` with exactly one batch dimension and removes trailing
+`ElementType.PAD` rows from each result. This is the explicit inverse of
+`pad_outlines`; use `Outline.unbind()` when padding must be preserved.
+
+### `GlyphData`
+
+`GlyphData` contains a transformed payload, glyph
 reference, resolved variation location, and the parallel `font_idx`,
 `character_idx`, `weight`, `width`, `italic`, `slant`, and `optical_size`
-targets. Registered variation-axis values take precedence; values not
-represented by an axis are read from equivalent OS/2, `head`, and `post`
-metadata when available. Unavailable targets are `NaN`.
+targets. Unavailable continuous targets are `None`.
 
-`Outline` and `GlyphData` intentionally use identity equality. Their tensor
-payloads require explicit comparisons such as `torch.equal()` rather than
-dataclass-generated equality. `GlyphSample` remains a value record.
+`location` is an ordinary `dict[str, float]` mapping OpenType axis tags to the
+values used to load the glyph.
+
+Indices are Python integers and continuous targets are floats. An unavailable
+continuous target is `None`.
+
+`GlyphData` objects compare by identity. Compare tensor payloads explicitly when
+content equality is required.
+
+Define a local `DataLoader.collate_fn` for the model's input contract and use
+[`pad_outlines`](#pad-outlines) when its payloads are variable-length outlines.
+See [DataLoader](../guide/dataloader.md).
 
 ### `ElementType: IntEnum`
 
@@ -53,6 +110,9 @@ class ElementType(IntEnum):
     CLOSE = 5
     END = 6
 ```
+
+`PAD` is never produced by loading a font. It marks rows introduced by padding a
+batch.
 
 ### `TYPE_DIM: int`
 

--- a/docs/en/reference/nn.md
+++ b/docs/en/reference/nn.md
@@ -1,8 +1,9 @@
 # Neural Network Building Blocks
 
 TorchFont provides small font-specific building blocks in `torchfont.nn`.
-They operate on ordinary tensors so they compose with standard PyTorch modules,
-devices, dtypes, autograd, and serialization.
+They take an [`Outline`](./core-types.md#outline), batched or not, and return
+ordinary tensors, so they compose with standard PyTorch modules, devices, dtypes,
+autograd, and serialization.
 
 ## `OutlineEmbedding`
 
@@ -12,16 +13,19 @@ token features:
 ```python
 import torch
 
-from torchfont import ElementType
+from torchfont import ElementType, Outline
 from torchfont.nn import OutlineEmbedding
 
 embedding = OutlineEmbedding(embedding_dim=256)
-types = torch.tensor(
-    [[ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END, ElementType.PAD]]
+outline = Outline(
+    torch.tensor(
+        [[ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END, ElementType.PAD]]
+    ),
+    torch.zeros((1, 4, 6)),  # (batch, sequence, 6)
 )
-coords = torch.zeros((1, 4, 6))  # (batch, sequence, 6)
-tokens = embedding(types, coords)  # (batch, sequence, 256)
-padding_mask = types == ElementType.PAD
+
+tokens = embedding(outline)  # (1, 4, 256)
+padding_mask = outline.padding_mask  # (1, 4)
 ```
 
 The module adds a learned element-type embedding to a bias-free linear
@@ -45,7 +49,7 @@ meaning for the target element type:
 ```python
 from torchfont.nn import functional as F
 
-loss = F.coordinate_loss(predicted_coords, target_coords, target_types)
+loss = F.coordinate_loss(predicted_coords, target_outline)
 ```
 
 - `MOVE_TO` and `LINE_TO`: endpoint only
@@ -53,8 +57,8 @@ loss = F.coordinate_loss(predicted_coords, target_coords, target_types)
 - `CURVE_TO`: both control points and endpoint
 - `CLOSE`, `END`, and `PAD`: no coordinates
 
-Inputs and targets have shape `(..., N, 6)`, while element types have shape
-`(..., N)`. Supported reductions are `"none"`, `"mean"`, and `"sum"`.
+Predictions have shape `(..., N, 6)`, matching the target's coordinates.
+Supported reductions are `"none"`, `"mean"`, and `"sum"`.
 The mean is taken over active coordinate scalars rather than padded storage.
 If there are no active coordinates, the mean is a differentiable zero.
 Non-finite values in inactive coordinate slots are ignored.
@@ -68,16 +72,11 @@ into one training objective:
 from torchfont.nn import OutlineLoss
 
 criterion = OutlineLoss(type_weight=1.0, coordinate_weight=0.5)
-loss = criterion(
-    type_logits,
-    predicted_coords,
-    target_types,
-    target_coords,
-)
+loss = criterion(type_logits, predicted_coords, target_outline)
 ```
 
-`type_logits` has shape `(..., N, TYPE_DIM)`. The other tensors have the same
-shapes accepted by `coordinate_loss`. Cross entropy is averaged over non-padding
+`type_logits` has shape `(..., N, TYPE_DIM)`. Cross entropy is averaged over
+non-padding
 elements, while coordinate error is averaged independently over active
 coordinate scalars. The two means are then combined using `type_weight` and
 `coordinate_weight`. This keeps their relative weighting stable across outline

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -193,6 +193,12 @@ floating point dtype.
 Functional pipelines can be used with `torch.compile`:
 
 ```python
+import torch
+
+# Required on PyTorch 2.4 when an operation can change the outline length.
+torch._dynamo.config.capture_dynamic_output_shape_ops = True
+
+
 def pipeline(types, coords):
     outline = Outline(types, coords)
     outline = F.remove_overlaps(outline)

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -195,7 +195,7 @@ Functional pipelines can be used with `torch.compile`:
 ```python
 import torch
 
-# Required on PyTorch 2.4 when an operation can change the outline length.
+# Required on PyTorch 2.5 when an operation can change the outline length.
 torch._dynamo.config.capture_dynamic_output_shape_ops = True
 
 

--- a/docs/en/reference/transforms.md
+++ b/docs/en/reference/transforms.md
@@ -1,9 +1,8 @@
 # Transforms
 
-TorchFont transforms follow the TorchVision Transforms v2
-(`torchvision.transforms.v2`) model: semantic data objects,
-class-based stochastic transforms, deterministic functional kernels, and pytree
-composition.
+TorchFont provides composable transforms for loading, modifying, and rendering
+glyphs. TorchVision is optional and can be added when the result should enter an
+image pipeline.
 
 ## Data types
 
@@ -12,11 +11,9 @@ from torchfont import GlyphData, Outline
 ```
 
 `Outline(types, coords)` keeps the two coupled tensors together.
-`GlyphData[T]` keeps a transformed payload, glyph reference, concrete variation
-location, and targets together. Since its payload is generic, a pipeline can
-change it from `Outline` to a plain bitmap tensor without losing metadata. Rasterized
-glyphs do not need a TorchFont-specific tensor subclass: they cross into image
-semantics explicitly through TorchVision's `ToImage()` when required.
+`GlyphData[T]` keeps a transformed payload, glyph reference, variation location,
+and targets together. A pipeline can change its payload from `Outline` to a
+bitmap tensor without losing the other fields.
 
 ## Loading and composition
 
@@ -49,34 +46,17 @@ records it in `GlyphData.location`; on a static face it naturally uses an empty
 location. For dataset samples, it also resolves the parallel `weight`, `width`,
 `italic`, `slant`, and `optical_size` targets on the returned `GlyphData`.
 
-`Transform` flattens nested pytree inputs, samples parameters once for all
-matching semantic leaves, and restores the input structure. Thus corresponding
-outlines in one transform call receive the same flip, affine parameters, or
-element-level random values. Apply the transform separately to independent
-samples. Random transforms use PyTorch's default RNG, so
+Transforms accept nested inputs and preserve their structure. Corresponding
+outlines in one call receive the same randomly sampled parameters. Apply the
+transform separately to independent samples. Random transforms use PyTorch's default RNG, so
 `torch.manual_seed` and DataLoader worker seeding apply normally.
-Built-in transforms contain configuration only and remain pickle-friendly.
-`Compose` registers its children in a `torch.nn.ModuleList`, including when it
-is constructed from an ordinary list of modules. `RandomApply` registers the
-single module it wraps. Plain callables are intentionally
-unsupported: define a small `nn.Module` so its
-behavior, representation, and pickle requirements remain explicit. This keeps
-module traversal, state dictionaries, hooks, and configuration display
-consistent with PyTorch.
+Built-in transforms can be used with multiprocessing data loaders. `Compose`
+accepts `nn.Module` transforms; define custom transforms as `nn.Module`
+subclasses rather than plain callables. An empty `Compose` leaves its input
+unchanged. Use `Compose` inside `RandomApply` to group several transforms.
 
-Containers invoke registered children through the module call path, so forward
-hooks remain effective. `train()` and `eval()` propagate normally, but built-in
-random transforms intentionally do not use the `training` flag: preprocessing
-and model mode are separate concerns. Select a deterministic pipeline explicitly
-for evaluation rather than relying on `eval()` to disable augmentation.
-
-Like `torchvision.transforms.v2`, `Transform` subclasses and containers accept
-either one pytree or multiple positional inputs. `check_inputs()` is available
-to custom transforms that need to check relationships between leaves before sampling parameters.
-`Compose` immediately materializes an iterable of `nn.Module` objects into an
-`nn.ModuleList`; an empty iterable is an identity transform. `RandomApply` wraps
-one `nn.Module`. Use `Compose` inside `RandomApply` when grouping several
-transforms.
+Calling `eval()` does not disable random data augmentation. Use a deterministic
+pipeline for evaluation.
 
 `RandomApply(transform, p)` controls whether one transform is applied.
 Probabilities such as `RandomSplitSegments.split_probability` control behavior
@@ -103,8 +83,8 @@ alongside the converted payload.
 `RenderBitmap` returns a plain grayscale `H x W` tensor. Use
 `torchvision.transforms.v2.ToImage()` as the boundary into an image pipeline:
 it adds the channel
-dimension and returns a `tv_tensors.Image` of shape `1 x H x W`. It preserves
-the enclosing `GlyphData` because both libraries operate on pytrees.
+dimension and returns a `tv_tensors.Image` of shape `1 x H x W`. Fields in an
+enclosing `GlyphData` are preserved.
 `RenderBitmap(antialias=False)` produces binary edge coverage. This controls
 vector rasterization and is independent of the `antialias` option on a later
 `v2.Resize`, which controls image resampling.
@@ -137,7 +117,7 @@ not scale pixel values. `ToPureTensor()` removes the image subclass before the
 payload enters a model. TorchVision remains an optional integration dependency;
 TorchFont's renderer does not require it.
 
-## Functional kernels
+## Functional API
 
 Deterministic operations are available from `torchfont.transforms.functional`:
 
@@ -156,10 +136,70 @@ shape = bitmap.shape
 The functional API does not sample randomness. Random selection and parameter
 sampling belong to the `Random*` transform classes.
 
-These transforms are `nn.Module` objects for composition, registration, PyTorch
-RNG behavior, and pytree processing. Rust-backed outline functionals cross a
-CPU/NumPy boundary and are preprocessing operations: they are not promised to
-participate in autograd, remain on an accelerator, or be captured by
-`torch.compile`. Functionals currently operate on the single semantic input type
-documented by their signatures; TorchFont does not add a kernel registry until
-multiple outline representations require one.
+### Single glyphs only
+
+Every operation in this section accepts a single glyph. Passing a batched
+`Outline` raises:
+
+```python
+F.affine(batch, angle=5.0)
+# ValueError: affine operates on a single outline, got batch shape (64,);
+#             iterate with unpad_outlines() first
+```
+
+Transforms run per sample, before collation. Batch a pipeline's output with
+[`pad_outlines`](./core-types.md#pad-outlines) or a `DataLoader`.
+
+### Differentiability
+
+Gradient support varies by operation:
+
+| Kernel | Differentiable |
+| --- | --- |
+| `affine` | yes |
+| `coord_jitter` | yes, in both the outline and the noise |
+| `horizontal_flip`, `vertical_flip` | only with `preserve_winding=False` |
+| `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | no |
+| `remove_overlaps`, `remove_overlap_groups` | no |
+| `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | no |
+| `render_bitmap` | no |
+
+Passing an outline that requires grad to an operation marked "no" raises:
+
+```python
+outline.coords.requires_grad_()
+F.remove_overlaps(outline)
+# Raises RuntimeError
+```
+
+`affine` and the flips pivot around the tight bounding-box centre. Gradients flow
+through the transformed coordinates but not through that centre.
+
+### Devices
+
+`LoadGlyph` returns CPU `float32` outlines. `Affine`, flip, curve, overlap, and
+subpath transforms, as well as `RenderBitmap`, require CPU `float32` outlines.
+Convert other outlines explicitly before calling them:
+
+```python
+outline = outline.to("cpu", torch.float32)
+```
+
+`RandomCoordJitter` and `functional.coord_jitter` preserve the input device and
+floating point dtype.
+
+### `torch.compile`
+
+Functional pipelines can be used with `torch.compile`:
+
+```python
+def pipeline(types, coords):
+    outline = Outline(types, coords)
+    outline = F.remove_overlaps(outline)
+    outline = F.cubic_to_quad(outline)
+    outline = F.affine(outline, angle=10.0)
+    return F.render_bitmap(outline, 32)
+
+
+compiled = torch.compile(pipeline)
+```

--- a/docs/ja/guide/dataloader.md
+++ b/docs/ja/guide/dataloader.md
@@ -32,10 +32,9 @@ dataset = GlyphDataset(
 )
 
 data: GlyphData[Outline] = dataset[0]
-types, coords = data.data.types, data.data.coords
 
-print(types.shape)
-print(coords.shape)
+print(data.data.shape)
+print(data.data.coords.shape)
 ```
 
 `LoadGlyph` を渡すと、`dataset[0]` は `GlyphData[Outline]` を返します。`data` Field が
@@ -49,21 +48,35 @@ torch.Size([37, 6])
 
 ## DataLoader を作成する
 
-グリフのアウトライン系列は可変長のため、バッチ化には `collate_fn` が必要です。`pad_sequence` を使ってバッチ内のシーケンスを揃えます。次のコードを実行してください。
+グリフのアウトライン系列は可変長なので、モデルの入力契約に合うローカルな
+`collate_fn` を定義します。Payload には `pad_outlines` を使い、モデルが必要とする
+Target だけを Tensor に変換します。
 
 ```python
-from torch.nn.utils.rnn import pad_sequence
+import math
+
+import torch
 from torch.utils.data import DataLoader
 
 from torchfont.datasets import GlyphDataset
-from torchfont import GlyphData, Outline
+from torchfont import GlyphData, Outline, pad_outlines
 from torchfont.transforms import LoadGlyph
 
 
-def collate_fn(batch: list[GlyphData[Outline]]):
-    types = pad_sequence([item.data.types for item in batch], batch_first=True)
-    coords = pad_sequence([item.data.coords for item in batch], batch_first=True)
-    return types, coords
+def collate_fn(samples: list[GlyphData[Outline]]):
+    return {
+        "outline": pad_outlines([sample.data for sample in samples]),
+        "font_idx": torch.tensor(
+            [sample.font_idx for sample in samples], dtype=torch.long
+        ),
+        "weight": torch.tensor(
+            [
+                math.nan if sample.weight is None else sample.weight
+                for sample in samples
+            ],
+            dtype=torch.float32,
+        ),
+    }
 
 
 dataset = GlyphDataset(
@@ -77,38 +90,94 @@ dataset = GlyphDataset(
     transform=LoadGlyph(),
 )
 
-loader = DataLoader(dataset, batch_size=64, shuffle=True, collate_fn=collate_fn)
-types_t, coords_t = next(iter(loader))
+loader = DataLoader(
+    dataset,
+    batch_size=64,
+    shuffle=True,
+    collate_fn=collate_fn,
+)
+batch = next(iter(loader))
 
-print(types_t.shape)
-print(coords_t.shape)
+print(batch["outline"].shape)
+print(batch["outline"].coords.shape)
+print(batch["weight"].shape)
 ```
 
-`collate_fn` はバッチ内の最長シーケンスに合わせてパディングします。実行すると次のような出力が得られます。1 次元目はバッチサイズです。2 次元目はバッチ内の最長シーケンス長で、バッチごとに異なります。
+Outline はバッチ内の最長のものに合わせてパディングされます。1 次元目はバッチサイズです。2 次元目はバッチ内の最長シーケンス長で、バッチごとに異なります。Target は長さ `batch_size` の 1 次元テンソルになります。次のような出力が得られます。
 
 ```
 torch.Size([64, 369])
 torch.Size([64, 369, 6])
+torch.Size([64])
+```
+
+## パディング済みバッチを扱う
+
+パディングされた要素は `ElementType.PAD` です。その値と比較して復元するのではなく、`padding_mask` を読んでください。これは Attention モジュールが `key_padding_mask` として要求するものそのままです。
+
+```python
+mask = batch["outline"].padding_mask  # (64, 369)、パディング位置が True
+```
+
+`unpad_outlines()` は Padding 済み Batch を明示的に分割し、入力した単一 Outline に戻します。一方、`Outline.unbind()` は通常の Tensor 操作と同じく Padding を保持します。
+
+```python
+from torchfont import unpad_outlines
+
+singles = unpad_outlines(batch["outline"])
+
+print(len(singles), singles[0].shape)
+```
+
+`torchfont.nn` のモジュールはバッチ化の有無を問わず `Outline` を受け取るので、パディング済みバッチをそのままモデルに渡せます。
+
+```python
+from torchfont.nn import OutlineEmbedding
+
+tokens = OutlineEmbedding(embedding_dim=256)(batch["outline"])
+
+print(tokens.shape)  # (64, 369, 256)
+```
+
+## DataLoader を使わずにバッチ化する
+
+`pad_outlines` は同じパディング処理を直接呼び出せます。
+
+```python
+from torchfont import pad_outlines
+
+batched = pad_outlines([dataset[0].data, dataset[1].data])
+
+print(batched.shape)
 ```
 
 ## マルチプロセス読み込み
 
-`num_workers` と `prefetch_factor` を指定すると、データ読み込みをワーカープロセスで並列化できます。シーケンス長が長いと転送コストが大きくなるため、この例の `collate_fn` で先頭 512 要素に切り詰めます。`tqdm` で全バッチを読み込んでスループットを確認します。次のコードを実行してください。
+`num_workers` と `prefetch_factor` を指定すると、データ読み込みをワーカープロセスで並列化できます。
+
+各バッチはその中の最長 Outline に合わせてパディングされるため、巨大なグリフが 1 つ混ざるとバッチ全体、ひいては学習プロセスへの転送量が膨らみます。次の例ではローカルな `collate_fn` で各 Outline を 512 要素に打ち切ります。ワーカープロセスは `collate_fn` を pickle するため、lambda ではなくモジュールレベルの関数として定義してください。
+
+`tqdm` で全バッチを読み込んでスループットを確認します。次のコードを実行してください。
 
 ```python
+import torch
 from tqdm import tqdm
-from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 
+from torchfont import GlyphData, Outline, pad_outlines
 from torchfont.datasets import GlyphDataset
-from torchfont import GlyphData, Outline
 from torchfont.transforms import LoadGlyph
 
+MAX_ELEMENTS = 512
 
-def collate_fn(batch: list[GlyphData[Outline]]):
-    types = pad_sequence([item.data.types[:512] for item in batch], batch_first=True)
-    coords = pad_sequence([item.data.coords[:512] for item in batch], batch_first=True)
-    return types, coords
+
+def collate_fn(samples: list[GlyphData[Outline]]):
+    return {
+        "outline": pad_outlines([sample.data[:MAX_ELEMENTS] for sample in samples]),
+        "font_idx": torch.tensor(
+            [sample.font_idx for sample in samples], dtype=torch.long
+        ),
+    }
 
 
 dataset = GlyphDataset(
@@ -143,3 +212,7 @@ for batch in tqdm(loader):
 len(dataset)=...
 100%|██████████| .../... [..., ...it/s]
 ```
+
+::: tip 打ち切らずにパディングを抑える
+打ち切りは幾何情報を捨てます。Outline 全体を保ったままパディングのコストを避けるには、長さを打ち切るのではなく、長さを考慮した `Sampler` で近い長さの Glyph をまとめてください。
+:::

--- a/docs/ja/guide/glyph-data-format.md
+++ b/docs/ja/guide/glyph-data-format.md
@@ -41,6 +41,11 @@ print(data.optical_size)  # ポイント単位の Optical Size
 返り値の `GlyphData[Outline]` は、意味型の Outline、決定的な Glyph 参照、Dataset
 固有の Target を浅い一つの Record に保持します。
 
+Index は Python の整数、連続 Target は Float です。フォントに存在しない連続
+Target は `None` になります。学習アプリケーション側のローカルな `collate_fn` で、
+必要な Target だけを Tensor に変換し、`NaN` と Mask の併用など欠損値の表現も
+選択できます。
+
 ## アウトラインモデル
 
 グリフのアウトラインは、パス要素の系列として表現されます。
@@ -90,7 +95,9 @@ MOVE_TO
 種類は `MoveTo`、`LineTo`、`QuadTo`、`CurveTo`、`Close`、`End`、`Pad` の 7 つです。
 
 - `ElementType.END` はシーケンス終端を表します
-- `ElementType.PAD` は `pad_sequence` や独自のパディングで出現します
+- `ElementType.PAD` はバッチのパディングで導入された行を標識します。フォントの
+  読み込みでは生成されず、単一グリフには含まれません。値と比較するのではなく
+  `outline.padding_mask` を読んでください
 
 ## 座標
 

--- a/docs/ja/reference/core-types.md
+++ b/docs/ja/reference/core-types.md
@@ -2,9 +2,7 @@
 
 ## `torchfont`
 
-変更不可の意味レコードとアウトラインのエンコーディングに使う共通型です。
-テンソルサブクラスの挙動を追加せず、データセットと変換パイプラインの間で
-フォントの意味を保持します。
+フォントデータをデータセットと変換パイプラインの間で受け渡すための型です。
 
 ```python
 from torchfont import (
@@ -14,28 +12,87 @@ from torchfont import (
     GlyphRef,
     GlyphSample,
     Outline,
-    VariationLocation,
+    pad_outlines,
+    unpad_outlines,
 )
 ```
 
-`VariationLocation` は変更不可でハッシュ可能なマッピングで、軸タグを常に
-ソート済みの順序で保持します。イテラブルな入力に正規化後の重複タグがある場合は、
-値を黙って上書きせず拒否します。`FontRef`、グリフ参照、データセットのサンプルは
-変更不可の `dataclass` で、マルチプロセスのデータローダーでも `pickle` 可能です。
+Variation Location には `dict[str, float]` を使います。Font 参照、Glyph 参照、
+Dataset Sample はマルチプロセスの DataLoader でも使用できます。
 
-`Outline` は一つの可変長で、バッチ化されていないグリフを表します。`types` は形状 `(N,)` の
-`torch.long`、`coords` は形状 `(N, 6)` の `torch.float32` で、各行が一対一に対応し、
-同じデバイス上に置かれます。これらの構造的不変条件は `Outline` 構築時に検査されます。
-各要素型で使われない座標、および `CLOSE`、`END`、`PAD` の全座標には意味が
-ありません。`GlyphData` は変換後の Payload、Glyph 参照、確定済みの Variation Location、
-並列な `font_idx`、`character_idx`、`weight`、`width`、`italic`、`slant`、`optical_size`
-Target を浅い一つの Record に保持します。Registered Axis の値を優先し、Axis にない値は
-可能な場合に OS/2、`head`、`post` の同等な Metadata から取得します。取得できない Target
-は `NaN` です。
+### `Outline`
 
-`Outline` と `GlyphData` は意図的に同一性による比較を使います。Tensor Payload には
-`dataclass` が生成する等値比較ではなく、`torch.equal()` などを使います。`GlyphSample` は
-値 Record のままです。
+`Outline` は結合した二つのテンソルを保持します。`types` は形状 `(*batch, N)` の
+`torch.long`、`coords` は形状 `(*batch, N, 6)` の任意の浮動小数点型で、各行が
+一対一に対応し、同じデバイス上に置かれます。各要素型で使われない座標、および
+`CLOSE`、`END`、`PAD` の全座標には意味がありません。
+
+単一グリフの Batch 形状は空です。[`pad_outlines`](#pad-outlines) は単一グリフを
+バッチにまとめます。ほとんどの Transform は単一グリフだけを扱い、バッチ化された
+`Outline` は明示的なエラーで拒否します。
+
+次のプロパティで、中身を取り出さずに Outline を調べられます。
+
+| プロパティ | 意味 |
+| --- | --- |
+| `shape` | `types` の形状、つまり `(*batch, N)` |
+| `batch_shape` | 先頭の Batch 次元。単一グリフでは空 |
+| `num_elements` | パディングを含む 1 グリフあたりの要素数 |
+| `is_batched` | Batch 次元を持つかどうか |
+| `dtype` | `coords` の浮動小数点型 |
+| `device` | 両テンソルが共有するデバイス |
+| `padding_mask` | 要素が `PAD` の位置で `True` になる Boolean Mask |
+
+`to()` と `pin_memory()` は両方のテンソルに同時に適用されます。`to()` に渡す dtype は
+`coords` にのみ適用され、浮動小数点型でなければなりません。それ以外の Tensor 操作は
+`types` または `coords` に直接適用します。Index は座標軸を常に保ったまま論理的な `(*batch, N)` 次元を
+対象にし、最後の要素次元を取り除く Index は使えません。`len()` は最初の論理次元の
+長さを返します。`unbind()` は内容を変更せず、最初の
+Batch 次元だけを分割します。
+
+`Outline` 同士は同一性で比較されます。内容の等値性が必要な場合は `types` と
+`coords` を `torch.equal()` で明示的に比較します。入力テンソルをその場で変更すると、
+その変更は Outline にも反映されます。どちらの属性への代入もエラーになります。
+
+### `pad_outlines`
+
+```python
+pad_outlines(outlines: Sequence[Outline]) -> Outline
+```
+
+単一 Outline を `ElementType.PAD` とゼロ座標でパディングして一つのバッチに
+まとめます。入力はすべて単一グリフで、デバイスと `coords` の dtype が共通で
+なければなりません。パディング位置は `padding_mask` で取得でき、
+[`unpad_outlines`](#unpad-outlines) で元に戻せます。
+
+### `unpad_outlines`
+
+```python
+unpad_outlines(outline: Outline) -> tuple[Outline, ...]
+```
+
+Batch 次元がちょうど一つの `Outline` を分割し、各結果の末尾にある
+`ElementType.PAD` 行を除去します。これは `pad_outlines` の明示的な逆操作です。
+Padding を保持する場合は `Outline.unbind()` を使います。
+
+### `GlyphData`
+
+`GlyphData` は変換後の Payload、Glyph 参照、Variation Location、
+並列な `font_idx`、`character_idx`、`weight`、`width`、`italic`、`slant`、
+`optical_size` Target を保持します。取得できない連続 Target は `None` です。
+
+`location` は Glyph の読み込みに使った OpenType Axis Tag と値を保持する通常の
+`dict[str, float]` です。
+
+Index は Python の整数、連続 Target は Float です。取得できない連続 Target は
+`None` になります。
+
+`GlyphData` 同士は同一性で比較されます。Tensor Payload の内容を比較する場合は、
+明示的な Tensor 比較を使ってください。
+
+モデルの入力契約に合わせてローカルな `DataLoader.collate_fn` を定義し、Payload が可変長 Outline の
+場合は [`pad_outlines`](#pad-outlines) を使います。
+[DataLoader](../guide/dataloader.md) を参照してください。
 
 ### `ElementType: IntEnum`
 
@@ -49,6 +106,9 @@ class ElementType(IntEnum):
     CLOSE = 5
     END = 6
 ```
+
+`PAD` はフォントの読み込みでは生成されません。バッチのパディングで導入された行を
+標識します。
 
 ### `TYPE_DIM: int`
 

--- a/docs/ja/reference/nn.md
+++ b/docs/ja/reference/nn.md
@@ -1,7 +1,8 @@
 # ニューラルネットワーク構成要素
 
 TorchFont は、フォント固有の小さな構成要素を `torchfont.nn` で提供します。
-通常のテンソルを入出力するため、標準の PyTorch Module、Device、Dtype、Autograd、
+バッチ化の有無を問わず [`Outline`](./core-types.md#outline) を受け取り、通常の
+テンソルを返すため、標準の PyTorch Module、Device、Dtype、Autograd、
 Serialization と組み合わせられます。
 
 ## `OutlineEmbedding`
@@ -11,16 +12,19 @@ Serialization と組み合わせられます。
 ```python
 import torch
 
-from torchfont import ElementType
+from torchfont import ElementType, Outline
 from torchfont.nn import OutlineEmbedding
 
 embedding = OutlineEmbedding(embedding_dim=256)
-types = torch.tensor(
-    [[ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END, ElementType.PAD]]
+outline = Outline(
+    torch.tensor(
+        [[ElementType.MOVE_TO, ElementType.LINE_TO, ElementType.END, ElementType.PAD]]
+    ),
+    torch.zeros((1, 4, 6)),  # (batch, sequence, 6)
 )
-coords = torch.zeros((1, 4, 6))  # (batch, sequence, 6)
-tokens = embedding(types, coords)  # (batch, sequence, 256)
-padding_mask = types == ElementType.PAD
+
+tokens = embedding(outline)  # (1, 4, 256)
+padding_mask = outline.padding_mask  # (1, 4)
 ```
 
 学習可能な要素型 Embedding と、Bias なしの線形層による6次元連続座標の射影を加算します。
@@ -41,7 +45,7 @@ embedding = OutlineEmbedding(256, device="cuda", dtype=torch.float16)
 ```python
 from torchfont.nn import functional as F
 
-loss = F.coordinate_loss(predicted_coords, target_coords, target_types)
+loss = F.coordinate_loss(predicted_coords, target_outline)
 ```
 
 - `MOVE_TO` と `LINE_TO`: End Point のみ
@@ -49,8 +53,7 @@ loss = F.coordinate_loss(predicted_coords, target_coords, target_types)
 - `CURVE_TO`: 二つの Control Point と End Point
 - `CLOSE`、`END`、`PAD`: 座標なし
 
-Input と Target の Shape は `(..., N, 6)`、要素型の Shape は `(..., N)` です。
-Reduction は `"none"`、`"mean"`、`"sum"` に対応します。Mean は Padding を含む格納領域ではなく、
+Prediction の Shape は `(..., N, 6)` で、Target の座標と一致します。Reduction は `"none"`、`"mean"`、`"sum"` に対応します。Mean は Padding を含む格納領域ではなく、
 有効な座標 Scalar に対して計算されます。有効な座標がない場合、Mean は微分可能なゼロになります。
 無効な座標 Slot にある非有限値は無視されます。
 
@@ -62,16 +65,10 @@ Reduction は `"none"`、`"mean"`、`"sum"` に対応します。Mean は Paddin
 from torchfont.nn import OutlineLoss
 
 criterion = OutlineLoss(type_weight=1.0, coordinate_weight=0.5)
-loss = criterion(
-    type_logits,
-    predicted_coords,
-    target_types,
-    target_coords,
-)
+loss = criterion(type_logits, predicted_coords, target_outline)
 ```
 
-`type_logits` の Shape は `(..., N, TYPE_DIM)` です。他の Tensor は
-`coordinate_loss` と同じ Shape を受け取ります。Cross Entropy は Padding 以外の要素で平均し、
+`type_logits` の Shape は `(..., N, TYPE_DIM)` です。Cross Entropy は Padding 以外の要素で平均し、
 座標誤差は有効な座標 Scalar で独立に平均します。その後、二つの Mean を `type_weight` と
 `coordinate_weight` で重み付けします。このため、Outline の長さや Padding 量が変化しても、
 相対的な重みが安定します。すべてが Padding の Input に対しては、微分可能なゼロ Loss を返します。

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -1,8 +1,7 @@
 # Transform
 
-TorchFont の Transform は TorchVision Transforms v2（`torchvision.transforms.v2`）と同様に、意味を持つデータ型、
-クラスベースの確率的 Transform、決定論的な Functional カーネル、PyTree の合成を
-基本にします。
+TorchFont は Glyph の読み込み、変形、描画を組み合わせるための Transform を提供します。
+結果を画像パイプラインへ渡す場合は、任意で TorchVision を組み合わせられます。
 
 ## データ型
 
@@ -11,11 +10,8 @@ from torchfont import GlyphData, Outline
 ```
 
 `Outline(types, coords)` は不可分な二つのテンソルを一つにまとめます。
-`GlyphData[T]` は変換中の Payload、Glyph 参照、実際に使用した Variation Location、Target
-を保持します。Payload は Generic なので、Metadata を失わずに
-`Outline` から通常のビットマップテンソルへ変換できます。ラスタライズしたグリフには
-TorchFont 固有のテンソルサブクラスを設けず、画像として扱う必要がある境界で TorchVision の
-`ToImage()` を明示的に適用します。
+`GlyphData[T]` は変換中の Payload、Glyph 参照、Variation Location、Target を保持します。
+他の Field を失わずに、Payload を `Outline` からビットマップテンソルへ変換できます。
 
 ## 読み込みと合成
 
@@ -48,29 +44,18 @@ Random Policy は `GlyphSample` または `GlyphRef` に対して位置を 1 点
 Dataset Sample に対しては、返される `GlyphData` の並列な `weight`、`width`、`italic`、
 `slant`、`optical_size` Target も解決します。
 
-`Transform` はネストした PyTree を平坦化し、一致するすべての意味的なリーフに対して
-パラメーターを一度だけ生成し、元の構造を復元します。そのため、一回の呼び出しに含まれる
-対応する複数アウトラインには、同じ反転、アフィンパラメーター、要素単位の乱数が適用されます。
+Transform はネストした入力を受け取り、その構造を保ちます。一回の呼び出しに含まれる
+対応する複数 Outline には、同じランダムパラメーターが適用されます。
 独立したサンプルには Transform を個別に適用します。確率的 Transform は PyTorch の
 デフォルト RNG を使うため、`torch.manual_seed` と `DataLoader` ワーカーのシードが通常どおり
 機能します。
-組み込み Transform は設定のみを保持し、`pickle` 可能です。`Compose` に通常のリストを
-渡した場合も、子 Transform は内部の `torch.nn.ModuleList` に登録されます。通常の
-`callable` には意図的に対応しません。小さな `nn.Module` を定義し、挙動、表示、`pickle`
-要件を明示します。これによりモジュールの走査、状態辞書、フック、設定表示を PyTorch の
-規則に揃えます。
+組み込み Transform はマルチプロセスの DataLoader でも使用できます。`Compose` には
+`nn.Module` の Transform を渡します。独自 Transform も通常の Callable ではなく
+`nn.Module` の Subclass として定義してください。空の `Compose` は入力を変更しません。
+複数の Transform を `RandomApply` でまとめる場合は、内側に `Compose` を置きます。
 
-コンテナーは登録した子をモジュール呼び出し経路で呼ぶため、`forward` フックも機能します。
-`train()` と `eval()` は通常どおり伝播しますが、組み込みの確率的 Transform は意図的に
-`training` フラグを参照しません。前処理とモデルのモードは別の関心事なので、評価時は
-`eval()` でデータ拡張が止まることに依存せず、決定論的パイプラインを明示的に選びます。
-
-`torchvision.transforms.v2` と同様に、`Transform` のサブクラスとコンテナーは一つの
-PyTree または複数の位置引数を受け取れます。リーフ間の関係をパラメーターのサンプリング前に確認する
-カスタム Transform のために `check_inputs()` を利用できます。`Compose` は
-`nn.Module` の `Iterable` を即座に `nn.ModuleList` へ具体化し、空の `Iterable` は
-恒等 Transform として扱います。`RandomApply` は一つの `nn.Module` を包みます。複数の Transform を
-`RandomApply` でまとめる場合は、内側に `Compose` を置きます。
+`eval()` を呼んでもランダムな Data Augmentation は無効になりません。評価時には
+決定論的な Pipeline を使用してください。
 
 `RandomApply(transform, p)` は一つの Transform を適用するか制御します。
 `RandomSplitSegments.split_probability` などは、適用された Transform 内部の挙動を
@@ -95,8 +80,8 @@ PyTree または複数の位置引数を受け取れます。リーフ間の関�
 
 `RenderBitmap` はグレースケールの通常の `H x W` テンソルを返します。
 `torchvision.transforms.v2.ToImage()` を画像パイプラインへの境界として使うと、チャンネル次元が追加され、
-形状が `1 x H x W` の `tv_tensors.Image` になります。両ライブラリが PyTree を処理するため、
-外側の `GlyphData` も維持されます。
+形状が `1 x H x W` の `tv_tensors.Image` になります。外側の `GlyphData` の Field も
+維持されます。
 `RenderBitmap(antialias=False)` は Edge Coverage を二値化します。これは Vector の
 Rasterization を制御するもので、後段の `v2.Resize` における画像の Resampling を制御する
 `antialias` Option とは独立しています。
@@ -128,7 +113,7 @@ image = data.data  # Tensor, (1, 64, 64), float32, range [0, 1]
 スケーリングしません。`ToPureTensor()` はモデルへ渡す前に `Image` サブクラスを取り除きます。
 TorchVision は任意の統合先であり、TorchFont のレンダラーには不要です。
 
-## Functional カーネル
+## Functional API
 
 決定論的な処理は `torchfont.transforms.functional` から利用できます。
 
@@ -147,8 +132,70 @@ shape = bitmap.shape
 Functional API は乱数を生成しません。ランダムな選択とパラメーターのサンプリングは
 `Random*` Transform クラスの責務です。
 
-これらの Transform が `nn.Module` なのは、合成、モジュール登録、PyTorch RNG、PyTree
-処理のためです。Rust バックエンドのアウトライン用 Functional は CPU / NumPy 境界を通る
-前処理であり、自動微分への参加、アクセラレーター上での実行維持、`torch.compile` による
-キャプチャーは保証しません。現在の Functional はシグネチャーに記載した単一の意味型を
-処理します。複数のアウトライン表現が必要になるまではカーネルレジストリを導入しません。
+### 単一グリフのみを扱う
+
+この節の各処理は単一グリフを対象とします。バッチ化された `Outline` を渡すと
+エラーになります。
+
+```python
+F.affine(batch, angle=5.0)
+# ValueError: affine operates on a single outline, got batch shape (64,);
+#             iterate with unpad_outlines() first
+```
+
+Transform は Collate の前にサンプルごとに実行されます。パイプラインの出力は
+[`pad_outlines`](./core-types.md#pad-outlines) または `DataLoader` でバッチ化してください。
+
+### 微分可能性
+
+勾配への対応は処理ごとに異なります。
+
+| カーネル | 微分可能 |
+| --- | --- |
+| `affine` | はい |
+| `coord_jitter` | はい。Outline と Noise の両方について |
+| `horizontal_flip`, `vertical_flip` | `preserve_winding=False` のときのみ |
+| `quad_to_cubic`, `cubic_to_quad`, `merge_curves`, `split_segments` | いいえ |
+| `remove_overlaps`, `remove_overlap_groups` | いいえ |
+| `normalize_subpath_start_points`, `set_subpath_start_points`, `reorder_subpaths` | いいえ |
+| `render_bitmap` | いいえ |
+
+「いいえ」の処理に勾配を要求する Outline を渡すとエラーになります。
+
+```python
+outline.coords.requires_grad_()
+F.remove_overlaps(outline)
+# RuntimeError が発生
+```
+
+`affine` と Flip は Tight Bounding Box の中心を軸に変換します。勾配は変換後の
+座標を通って流れますが、この中心を通っては流れません。
+
+### デバイス
+
+`LoadGlyph` は CPU の `float32` Outline を返します。`Affine`、Flip、Curve、Overlap、
+Subpath の各 Transform と `RenderBitmap` は、CPU の `float32` Outline を必要とします。
+それ以外の Outline は呼び出す前に明示的に変換してください。
+
+```python
+outline = outline.to("cpu", torch.float32)
+```
+
+`RandomCoordJitter` と `functional.coord_jitter` は入力の Device と浮動小数点 dtype を
+維持します。
+
+### `torch.compile`
+
+Functional Pipeline は `torch.compile` で使用できます。
+
+```python
+def pipeline(types, coords):
+    outline = Outline(types, coords)
+    outline = F.remove_overlaps(outline)
+    outline = F.cubic_to_quad(outline)
+    outline = F.affine(outline, angle=10.0)
+    return F.render_bitmap(outline, 32)
+
+
+compiled = torch.compile(pipeline)
+```

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -189,6 +189,12 @@ outline = outline.to("cpu", torch.float32)
 Functional Pipeline は `torch.compile` で使用できます。
 
 ```python
+import torch
+
+# Outline の長さが変わる処理を PyTorch 2.4 で使う場合に必要です。
+torch._dynamo.config.capture_dynamic_output_shape_ops = True
+
+
 def pipeline(types, coords):
     outline = Outline(types, coords)
     outline = F.remove_overlaps(outline)

--- a/docs/ja/reference/transforms.md
+++ b/docs/ja/reference/transforms.md
@@ -191,7 +191,7 @@ Functional Pipeline は `torch.compile` で使用できます。
 ```python
 import torch
 
-# Outline の長さが変わる処理を PyTorch 2.4 で使う場合に必要です。
+# Outline の長さが変わる処理を PyTorch 2.5 で使う場合に必要です。
 torch._dynamo.config.capture_dynamic_output_shape_ops = True
 
 

--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, cast
 
 import torch
@@ -49,7 +50,7 @@ class GlyphPipeline(torch.nn.Module):
 
     def forward(
         self, sample: GlyphSample
-    ) -> tuple[Tensor, Tensor, Tensor, int, int, float]:
+    ) -> tuple[Tensor, Tensor, Tensor, int, int, float | None]:
         data = cast("GlyphData[Outline]", self.prepare_outline(sample))
         image_data = cast("GlyphData[Tensor]", self.rasterize(data))
         return (
@@ -63,7 +64,7 @@ class GlyphPipeline(torch.nn.Module):
 
 
 def collate_fn(
-    batch: list[tuple[Tensor, Tensor, Tensor, int, int, float]],
+    batch: list[tuple[Tensor, Tensor, Tensor, int, int, float | None]],
 ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
     types, coords, images, fonts, characters, weights = zip(*batch, strict=True)
     return (
@@ -72,7 +73,10 @@ def collate_fn(
         torch.stack(images),
         torch.tensor(fonts, dtype=torch.long),
         torch.tensor(characters, dtype=torch.long),
-        torch.tensor(weights, dtype=torch.float32),
+        torch.tensor(
+            [math.nan if weight is None else weight for weight in weights],
+            dtype=torch.float32,
+        ),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["numpy>=1.21.3", "torch>=2.3.0"]
+dependencies = ["numpy>=1.21.3", "torch>=2.4.0"]
 
 [project.urls]
 Repository = "https://github.com/torchfont/torchfont"
@@ -84,6 +84,8 @@ ignore = ["COM812", "CPY001", "D203", "D213", "EXE002"]
 
 [tool.ruff.lint.per-file-ignores]
 "examples/**/*.py" = ["D", "T201"]
+# Operator signatures are fixed by the schema each kernel is registered with.
+"torchfont/_ops.py" = ["FBT001", "PLR0913", "PLR0917"]
 "torchfont/transforms/functional/_geometry.py" = ["PLR0913"]
 "tests/**/*.py" = ["D", "PLR2004", "S101"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["numpy>=1.21.3", "torch>=2.4.0"]
+dependencies = ["numpy>=1.21.3", "torch>=2.5.0"]
 
 [project.urls]
 Repository = "https://github.com/torchfont/torchfont"
@@ -52,7 +52,7 @@ dev = [
     "pytest>=8.4.2",
     "pytest-benchmark>=5.1.0",
     "skia-pathops>=0.9.2",
-    "torchvision>=0.18.0",
+    "torchvision>=0.20.0",
     "tqdm>=4.67.1",
     "ty>=0.0.63",
     "types-tqdm>=4.67.0.20250809",

--- a/tests/_pairs.py
+++ b/tests/_pairs.py
@@ -1,0 +1,51 @@
+"""Tensor-pair adapters for kernels whose public API takes an ``Outline``.
+
+Many kernel tests were written against ``(types, coords)`` pairs. The public
+functional API takes and returns :class:`torchfont.Outline`, so these adapters
+keep those tests focused on kernel behaviour instead of container plumbing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from torchfont import Outline
+from torchfont.transforms import functional as F  # noqa: N812
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+
+def _pair(outline: Outline) -> tuple[Tensor, Tensor]:
+    return outline.types, outline.coords
+
+
+def quad_to_cubic(
+    types: Tensor,
+    coords: Tensor,
+    merge_curves: bool = False,  # noqa: FBT001, FBT002
+) -> tuple[Tensor, Tensor]:
+    """Call :func:`torchfont.transforms.functional.quad_to_cubic` on a pair."""
+    return _pair(F.quad_to_cubic(Outline(types, coords), merge_curves=merge_curves))
+
+
+def cubic_to_quad(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Call :func:`torchfont.transforms.functional.cubic_to_quad` on a pair."""
+    return _pair(F.cubic_to_quad(Outline(types, coords)))
+
+
+def merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Call :func:`torchfont.transforms.functional.merge_curves` on a pair."""
+    return _pair(F.merge_curves(Outline(types, coords)))
+
+
+def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Call :func:`torchfont.transforms.functional.remove_overlaps` on a pair."""
+    return _pair(F.remove_overlaps(Outline(types, coords)))
+
+
+def normalize_subpath_start_points(
+    types: Tensor, coords: Tensor
+) -> tuple[Tensor, Tensor]:
+    """Call the subpath start-point normaliser on a pair."""
+    return _pair(F.normalize_subpath_start_points(Outline(types, coords)))

--- a/tests/google_fonts/test_merge_curves.py
+++ b/tests/google_fonts/test_merge_curves.py
@@ -5,11 +5,11 @@ import pytest
 from torch import Tensor
 from torch.utils.data import DataLoader
 
+from tests._pairs import merge_curves
 from torchfont import GlyphSample, Outline
 from torchfont.datasets import GlyphDataset
 from torchfont.transforms import functional as _functional
 from torchfont.transforms.functional import render_bitmap
-from torchfont.transforms.functional._curves import _merge_curves as merge_curves
 
 logger = logging.getLogger(__name__)
 

--- a/tests/google_fonts/test_remove_overlaps.py
+++ b/tests/google_fonts/test_remove_overlaps.py
@@ -6,11 +6,11 @@ import torch
 from torch import Tensor
 from torch.utils.data import DataLoader
 
+from tests._pairs import remove_overlaps
 from torchfont import ElementType, GlyphSample, Outline
 from torchfont.datasets import GlyphDataset
 from torchfont.transforms import functional as _functional
 from torchfont.transforms.functional import render_bitmap
-from torchfont.transforms.functional._outline import _remove_overlaps as remove_overlaps
 
 logger = logging.getLogger(__name__)
 

--- a/tests/nn/test_embedding.py
+++ b/tests/nn/test_embedding.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from torchfont import COORD_DIM, TYPE_DIM, ElementType
+from torchfont import COORD_DIM, TYPE_DIM, ElementType, Outline
 from torchfont.nn import OutlineEmbedding
 
 
@@ -10,10 +10,12 @@ def test_outline_embedding_combines_types_and_coordinates() -> None:
     with torch.no_grad():
         embedding.type_embedding.weight.fill_(1.0)
         embedding.coord_projection.weight.fill_(2.0)
-    types = torch.tensor([[ElementType.MOVE_TO, ElementType.LINE_TO]])
-    coords = torch.ones((1, 2, 6))
+    outline = Outline(
+        torch.tensor([[ElementType.MOVE_TO, ElementType.LINE_TO]]),
+        torch.ones((1, 2, 6)),
+    )
 
-    output = embedding(types, coords)
+    output = embedding(outline)
 
     assert output.shape == (1, 2, 3)
     assert torch.equal(output, torch.full((1, 2, 3), 5.0))
@@ -24,15 +26,17 @@ def test_outline_embedding_ignores_inactive_coordinates() -> None:
     with torch.no_grad():
         embedding.type_embedding.weight.zero_()
         embedding.coord_projection.weight.fill_(1.0)
-    types = torch.tensor([ElementType.MOVE_TO, ElementType.QUAD_TO])
-    coords = torch.tensor(
-        [
-            [100.0, 100.0, 100.0, 100.0, 1.0, 2.0],
-            [1.0, 2.0, 100.0, 100.0, 3.0, 4.0],
-        ]
+    outline = Outline(
+        torch.tensor([ElementType.MOVE_TO, ElementType.QUAD_TO]),
+        torch.tensor(
+            [
+                [100.0, 100.0, 100.0, 100.0, 1.0, 2.0],
+                [1.0, 2.0, 100.0, 100.0, 3.0, 4.0],
+            ]
+        ),
     )
 
-    output = embedding(types, coords)
+    output = embedding(outline)
 
     assert torch.equal(output[:, 0], torch.tensor([3.0, 10.0]))
 
@@ -42,25 +46,28 @@ def test_outline_embedding_ignores_nonfinite_inactive_coordinates() -> None:
     with torch.no_grad():
         embedding.type_embedding.weight.zero_()
         embedding.coord_projection.weight.fill_(1.0)
-    types = torch.tensor([ElementType.MOVE_TO, ElementType.PAD])
-    coords = torch.tensor(
-        [
-            [torch.nan, torch.inf, -torch.inf, torch.nan, 1.0, 2.0],
-            [torch.nan, torch.inf, -torch.inf, torch.nan, torch.nan, torch.inf],
-        ]
+    outline = Outline(
+        torch.tensor([ElementType.MOVE_TO, ElementType.PAD]),
+        torch.tensor(
+            [
+                [torch.nan, torch.inf, -torch.inf, torch.nan, 1.0, 2.0],
+                [torch.nan, torch.inf, -torch.inf, torch.nan, torch.nan, torch.inf],
+            ]
+        ),
     )
 
-    output = embedding(types, coords)
+    output = embedding(outline)
 
     assert torch.equal(output, torch.tensor([[3.0], [0.0]]))
 
 
 def test_outline_embedding_zeroes_padding_tokens() -> None:
     embedding = OutlineEmbedding(4)
-    types = torch.tensor([ElementType.MOVE_TO, ElementType.PAD])
-    coords = torch.ones((2, 6))
+    outline = Outline(
+        torch.tensor([ElementType.MOVE_TO, ElementType.PAD]), torch.ones((2, 6))
+    )
 
-    output = embedding(types, coords)
+    output = embedding(outline)
 
     assert torch.count_nonzero(output[0]) > 0
     assert torch.count_nonzero(output[1]) == 0
@@ -68,10 +75,11 @@ def test_outline_embedding_zeroes_padding_tokens() -> None:
 
 def test_outline_embedding_supports_factory_dtype() -> None:
     embedding = OutlineEmbedding(4, dtype=torch.float64)
-    types = torch.tensor([ElementType.MOVE_TO])
-    coords = torch.ones((1, 6), dtype=torch.float64)
+    outline = Outline(
+        torch.tensor([ElementType.MOVE_TO]), torch.ones((1, 6), dtype=torch.float64)
+    )
 
-    output = embedding(types, coords)
+    output = embedding(outline)
 
     assert output.dtype == torch.float64
     assert embedding.type_embedding.weight.dtype == torch.float64
@@ -110,10 +118,3 @@ def test_outline_embedding_reset_parameters_redraws_and_keeps_padding_zero() -> 
 
     assert not torch.equal(embedding.type_embedding.weight[1:], before[1:])
     assert torch.count_nonzero(embedding.type_embedding.weight[0]) == 0
-
-
-def test_outline_embedding_rejects_misaligned_shapes() -> None:
-    embedding = OutlineEmbedding(4)
-
-    with pytest.raises(ValueError, match="types shape must match"):
-        embedding(torch.zeros(2, dtype=torch.long), torch.zeros((1, 2, 6)))

--- a/tests/nn/test_functional.py
+++ b/tests/nn/test_functional.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from torchfont import ElementType
+from torchfont import ElementType, Outline
 from torchfont.nn.functional import coordinate_loss
 
 
@@ -24,7 +24,7 @@ def test_coordinate_loss_masks_inactive_coordinates() -> None:
     prediction = torch.zeros((len(types), 6))
     target = torch.ones_like(prediction)
 
-    loss = coordinate_loss(prediction, target, types, reduction="none")
+    loss = coordinate_loss(prediction, Outline(types, target), reduction="none")
 
     expected = torch.tensor(
         [
@@ -51,7 +51,7 @@ def test_coordinate_loss_ignores_nonfinite_inactive_coordinates() -> None:
         ]
     )
 
-    loss = coordinate_loss(prediction, target, types, reduction="none")
+    loss = coordinate_loss(prediction, Outline(types, target), reduction="none")
 
     assert torch.equal(
         loss,
@@ -63,7 +63,7 @@ def test_coordinate_loss_mean_is_zero_without_active_coordinates() -> None:
     types = torch.tensor([ElementType.CLOSE, ElementType.END, ElementType.PAD])
     prediction = torch.zeros((3, 6), requires_grad=True)
 
-    loss = coordinate_loss(prediction, torch.ones_like(prediction), types)
+    loss = coordinate_loss(prediction, Outline(types, torch.ones_like(prediction)))
     loss.backward()
 
     assert loss.item() == 0.0
@@ -76,8 +76,11 @@ def test_coordinate_loss_reductions_count_only_active_coordinates() -> None:
     prediction = torch.zeros((len(types), 6))
     target = torch.ones_like(prediction)
 
-    assert coordinate_loss(prediction, target, types).item() == 1.0
-    assert coordinate_loss(prediction, target, types, reduction="sum").item() == 14.0
+    assert coordinate_loss(prediction, Outline(types, target)).item() == 1.0
+    assert (
+        coordinate_loss(prediction, Outline(types, target), reduction="sum").item()
+        == 14.0
+    )
 
 
 def test_coordinate_loss_backpropagates_only_through_active_coordinates() -> None:
@@ -85,7 +88,7 @@ def test_coordinate_loss_backpropagates_only_through_active_coordinates() -> Non
     prediction = torch.zeros((2, 6), requires_grad=True)
     target = torch.ones_like(prediction)
 
-    coordinate_loss(prediction, target, types, reduction="sum").backward()
+    coordinate_loss(prediction, Outline(types, target), reduction="sum").backward()
 
     grad = prediction.grad
     assert grad is not None
@@ -93,33 +96,17 @@ def test_coordinate_loss_backpropagates_only_through_active_coordinates() -> Non
     assert torch.count_nonzero(grad[1]) == 0
 
 
-@pytest.mark.parametrize(
-    ("prediction_shape", "target_shape", "types_shape", "match"),
-    [
-        ((2, 6), (3, 6), (2,), "same shape"),
-        ((2, 5), (2, 5), (2,), "must have shape"),
-        ((2, 6), (2, 6), (1, 2), "types shape must match"),
-    ],
-)
-def test_coordinate_loss_rejects_misaligned_shapes(
-    prediction_shape: tuple[int, ...],
-    target_shape: tuple[int, ...],
-    types_shape: tuple[int, ...],
-    match: str,
-) -> None:
-    with pytest.raises(ValueError, match=match):
-        coordinate_loss(
-            torch.zeros(prediction_shape),
-            torch.zeros(target_shape),
-            torch.zeros(types_shape, dtype=torch.long),
-        )
+def test_coordinate_loss_rejects_a_prediction_that_does_not_match_the_target() -> None:
+    target = Outline(torch.zeros(3, dtype=torch.long), torch.zeros((3, 6)))
+
+    with pytest.raises(ValueError, match="same shape as the target coordinates"):
+        coordinate_loss(torch.zeros((2, 6)), target)
 
 
 def test_coordinate_loss_rejects_invalid_reduction() -> None:
     with pytest.raises(ValueError, match="not a valid value"):
         coordinate_loss(
             torch.zeros((1, 6)),
-            torch.zeros((1, 6)),
-            torch.tensor([ElementType.MOVE_TO]),
+            Outline(torch.tensor([ElementType.MOVE_TO]), torch.zeros((1, 6))),
             reduction="invalid",  # ty: ignore[invalid-argument-type]
         )

--- a/tests/nn/test_loss.py
+++ b/tests/nn/test_loss.py
@@ -2,43 +2,38 @@ import pytest
 import torch
 from torch.nn import functional as torch_functional
 
-from torchfont import TYPE_DIM, ElementType
+from torchfont import TYPE_DIM, ElementType, Outline
 from torchfont.nn import OutlineLoss
 from torchfont.nn import functional as font_functional
 
 
-def _inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    target_types = torch.tensor(
-        [ElementType.MOVE_TO, ElementType.CURVE_TO, ElementType.PAD]
-    )
+def _inputs() -> tuple[torch.Tensor, torch.Tensor, Outline]:
     type_logits = torch.zeros((3, TYPE_DIM), requires_grad=True)
     coordinate_prediction = torch.zeros((3, 6), requires_grad=True)
-    target_coords = torch.ones_like(coordinate_prediction)
-    return type_logits, coordinate_prediction, target_types, target_coords
+    target = Outline(
+        torch.tensor([ElementType.MOVE_TO, ElementType.CURVE_TO, ElementType.PAD]),
+        torch.ones_like(coordinate_prediction),
+    )
+    return type_logits, coordinate_prediction, target
 
 
 def test_outline_loss_combines_independently_averaged_losses() -> None:
-    type_logits, prediction, target_types, target_coords = _inputs()
+    type_logits, prediction, target = _inputs()
 
     loss = font_functional.outline_loss(
         type_logits,
         prediction,
-        target_types,
-        target_coords,
+        target,
         type_weight=2.0,
         coordinate_weight=3.0,
     )
 
     expected_type_loss = torch_functional.cross_entropy(
         type_logits,
-        target_types,
+        target.types,
         ignore_index=ElementType.PAD,
     )
-    expected_coord_loss = font_functional.coordinate_loss(
-        prediction,
-        target_coords,
-        target_types,
-    )
+    expected_coord_loss = font_functional.coordinate_loss(prediction, target)
     assert torch.allclose(loss, 2 * expected_type_loss + 3 * expected_coord_loss)
 
 
@@ -58,9 +53,9 @@ def test_outline_loss_module_delegates_to_functional_loss() -> None:
 
 
 def test_outline_loss_backpropagates_through_both_predictions() -> None:
-    type_logits, prediction, target_types, target_coords = _inputs()
+    type_logits, prediction, target = _inputs()
 
-    OutlineLoss()(type_logits, prediction, target_types, target_coords).backward()
+    OutlineLoss()(type_logits, prediction, target).backward()
 
     assert type_logits.grad is not None
     assert prediction.grad is not None
@@ -69,16 +64,13 @@ def test_outline_loss_backpropagates_through_both_predictions() -> None:
 
 
 def test_outline_loss_is_zero_for_all_padding() -> None:
-    target_types = torch.tensor([ElementType.PAD, ElementType.PAD])
     type_logits = torch.zeros((2, TYPE_DIM), requires_grad=True)
     prediction = torch.zeros((2, 6), requires_grad=True)
-
-    loss = OutlineLoss()(
-        type_logits,
-        prediction,
-        target_types,
-        torch.zeros_like(prediction),
+    target = Outline(
+        torch.tensor([ElementType.PAD, ElementType.PAD]), torch.zeros_like(prediction)
     )
+
+    loss = OutlineLoss()(type_logits, prediction, target)
     loss.backward()
 
     assert loss.item() == 0.0
@@ -99,12 +91,7 @@ def test_outline_loss_rejects_misaligned_type_logits(
     logits_shape: tuple[int, ...],
     match: str,
 ) -> None:
-    _, prediction, target_types, target_coords = _inputs()
+    _, prediction, target = _inputs()
 
     with pytest.raises(ValueError, match=match):
-        font_functional.outline_loss(
-            torch.zeros(logits_shape),
-            prediction,
-            target_types,
-            target_coords,
-        )
+        font_functional.outline_loss(torch.zeros(logits_shape), prediction, target)

--- a/tests/nn/test_outline_inputs.py
+++ b/tests/nn/test_outline_inputs.py
@@ -1,0 +1,63 @@
+"""``torchfont.nn`` operating on single and batched :class:`torchfont.Outline`."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from torchfont import COORD_DIM, TYPE_DIM, ElementType, Outline, pad_outlines
+from torchfont.nn import OutlineEmbedding, OutlineLoss
+from torchfont.nn import functional as F  # noqa: N812
+
+
+def _outline(length: int = 4) -> Outline:
+    types = torch.tensor(
+        [ElementType.MOVE_TO, ElementType.CURVE_TO, ElementType.CLOSE, ElementType.END],
+        dtype=torch.long,
+    )[:length]
+    return Outline(types, torch.rand(length, COORD_DIM))
+
+
+@pytest.fixture
+def batch() -> Outline:
+    return pad_outlines([_outline(), _outline(3)])
+
+
+def test_embedding_accepts_a_single_outline() -> None:
+    assert OutlineEmbedding(8)(_outline()).shape == (4, 8)
+
+
+def test_embedding_accepts_a_batched_outline(batch: Outline) -> None:
+    assert OutlineEmbedding(8)(batch).shape == (2, 4, 8)
+
+
+def test_loss_accepts_a_batched_outline(batch: Outline) -> None:
+    logits = torch.zeros(*batch.shape, TYPE_DIM)
+    prediction = torch.zeros(*batch.shape, COORD_DIM)
+
+    assert OutlineLoss()(logits, prediction, batch).ndim == 0
+
+
+def test_coordinate_loss_accepts_a_batched_outline(batch: Outline) -> None:
+    prediction = torch.zeros(*batch.shape, COORD_DIM)
+
+    assert F.coordinate_loss(prediction, batch).ndim == 0
+
+
+def test_loss_ignores_padding_introduced_by_pad_outlines() -> None:
+    single = _outline(3)
+    batch = pad_outlines([single, single])
+    padded_loss = OutlineLoss()(
+        torch.zeros(*batch.shape, TYPE_DIM),
+        torch.zeros(*batch.shape, COORD_DIM),
+        batch,
+    )
+
+    unpadded = pad_outlines([single])
+    unpadded_loss = OutlineLoss()(
+        torch.zeros(*unpadded.shape, TYPE_DIM),
+        torch.zeros(*unpadded.shape, COORD_DIM),
+        unpadded,
+    )
+
+    assert torch.allclose(padded_loss, unpadded_loss)

--- a/tests/test_core_types.py
+++ b/tests/test_core_types.py
@@ -1,8 +1,6 @@
-import math
-import pickle
-
 import pytest
 import torch
+from torch.utils import _pytree as pytree
 
 import torchfont
 from torchfont import (
@@ -14,7 +12,6 @@ from torchfont import (
     GlyphRef,
     GlyphSample,
     Outline,
-    VariationLocation,
 )
 
 
@@ -27,35 +24,6 @@ def test_core_types_are_exported_from_package_root() -> None:
     assert torchfont.GlyphRef is GlyphRef
     assert torchfont.GlyphSample is GlyphSample
     assert torchfont.Outline is Outline
-    assert torchfont.VariationLocation is VariationLocation
-
-
-def test_variation_location_is_order_independent_and_hashable() -> None:
-    first = VariationLocation({"wght": 700, "wdth": 75})
-    second = VariationLocation([("wdth", 75), ("wght", 700)])
-
-    assert first == second
-    assert first == {"wdth": 75.0, "wght": 700.0}
-    assert hash(first) == hash(second)
-    assert tuple(first) == ("wdth", "wght")
-
-
-def test_variation_location_is_immutable() -> None:
-    location = VariationLocation({"wght": 400})
-
-    with pytest.raises(TypeError):
-        location["wght"] = 700  # type: ignore[index]  # ty: ignore[invalid-assignment]
-
-
-def test_variation_location_rejects_duplicate_normalized_tags() -> None:
-    with pytest.raises(ValueError, match="duplicate variation axis tag 'wght'"):
-        VariationLocation([("wght", 400), ("wght", 700)])
-
-
-def test_variation_location_pickle_round_trip() -> None:
-    location = VariationLocation({"wght": 400})
-
-    assert pickle.loads(pickle.dumps(location)) == location  # noqa: S301
 
 
 def test_glyph_ref_identifies_face_and_codepoint() -> None:
@@ -70,7 +38,7 @@ def test_glyph_ref_identifies_face_and_codepoint() -> None:
         (
             torch.zeros((1, 1), dtype=torch.long),
             torch.zeros((1, 6)),
-            "types must be 1-D",
+            "exactly one more dimension",
         ),
         (
             torch.zeros(1, dtype=torch.long),
@@ -80,7 +48,12 @@ def test_glyph_ref_identifies_face_and_codepoint() -> None:
         (
             torch.zeros(1, dtype=torch.long),
             torch.zeros((2, 6)),
-            "same number of rows",
+            "types shape must match coords",
+        ),
+        (
+            torch.zeros((2, 3), dtype=torch.long),
+            torch.zeros((2, 4, 6)),
+            "types shape must match coords",
         ),
     ],
 )
@@ -96,7 +69,7 @@ def test_outline_rejects_incompatible_shapes(
 def test_outline_rejects_invalid_dtypes() -> None:
     with pytest.raises(TypeError, match=r"types must have dtype torch\.long"):
         Outline(torch.zeros(1), torch.zeros((1, 6)))
-    with pytest.raises(TypeError, match=r"coords must have dtype torch\.float32"):
+    with pytest.raises(TypeError, match="coords must have a floating point dtype"):
         Outline(
             torch.zeros(1, dtype=torch.long), torch.zeros((1, 6), dtype=torch.int64)
         )
@@ -110,37 +83,108 @@ def test_outline_rejects_mismatched_devices() -> None:
         )
 
 
-def test_semantic_containers_use_identity_equality() -> None:
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64]
+)
+def test_outline_accepts_any_floating_coords_dtype(dtype: torch.dtype) -> None:
+    outline = Outline(
+        torch.zeros(1, dtype=torch.long), torch.zeros((1, 6), dtype=dtype)
+    )
+
+    assert outline.dtype is dtype
+
+
+def test_outline_accepts_batch_dimensions() -> None:
+    outline = Outline(torch.zeros((4, 9), dtype=torch.long), torch.zeros((4, 9, 6)))
+
+    assert outline.is_batched
+    assert outline.shape == (4, 9)
+    assert outline.batch_shape == (4,)
+    assert outline.num_elements == 9
+    assert len(outline) == 4
+
+
+def test_outline_keeps_identity_equality() -> None:
     types = torch.tensor([1, 6], dtype=torch.long)
     coords = torch.zeros((2, 6))
     first = Outline(types, coords)
     second = Outline(types.clone(), coords.clone())
+    assert first is not second
+    assert first != second
+    assert hash(first) == object.__hash__(first)
+
+
+def test_glyph_data_keeps_identity_equality() -> None:
+    types = torch.tensor([1, 6], dtype=torch.long)
+    coords = torch.zeros((2, 6))
     sample = GlyphSample(GlyphRef(FontRef("font.ttf", 0), 0x41), 0, 0)
-    first_data = GlyphData(
-        first,
-        sample.ref,
-        VariationLocation(),
-        0,
-        0,
-        400.0,
-        100.0,
-        0.0,
-        0.0,
-        math.nan,
-    )
-    second_data = GlyphData(
-        second,
-        sample.ref,
-        VariationLocation(),
-        0,
-        0,
-        400.0,
-        100.0,
-        0.0,
-        0.0,
-        math.nan,
+
+    def build(outline: Outline) -> GlyphData[Outline]:
+        return GlyphData(
+            outline,
+            sample.ref,
+            {},
+            font_idx=0,
+            character_idx=0,
+            weight=400.0,
+            width=100.0,
+            italic=0.0,
+            slant=0.0,
+            optical_size=None,
+        )
+
+    first_data = build(Outline(types, coords))
+    second_data = build(Outline(types.clone(), coords.clone()))
+
+    assert first_data != second_data
+    assert hash(first_data) == object.__hash__(first_data)
+
+
+def test_glyph_data_targets_are_pytree_children() -> None:
+    ref = GlyphRef(FontRef("font.ttf", 0), 0x41)
+    location = {"wght": 400.0}
+    data = GlyphData(
+        torch.tensor([1.0]),
+        ref,
+        location,
+        font_idx=2,
+        character_idx=3,
+        weight=400.0,
+        width=None,
+        italic=0.0,
+        slant=None,
+        optical_size=12.0,
     )
 
-    assert first != second
-    assert first_data != second_data
-    assert hash(first) == object.__hash__(first)
+    leaves, spec = pytree.tree_flatten(data)
+    rebuilt = pytree.tree_unflatten(leaves, spec)
+
+    assert leaves[1:] == [2, 3, 400.0, None, 0.0, None, 12.0]
+    assert rebuilt.ref is ref
+    assert rebuilt.location is location
+    assert rebuilt.font_idx == 2
+    assert rebuilt.width is None
+
+
+def test_glyph_data_pytree_structure_does_not_depend_on_target_values() -> None:
+    ref = GlyphRef(FontRef("font.ttf", 0), 0x41)
+    location: dict[str, float] = {}
+
+    def make(weight: float | None) -> GlyphData[torch.Tensor]:
+        return GlyphData(
+            torch.tensor([1.0]),
+            ref,
+            location,
+            font_idx=0,
+            character_idx=0,
+            weight=weight,
+            width=None,
+            italic=None,
+            slant=None,
+            optical_size=None,
+        )
+
+    _, first_spec = pytree.tree_flatten(make(400.0))
+    _, second_spec = pytree.tree_flatten(make(None))
+
+    assert first_spec == second_spec

--- a/tests/test_outline_container.py
+++ b/tests/test_outline_container.py
@@ -1,0 +1,210 @@
+"""Tensor-like container behaviour of :class:`torchfont.Outline`."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.utils import _pytree as pytree
+
+from torchfont import ElementType, Outline, pad_outlines, unpad_outlines
+from torchfont.transforms import Affine
+
+
+@pytest.fixture
+def triangle() -> Outline:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO,
+            ElementType.LINE_TO,
+            ElementType.LINE_TO,
+            ElementType.CLOSE,
+            ElementType.END,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(5, 6)
+    coords[1, 4:] = torch.tensor([1.0, 0.0])
+    coords[2, 4:] = torch.tensor([0.5, 1.0])
+    return Outline(types, coords)
+
+
+def test_outline_exposes_tensor_metadata(triangle: Outline) -> None:
+    assert triangle.shape == (5,)
+    assert triangle.batch_shape == ()
+    assert triangle.num_elements == 5
+    assert not triangle.is_batched
+    assert triangle.dtype is torch.float32
+    assert triangle.device == torch.device("cpu")
+
+
+def test_to_casts_only_coords(triangle: Outline) -> None:
+    moved = triangle.to(torch.float64)
+
+    assert moved.dtype is torch.float64
+    assert moved.types.dtype is torch.long
+    assert torch.equal(moved.types, triangle.types)
+
+
+def test_to_accepts_device_and_dtype_together(triangle: Outline) -> None:
+    moved = triangle.to("cpu", torch.float64)
+
+    assert moved.device == torch.device("cpu")
+    assert moved.dtype is torch.float64
+
+
+def test_to_rejects_a_non_floating_dtype(triangle: Outline) -> None:
+    with pytest.raises(TypeError, match="dtype must be floating point"):
+        triangle.to(torch.int32)
+
+
+def test_to_rejects_a_duplicated_dtype(triangle: Outline) -> None:
+    with pytest.raises(TypeError, match="both positionally and by keyword"):
+        triangle.to(torch.float64, torch.float64)
+
+
+def test_outline_is_a_pytree_leaf(triangle: Outline) -> None:
+    leaves, _ = pytree.tree_flatten(triangle)
+
+    assert leaves == [triangle]
+
+
+def test_tree_map_moves_an_outline(triangle: Outline) -> None:
+    moved = pytree.tree_map(lambda leaf: leaf.to(torch.float64), triangle)
+
+    assert moved.dtype is torch.float64
+
+
+def test_registering_outline_as_a_pytree_node_would_break_transforms(
+    triangle: Outline,
+) -> None:
+    """Guard the reason ``Outline`` must stay a leaf.
+
+    ``Transform`` selects work with ``isinstance(leaf, Outline)`` after
+    ``tree_flatten``. If ``Outline`` decomposed into bare tensors, nothing would
+    match and every transform would silently return its input.
+    """
+    flipped = Affine(angle=10.0)(triangle)
+
+    assert not torch.equal(flipped.coords, triangle.coords)
+    assert pytree.tree_flatten(triangle)[0] == [triangle]
+
+
+def test_padding_mask_marks_padding(triangle: Outline) -> None:
+    batch = pad_outlines([triangle, triangle[:3]])
+
+    assert batch.padding_mask.tolist() == [
+        [False] * 5,
+        [False, False, False, True, True],
+    ]
+
+
+def test_indexing_keeps_the_coordinate_axis(triangle: Outline) -> None:
+    head = triangle[:2]
+
+    assert head.shape == (2,)
+    assert head.coords.shape == (2, 6)
+
+
+def test_indexing_with_ellipsis_keeps_the_coordinate_axis() -> None:
+    outline = Outline(
+        torch.ones(2, 3, 4, dtype=torch.long),
+        torch.zeros(2, 3, 4, 6),
+    )
+
+    result = outline[..., :2]
+
+    assert result.shape == (2, 3, 2)
+    assert result.coords.shape == (2, 3, 2, 6)
+
+
+def test_indexing_rejects_removing_the_element_dimension(triangle: Outline) -> None:
+    with pytest.raises(IndexError, match="preserve the outline element dimension"):
+        triangle[0]
+
+
+def test_pad_outlines_stacks_to_the_longest(triangle: Outline) -> None:
+    batch = pad_outlines([triangle, triangle[:2], triangle[:4]])
+
+    assert batch.shape == (3, 5)
+    assert batch.coords.shape == (3, 5, 6)
+    assert batch.is_batched
+    assert len(batch) == 3
+
+
+def test_pad_outlines_then_unpad_round_trips(triangle: Outline) -> None:
+    parts = [triangle, triangle[:2], triangle[:4]]
+    restored = unpad_outlines(pad_outlines(parts))
+
+    assert len(restored) == len(parts)
+    for actual, expected in zip(restored, parts, strict=True):
+        assert torch.equal(actual.types, expected.types)
+        assert torch.equal(actual.coords, expected.coords)
+
+
+def test_unbind_preserves_padding(triangle: Outline) -> None:
+    batch = pad_outlines([triangle, triangle[:2]])
+
+    assert [part.shape for part in batch.unbind()] == [(5,), (5,)]
+
+
+def test_unbind_multidimensional_batch_keeps_padding() -> None:
+    outline = Outline(
+        torch.ones(2, 3, 4, dtype=torch.long),
+        torch.zeros(2, 3, 4, 6),
+    )
+
+    parts = outline.unbind()
+
+    assert [part.shape for part in parts] == [(3, 4), (3, 4)]
+
+
+def test_unbind_rejects_a_single_outline(triangle: Outline) -> None:
+    with pytest.raises(ValueError, match="unbind requires a batched outline"):
+        triangle.unbind()
+
+
+def test_unpad_outlines_rejects_a_single_outline(triangle: Outline) -> None:
+    with pytest.raises(ValueError, match="requires exactly one batch dimension"):
+        unpad_outlines(triangle)
+
+
+def test_unpad_outlines_rejects_a_multidimensional_batch() -> None:
+    outline = Outline(
+        torch.ones(2, 3, 4, dtype=torch.long),
+        torch.zeros(2, 3, 4, 6),
+    )
+
+    with pytest.raises(ValueError, match="requires exactly one batch dimension"):
+        unpad_outlines(outline)
+
+
+def test_pad_outlines_rejects_an_empty_sequence() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        pad_outlines([])
+
+
+def test_pad_outlines_rejects_a_batched_input(triangle: Outline) -> None:
+    """The copy into the padded tensor raises on a shape mismatch."""
+    batch = pad_outlines([triangle, triangle])
+
+    with pytest.raises(RuntimeError):
+        pad_outlines([batch])
+
+
+def test_pad_outlines_rejects_mixed_dtypes(triangle: Outline) -> None:
+    """Unlike a shape or device mismatch, a dtype mismatch would cast silently."""
+    with pytest.raises(ValueError, match="share one coords dtype"):
+        pad_outlines([triangle, triangle.to(torch.float64)])
+
+
+def test_outline_aliases_its_tensors(triangle: Outline) -> None:
+    """``frozen=True`` blocks rebinding attributes, not mutating the tensors."""
+    triangle.coords[0, 4] = 5.0
+
+    assert triangle.coords[0, 4] == 5.0
+    with pytest.raises(AttributeError):
+        triangle.types = triangle.types  # ty: ignore[invalid-assignment]
+
+
+def test_repr_summarises_instead_of_dumping_tensors(triangle: Outline) -> None:
+    assert repr(triangle) == ("Outline(shape=(5,), dtype=torch.float32, device=cpu)")

--- a/tests/transforms/curves/test_cubic_to_quad.py
+++ b/tests/transforms/curves/test_cubic_to_quad.py
@@ -3,16 +3,8 @@ import math
 import pytest
 import torch
 
+from tests._pairs import cubic_to_quad, merge_curves, quad_to_cubic
 from torchfont import ElementType
-from torchfont.transforms.functional._curves import (
-    _cubic_to_quad as cubic_to_quad,
-)
-from torchfont.transforms.functional._curves import (
-    _merge_curves as merge_curves,
-)
-from torchfont.transforms.functional._curves import (
-    _quad_to_cubic as quad_to_cubic,
-)
 
 from ._helpers import (
     _CUBIC_CURVES,

--- a/tests/transforms/curves/test_merge_curves.py
+++ b/tests/transforms/curves/test_merge_curves.py
@@ -3,13 +3,8 @@ from collections.abc import Callable
 import pytest
 import torch
 
+from tests._pairs import cubic_to_quad, merge_curves
 from torchfont import ElementType
-from torchfont.transforms.functional._curves import (
-    _cubic_to_quad as cubic_to_quad,
-)
-from torchfont.transforms.functional._curves import (
-    _merge_curves as merge_curves,
-)
 
 from ._helpers import (
     _CUBIC_CURVES,
@@ -228,7 +223,7 @@ def test_variable_length_transforms_reject_mismatched_coords(
     )
     coords = torch.zeros(1, 6, dtype=torch.float32)
 
-    with pytest.raises(ValueError, match="coords length"):
+    with pytest.raises(ValueError, match="types shape must match coords"):
         transform(types, coords)
 
 

--- a/tests/transforms/curves/test_quad_to_cubic.py
+++ b/tests/transforms/curves/test_quad_to_cubic.py
@@ -1,13 +1,8 @@
 import pytest
 import torch
 
+from tests._pairs import cubic_to_quad, quad_to_cubic
 from torchfont import ElementType
-from torchfont.transforms.functional._curves import (
-    _cubic_to_quad as cubic_to_quad,
-)
-from torchfont.transforms.functional._curves import (
-    _quad_to_cubic as quad_to_cubic,
-)
 
 from ._helpers import (
     _CUBIC_CURVES,
@@ -103,7 +98,7 @@ def test_quad_to_cubic_rejects_mismatched_coords() -> None:
     )
     coords = torch.zeros(2, 6, dtype=torch.float32)
 
-    with pytest.raises(ValueError, match="coords length"):
+    with pytest.raises(ValueError, match="types shape must match coords"):
         quad_to_cubic(types, coords)
 
 
@@ -128,12 +123,10 @@ def test_quad_to_cubic_merge_curves_runs_even_without_quadratics() -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_quad_to_cubic_preserves_cuda_device(
+def test_quad_to_cubic_rejects_cuda_input(
     quad_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = (tensor.cuda() for tensor in quad_outline)
 
-    out_types, out_coords = quad_to_cubic(types, coords)
-
-    assert out_types.device.type == "cuda"
-    assert out_coords.device.type == "cuda"
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        quad_to_cubic(types, coords)

--- a/tests/transforms/geometric/test_affine.py
+++ b/tests/transforms/geometric/test_affine.py
@@ -98,7 +98,9 @@ def test_affine_quad_pair1_stays_zero(
     assert out[quad_idx, 3].item() == pytest.approx(0.0)
 
 
-@pytest.mark.parametrize("scale", [0.0, float("nan"), float("inf")])
+@pytest.mark.parametrize(
+    "scale", [0.0, -1.0, float("nan"), float("inf"), float("-inf")]
+)
 def test_affine_invalid_scale_raises(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
     scale: float,
@@ -126,7 +128,12 @@ def test_affine_rejects_nan_shear(
 
 @pytest.mark.parametrize(
     "translate",
-    [(float("nan"), 0.0), (0.0, float("inf"))],
+    [
+        (float("nan"), 0.0),
+        (0.0, float("nan")),
+        (0.0, float("inf")),
+        (float("-inf"), 0.0),
+    ],
 )
 def test_affine_rejects_non_finite_translate(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
@@ -138,12 +145,10 @@ def test_affine_rejects_non_finite_translate(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_affine_preserves_cuda_device(
+def test_affine_rejects_cuda_input(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = (tensor.cuda() for tensor in simple_outline)
 
-    out_types, out_coords = affine(types, coords, angle=15.0)
-
-    assert out_types.device.type == "cuda"
-    assert out_coords.device.type == "cuda"
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        affine(types, coords, angle=15.0)

--- a/tests/transforms/geometric/test_horizontal_flip.py
+++ b/tests/transforms/geometric/test_horizontal_flip.py
@@ -123,12 +123,10 @@ def test_horizontal_flip_does_not_reverse_open_subpaths(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_horizontal_flip_preserves_cuda_device(
+def test_horizontal_flip_rejects_cuda_input(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = (tensor.cuda() for tensor in simple_outline)
 
-    out_types, out_coords = horizontal_flip(types, coords)
-
-    assert out_types.device.type == "cuda"
-    assert out_coords.device.type == "cuda"
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        horizontal_flip(types, coords)

--- a/tests/transforms/geometric/test_random_affine.py
+++ b/tests/transforms/geometric/test_random_affine.py
@@ -59,11 +59,10 @@ def test_random_affine_rejects_non_pair_ranges(name: str) -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_random_affine_preserves_cuda_device(
+def test_random_affine_rejects_cuda_input(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
-    output = RandomAffine(degrees=45.0)(
-        Outline(*(tensor.cuda() for tensor in simple_outline))
-    )
-    assert output.types.device.type == "cuda"
-    assert output.coords.device.type == "cuda"
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        RandomAffine(degrees=45.0)(
+            Outline(*(tensor.cuda() for tensor in simple_outline))
+        )

--- a/tests/transforms/geometric/test_random_horizontal_flip.py
+++ b/tests/transforms/geometric/test_random_horizontal_flip.py
@@ -30,11 +30,10 @@ def test_random_horizontal_flip_rejects_invalid_probability(p: float) -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_random_horizontal_flip_preserves_cuda_device(
+def test_random_horizontal_flip_rejects_cuda_input(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
-    output = RandomHorizontalFlip(1.0)(
-        Outline(*(tensor.cuda() for tensor in simple_outline))
-    )
-    assert output.types.device.type == "cuda"
-    assert output.coords.device.type == "cuda"
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        RandomHorizontalFlip(1.0)(
+            Outline(*(tensor.cuda() for tensor in simple_outline))
+        )

--- a/tests/transforms/geometric/test_random_vertical_flip.py
+++ b/tests/transforms/geometric/test_random_vertical_flip.py
@@ -15,11 +15,8 @@ def test_random_vertical_flip_probability_boundaries(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_random_vertical_flip_preserves_cuda_device(
+def test_random_vertical_flip_rejects_cuda_input(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
-    output = RandomVerticalFlip(1.0)(
-        Outline(*(tensor.cuda() for tensor in simple_outline))
-    )
-    assert output.types.device.type == "cuda"
-    assert output.coords.device.type == "cuda"
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        RandomVerticalFlip(1.0)(Outline(*(tensor.cuda() for tensor in simple_outline)))

--- a/tests/transforms/geometric/test_vertical_flip.py
+++ b/tests/transforms/geometric/test_vertical_flip.py
@@ -72,12 +72,10 @@ def test_vertical_flip_can_leave_reflected_winding(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_vertical_flip_preserves_cuda_device(
+def test_vertical_flip_rejects_cuda_input(
     simple_outline: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = (tensor.cuda() for tensor in simple_outline)
 
-    out_types, out_coords = vertical_flip(types, coords)
-
-    assert out_types.device.type == "cuda"
-    assert out_coords.device.type == "cuda"
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        vertical_flip(types, coords)

--- a/tests/transforms/outline/test_remove_overlaps.py
+++ b/tests/transforms/outline/test_remove_overlaps.py
@@ -1,7 +1,7 @@
 import torch
 
+from tests._pairs import remove_overlaps
 from torchfont import ElementType
-from torchfont.transforms.functional._outline import _remove_overlaps as remove_overlaps
 
 
 def test_remove_overlaps_merges_overlapping_subpaths() -> None:

--- a/tests/transforms/subpath/test_normalize_subpath_start_points.py
+++ b/tests/transforms/subpath/test_normalize_subpath_start_points.py
@@ -1,9 +1,7 @@
 import torch
 
+from tests._pairs import normalize_subpath_start_points
 from torchfont import ElementType
-from torchfont.transforms.functional._subpath import (
-    _normalize_subpath_start_points as normalize_subpath_start_points,
-)
 
 
 def test_normalize_subpath_start_points_uses_smallest_endpoint(

--- a/tests/transforms/subpath/test_randomize_subpath_start_points.py
+++ b/tests/transforms/subpath/test_randomize_subpath_start_points.py
@@ -43,12 +43,9 @@ def test_randomize_subpath_start_points_leaves_open_subpaths_unchanged(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_randomize_subpath_start_points_accepts_cpu_generator_for_cuda_input(
+def test_randomize_subpath_start_points_rejects_cuda_input(
     square: tuple[torch.Tensor, torch.Tensor],
 ) -> None:
     types, coords = (tensor.cuda() for tensor in square)
-    output = RandomizeSubpathStartPoints()(Outline(types, coords))
-    out_types, out_coords = output.types, output.coords
-
-    assert out_types.device.type == "cuda"
-    assert out_coords.device.type == "cuda"
+    with pytest.raises(NotImplementedError, match="CUDA"):
+        RandomizeSubpathStartPoints()(Outline(types, coords))

--- a/tests/transforms/test_autograd.py
+++ b/tests/transforms/test_autograd.py
@@ -1,0 +1,122 @@
+"""Which functional kernels carry gradients, and how the rest fail."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import torch
+
+from torchfont import ElementType, Outline, pad_outlines
+from torchfont.transforms import functional as F  # noqa: N812
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _curved() -> Outline:
+    types = torch.tensor(
+        [
+            ElementType.MOVE_TO,
+            ElementType.CURVE_TO,
+            ElementType.LINE_TO,
+            ElementType.CLOSE,
+            ElementType.END,
+        ],
+        dtype=torch.long,
+    )
+    coords = torch.zeros(5, 6)
+    coords[1] = torch.tensor([0.1, 0.9, 0.6, 0.9, 1.0, 0.2])
+    coords[2, 4:] = torch.tensor([0.4, 0.7])
+    return Outline(types, coords)
+
+
+def _grad_outline() -> tuple[Outline, torch.Tensor]:
+    outline = _curved()
+    coords = outline.coords.clone()
+    coords.requires_grad_()
+    return Outline(outline.types, coords), coords
+
+
+def test_affine_is_differentiable() -> None:
+    outline, coords = _grad_outline()
+
+    F.affine(
+        outline, angle=10.0, scale=1.2, translate=(0.1, 0.0)
+    ).coords.sum().backward()
+
+    assert coords.grad is not None
+    assert coords.grad.abs().sum() > 0
+
+
+def test_affine_does_not_backpropagate_through_the_bbox_centre() -> None:
+    """The pivot is a reference frame, so a pure translation has unit gradient."""
+    outline, coords = _grad_outline()
+
+    F.affine(outline, translate=(0.25, 0.0)).coords.sum().backward()
+
+    active = F.affine(outline, translate=(0.25, 0.0)).coords != 0
+    assert coords.grad is not None
+    assert torch.equal(coords.grad[active.detach()], torch.ones(int(active.sum())))
+
+
+def test_coord_jitter_is_differentiable_in_both_arguments() -> None:
+    outline, coords = _grad_outline()
+    noise = torch.zeros(5, 3, 2, requires_grad=True)
+
+    F.coord_jitter(outline, noise).coords.sum().backward()
+
+    assert coords.grad is not None
+    assert noise.grad is not None
+
+
+def test_flip_without_winding_preservation_is_differentiable() -> None:
+    outline, coords = _grad_outline()
+
+    F.horizontal_flip(outline, preserve_winding=False).coords.sum().backward()
+
+    assert coords.grad is not None
+
+
+@pytest.mark.parametrize(
+    ("name", "call"),
+    [
+        ("cubic_to_quad", F.cubic_to_quad),
+        ("quad_to_cubic", F.quad_to_cubic),
+        ("merge_curves", F.merge_curves),
+        ("remove_overlaps", F.remove_overlaps),
+        ("render_bitmap", F.render_bitmap),
+        ("normalize_subpath_start_points", F.normalize_subpath_start_points),
+        ("horizontal_flip", F.horizontal_flip),
+        ("vertical_flip", F.vertical_flip),
+    ],
+)
+def test_rust_kernels_name_themselves_when_grad_is_required(
+    name: str, call: Callable[[Outline], object]
+) -> None:
+    outline, _ = _grad_outline()
+
+    with pytest.raises(RuntimeError, match=f"{name}.*is not differentiable"):
+        call(outline)
+
+
+@pytest.mark.parametrize(
+    ("name", "call"),
+    [
+        ("affine", lambda outline: F.affine(outline, angle=5.0)),
+        ("cubic_to_quad", F.cubic_to_quad),
+        ("remove_overlaps", F.remove_overlaps),
+        ("render_bitmap", F.render_bitmap),
+        (
+            "coord_jitter",
+            lambda outline: F.coord_jitter(outline, torch.zeros(5, 3, 2)),
+        ),
+    ],
+)
+def test_kernels_reject_a_batched_outline(
+    name: str, call: Callable[[Outline], object]
+) -> None:
+    batch = pad_outlines([_curved(), _curved()])
+
+    with pytest.raises(ValueError, match=f"{name} operates on a single outline"):
+        call(batch)

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 import torch
 from torch.library import CustomOpDef, opcheck
@@ -9,6 +11,16 @@ from torch.library import CustomOpDef, opcheck
 import torchfont._ops as ops
 from torchfont import ElementType, Outline
 from torchfont.transforms import functional as F  # noqa: N812
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _capture_dynamic_output_shapes() -> Iterator[None]:
+    """Enable data-dependent custom-op outputs on every supported PyTorch."""
+    with torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True):  # noqa: SLF001
+        yield
 
 
 def _outline(elements: int = 5) -> Outline:

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,7 +14,7 @@ from torchfont import ElementType, Outline
 from torchfont.transforms import functional as F  # noqa: N812
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 
 @pytest.fixture(autouse=True)
@@ -42,6 +43,13 @@ def _pipeline(types: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
     outline = F.affine(outline, angle=10.0, scale=1.1)
     outline = F.normalize_subpath_start_points(outline)
     return F.render_bitmap(outline, 32)
+
+
+def _compile_pipeline(
+    *, dynamic: bool | None = None
+) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
+    backend = "eager" if sys.platform == "win32" else "inductor"
+    return torch.compile(_pipeline, fullgraph=True, dynamic=dynamic, backend=backend)
 
 
 def _cases() -> list[tuple[str, CustomOpDef, tuple[object, ...]]]:
@@ -105,7 +113,7 @@ def test_pipeline_compiles_into_one_graph() -> None:
 def test_compiled_pipeline_matches_eager() -> None:
     torch._dynamo.reset()  # noqa: SLF001
     outline = _outline()
-    compiled = torch.compile(_pipeline, fullgraph=True)
+    compiled = _compile_pipeline()
 
     result = compiled(outline.types, outline.coords)
 
@@ -116,7 +124,7 @@ def test_compiled_pipeline_matches_eager() -> None:
 def test_compiled_pipeline_handles_varying_element_counts(elements: int) -> None:
     """Outline length is data-dependent, so the fakes must allow it to vary."""
     outline = _outline(elements)
-    compiled = torch.compile(_pipeline, fullgraph=True)
+    compiled = _compile_pipeline()
 
     result = compiled(outline.types, outline.coords)
 
@@ -130,7 +138,7 @@ def test_pipeline_compiles_under_every_dynamic_setting(
     """``dynamic=True`` makes float parameters symbolic, so validation must trace."""
     torch._dynamo.reset()  # noqa: SLF001
     outline = _outline()
-    compiled = torch.compile(_pipeline, fullgraph=True, dynamic=dynamic)
+    compiled = _compile_pipeline(dynamic=dynamic)
 
     result = compiled(outline.types, outline.coords)
 

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -1,0 +1,166 @@
+"""Rust kernels as custom operators: operator contracts and graph capture."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.library import CustomOpDef, opcheck
+
+import torchfont._ops as ops
+from torchfont import ElementType, Outline
+from torchfont.transforms import functional as F  # noqa: N812
+
+
+def _outline(elements: int = 5) -> Outline:
+    types = torch.tensor(
+        [ElementType.MOVE_TO]
+        + [ElementType.CURVE_TO] * (elements - 3)
+        + [ElementType.CLOSE, ElementType.END],
+        dtype=torch.long,
+    )
+    generator = torch.Generator().manual_seed(elements)
+    return Outline(types, torch.rand(elements, 6, generator=generator) * 0.8)
+
+
+def _pipeline(types: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+    outline = Outline(types, coords)
+    outline = F.remove_overlaps(outline)
+    outline = F.cubic_to_quad(outline)
+    outline = F.merge_curves(outline)
+    outline = F.affine(outline, angle=10.0, scale=1.1)
+    outline = F.normalize_subpath_start_points(outline)
+    return F.render_bitmap(outline, 32)
+
+
+def _cases() -> list[tuple[str, CustomOpDef, tuple[object, ...]]]:
+    outline = _outline()
+    pair = (outline.types, outline.coords)
+    values = torch.rand(16, generator=torch.Generator().manual_seed(0))
+    return [
+        ("remove_overlaps", ops.remove_overlaps, pair),
+        ("cubic_to_quad", ops.cubic_to_quad, pair),
+        ("merge_curves", ops.merge_curves, pair),
+        ("quad_to_cubic", ops.quad_to_cubic, (*pair, False)),
+        ("quad_to_cubic_merged", ops.quad_to_cubic, (*pair, True)),
+        (
+            "normalize_subpath_start_points",
+            ops.normalize_subpath_start_points,
+            pair,
+        ),
+        ("reverse_closed_subpaths", ops.reverse_closed_subpaths, pair),
+        ("bbox_center", ops.bbox_center, pair),
+        ("set_subpath_start_points", ops.set_subpath_start_points, (*pair, values)),
+        ("reorder_subpaths", ops.reorder_subpaths, (*pair, values)),
+        ("remove_overlap_groups", ops.remove_overlap_groups, (*pair, values)),
+        (
+            "split_segments",
+            ops.split_segments,
+            (*pair, values, values, 0.5, [0.3, 0.7]),
+        ),
+        (
+            "render_bitmap",
+            ops.render_bitmap,
+            (*pair, 32, "bbox_square", "winding", True),
+        ),
+        (
+            "render_bitmap_bbox",
+            ops.render_bitmap,
+            (*pair, 32, "bbox", "winding", True),
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("name", "op", "args"), _cases(), ids=[case[0] for case in _cases()]
+)
+def test_operator_passes_opcheck(
+    name: str, op: CustomOpDef, args: tuple[object, ...]
+) -> None:
+    """Check schema, fake implementation, and autograd registration agree."""
+    del name
+    opcheck(op, args)
+
+
+def test_pipeline_compiles_into_one_graph() -> None:
+    explanation = torch._dynamo.explain(_pipeline)(  # noqa: SLF001
+        _outline().types, _outline().coords
+    )
+
+    assert explanation.graph_break_count == 0
+    assert explanation.graph_count == 1
+
+
+def test_compiled_pipeline_matches_eager() -> None:
+    torch._dynamo.reset()  # noqa: SLF001
+    outline = _outline()
+    compiled = torch.compile(_pipeline, fullgraph=True)
+
+    result = compiled(outline.types, outline.coords)
+
+    assert torch.equal(result, _pipeline(outline.types, outline.coords))
+
+
+@pytest.mark.parametrize("elements", [5, 9, 17, 33])
+def test_compiled_pipeline_handles_varying_element_counts(elements: int) -> None:
+    """Outline length is data-dependent, so the fakes must allow it to vary."""
+    outline = _outline(elements)
+    compiled = torch.compile(_pipeline, fullgraph=True)
+
+    result = compiled(outline.types, outline.coords)
+
+    assert torch.equal(result, _pipeline(outline.types, outline.coords))
+
+
+@pytest.mark.parametrize("dynamic", [None, True, False], ids=["auto", "on", "off"])
+def test_pipeline_compiles_under_every_dynamic_setting(
+    dynamic: bool | None,  # noqa: FBT001
+) -> None:
+    """``dynamic=True`` makes float parameters symbolic, so validation must trace."""
+    torch._dynamo.reset()  # noqa: SLF001
+    outline = _outline()
+    compiled = torch.compile(_pipeline, fullgraph=True, dynamic=dynamic)
+
+    result = compiled(outline.types, outline.coords)
+
+    assert torch.equal(result, _pipeline(outline.types, outline.coords))
+
+
+def test_bbox_center_shifts_with_the_outline() -> None:
+    outline = _outline()
+    shift = (0.25, -0.5)
+
+    center = ops.bbox_center(outline.types, outline.coords)
+    moved = F.affine(outline, translate=shift)
+    moved_center = ops.bbox_center(moved.types, moved.coords)
+
+    assert center.shape == (2,)
+    assert torch.allclose(moved_center, center + torch.tensor(shift), atol=1e-6)
+
+
+def test_bbox_center_of_an_empty_outline_is_the_origin() -> None:
+    empty = Outline(
+        torch.tensor([ElementType.END], dtype=torch.long), torch.zeros(1, 6)
+    )
+
+    assert torch.equal(ops.bbox_center(empty.types, empty.coords), torch.zeros(2))
+
+
+def test_native_operators_accept_float32() -> None:
+    dtype = torch.float32
+    outline = _outline().to(dtype)
+
+    converted = F.quad_to_cubic(outline)
+    transformed = F.affine(outline, angle=10.0)
+    bitmap = F.render_bitmap(outline, 32)
+
+    assert converted.dtype is dtype
+    assert transformed.dtype is dtype
+    assert bitmap.dtype is torch.uint8
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float64])
+def test_native_operators_reject_unsupported_dtypes(dtype: torch.dtype) -> None:
+    outline = _outline().to(dtype)
+
+    with pytest.raises(TypeError, match=r"coords must have dtype torch\.float32"):
+        F.quad_to_cubic(outline)

--- a/tests/transforms/test_transform.py
+++ b/tests/transforms/test_transform.py
@@ -1,4 +1,3 @@
-import math
 import pickle
 
 import pytest
@@ -255,7 +254,7 @@ def test_load_and_outline_transforms_preserve_glyph_metadata() -> None:
     assert output.width == 100.0
     assert output.italic == 0.0
     assert output.slant == 0.0
-    assert math.isnan(output.optical_size)
+    assert output.optical_size is None
     assert output.location == {}
 
 

--- a/torchfont/__init__.py
+++ b/torchfont/__init__.py
@@ -29,9 +29,16 @@ Package Layout:
 
 """
 
-from torchfont._font import FontRef, VariationLocation
+from torchfont._font import FontRef
 from torchfont._glyph import GlyphData, GlyphRef, GlyphSample
-from torchfont._outline import COORD_DIM, TYPE_DIM, ElementType, Outline
+from torchfont._outline import (
+    COORD_DIM,
+    TYPE_DIM,
+    ElementType,
+    Outline,
+    pad_outlines,
+    unpad_outlines,
+)
 
 from . import datasets, glyphsets, nn, transforms
 
@@ -44,9 +51,10 @@ __all__ = [
     "GlyphRef",
     "GlyphSample",
     "Outline",
-    "VariationLocation",
     "datasets",
     "glyphsets",
     "nn",
+    "pad_outlines",
     "transforms",
+    "unpad_outlines",
 ]

--- a/torchfont/_font.py
+++ b/torchfont/_font.py
@@ -1,61 +1,14 @@
-"""Persistent font references and variation locations."""
+"""Persistent font references."""
 
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from os import PathLike
-
-
-@dataclass(frozen=True, eq=False)
-class VariationLocation(Mapping[str, float]):
-    """An immutable, deterministic mapping of OpenType axis tags to values."""
-
-    _items: tuple[tuple[str, float], ...]
-
-    def __init__(
-        self,
-        values: Mapping[str, float] | Iterable[tuple[str, float]] = (),
-    ) -> None:
-        items = (
-            cast("Mapping[str, float]", values).items()
-            if isinstance(values, Mapping)
-            else values
-        )
-        normalized_values: dict[str, float] = {}
-        for raw_tag, raw_value in items:
-            tag = str(raw_tag)
-            if tag in normalized_values:
-                msg = f"duplicate variation axis tag {tag!r}"
-                raise ValueError(msg)
-            normalized_values[tag] = float(raw_value)
-        normalized = tuple(sorted(normalized_values.items()))
-        object.__setattr__(self, "_items", normalized)
-
-    def __getitem__(self, tag: str) -> float:
-        for candidate, value in self._items:
-            if candidate == tag:
-                return value
-        raise KeyError(tag)
-
-    def __iter__(self) -> Iterator[str]:
-        return (tag for tag, _value in self._items)
-
-    def __len__(self) -> int:
-        return len(self._items)
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Mapping):
-            return NotImplemented
-        return dict(self.items()) == dict(other.items())
-
-    def __hash__(self) -> int:
-        return hash(self._items)
 
 
 @dataclass(frozen=True)
@@ -70,4 +23,4 @@ class FontRef:
         object.__setattr__(self, "ttc_index", ttc_index)
 
 
-__all__ = ["FontRef", "VariationLocation"]
+__all__ = ["FontRef"]

--- a/torchfont/_glyph.py
+++ b/torchfont/_glyph.py
@@ -2,17 +2,38 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar
 
 from torch.utils._pytree import register_pytree_node
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from torchfont._font import FontRef, VariationLocation
+    from torchfont._font import FontRef
 
 T = TypeVar("T")
+
+_TARGET_FIELDS = (
+    "font_idx",
+    "character_idx",
+    "weight",
+    "width",
+    "italic",
+    "slant",
+    "optical_size",
+)
+
+
+class _GlyphDataTargets(TypedDict):
+    font_idx: int
+    character_idx: int
+    weight: float | None
+    width: float | None
+    italic: float | None
+    slant: float | None
+    optical_size: float | None
 
 
 @dataclass(frozen=True)
@@ -34,42 +55,73 @@ class GlyphSample:
 
 @dataclass(frozen=True, eq=False)
 class GlyphData(Generic[T]):
-    """A loaded glyph payload together with its reference and targets."""
+    """A loaded glyph payload together with its reference and targets.
+
+    Indices are Python integers and continuous targets are floats. An unavailable
+    continuous target is ``None``.
+
+    ``ref`` and ``location`` are metadata that no tensor can represent. Targets
+    remain pytree children so their values do not become part of its structure.
+    """
 
     data: T
     ref: GlyphRef
-    location: VariationLocation
+    location: dict[str, float]
     font_idx: int
     character_idx: int
-    weight: float
-    width: float
-    italic: float
-    slant: float
-    optical_size: float
+    weight: float | None
+    width: float | None
+    italic: float | None
+    slant: float | None
+    optical_size: float | None
 
 
 def _flatten_glyph_data(value: GlyphData[Any]) -> tuple[list[Any], object]:
-    return [value.data], (
-        value.ref,
-        value.location,
-        value.font_idx,
-        value.character_idx,
-        value.weight,
-        value.width,
-        value.italic,
-        value.slant,
-        value.optical_size,
-    )
+    children = [value.data, *(getattr(value, name) for name in _TARGET_FIELDS)]
+    return children, (value.ref, value.location)
 
 
 def _unflatten_glyph_data(
     children: Iterable[Any], context: tuple[Any, ...]
 ) -> GlyphData[Any]:
-    (data,) = children
-    return GlyphData(data, *context)
+    data, *targets = children
+    ref, location = context
+    return GlyphData(data, ref, location, *targets)
 
 
 register_pytree_node(GlyphData, _flatten_glyph_data, _unflatten_glyph_data)
 
 
-__all__ = ["GlyphData", "GlyphRef", "GlyphSample"]
+def _glyph_data_targets(
+    *,
+    font_idx: int,
+    character_idx: int,
+    metrics: tuple[float, float, float, float, float],
+) -> _GlyphDataTargets:
+    """Build the scalar targets carried by :class:`GlyphData`.
+
+    ``metrics`` is the ``(weight, width, italic, slant, optical_size)`` tuple
+    returned by the Rust ``glyph_targets`` helper, in that order.
+    """
+    weight, width, italic, slant, optical_size = metrics
+    return {
+        "font_idx": font_idx,
+        "character_idx": character_idx,
+        "weight": _optional_metric(weight),
+        "width": _optional_metric(width),
+        "italic": _optional_metric(italic),
+        "slant": _optional_metric(slant),
+        "optical_size": _optional_metric(optical_size),
+    }
+
+
+def _optional_metric(value: float) -> float | None:
+    """Represent an unavailable native metric explicitly at the Python boundary."""
+    return None if math.isnan(value) else value
+
+
+__all__ = [
+    "GlyphData",
+    "GlyphRef",
+    "GlyphSample",
+]

--- a/torchfont/_ops.py
+++ b/torchfont/_ops.py
@@ -81,10 +81,7 @@ def _selection(values: Tensor) -> np.ndarray:
 
 
 @torch.library.custom_op(
-    "torchfont::quad_to_cubic",
-    mutates_args=(),
-    device_types="cpu",
-    schema="(Tensor types, Tensor coords, bool merge_curves) -> (Tensor, Tensor)",
+    "torchfont::quad_to_cubic", mutates_args=(), device_types="cpu"
 )
 def quad_to_cubic(
     types: Tensor, coords: Tensor, merge_curves: bool
@@ -102,10 +99,7 @@ def _(types: Tensor, coords: Tensor, merge_curves: bool) -> tuple[Tensor, Tensor
 
 
 @torch.library.custom_op(
-    "torchfont::cubic_to_quad",
-    mutates_args=(),
-    device_types="cpu",
-    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
+    "torchfont::cubic_to_quad", mutates_args=(), device_types="cpu"
 )
 def cubic_to_quad(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Convert cubic segments to sequences of quadratic segments."""
@@ -118,12 +112,7 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     return _dynamic_outline(types, coords)
 
 
-@torch.library.custom_op(
-    "torchfont::merge_curves",
-    mutates_args=(),
-    device_types="cpu",
-    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
-)
+@torch.library.custom_op("torchfont::merge_curves", mutates_args=(), device_types="cpu")
 def merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Merge adjacent pieces of the same parent curve or line."""
     out = _torchfont.merge_curves(*_arrays(types, coords))
@@ -183,10 +172,7 @@ def _(
 
 
 @torch.library.custom_op(
-    "torchfont::remove_overlaps",
-    mutates_args=(),
-    device_types="cpu",
-    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
+    "torchfont::remove_overlaps", mutates_args=(), device_types="cpu"
 )
 def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Merge overlapping subpaths with Skia PathOps winding simplification."""
@@ -200,12 +186,7 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
-    "torchfont::remove_overlap_groups",
-    mutates_args=(),
-    device_types="cpu",
-    schema=(
-        "(Tensor types, Tensor coords, Tensor selection_values) -> (Tensor, Tensor)"
-    ),
+    "torchfont::remove_overlap_groups", mutates_args=(), device_types="cpu"
 )
 def remove_overlap_groups(
     types: Tensor, coords: Tensor, selection_values: Tensor
@@ -227,7 +208,6 @@ def _(types: Tensor, coords: Tensor, selection_values: Tensor) -> tuple[Tensor, 
     "torchfont::normalize_subpath_start_points",
     mutates_args=(),
     device_types="cpu",
-    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
 )
 def normalize_subpath_start_points(
     types: Tensor, coords: Tensor
@@ -243,12 +223,7 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
-    "torchfont::set_subpath_start_points",
-    mutates_args=(),
-    device_types="cpu",
-    schema=(
-        "(Tensor types, Tensor coords, Tensor selection_values) -> (Tensor, Tensor)"
-    ),
+    "torchfont::set_subpath_start_points", mutates_args=(), device_types="cpu"
 )
 def set_subpath_start_points(
     types: Tensor, coords: Tensor, selection_values: Tensor
@@ -267,10 +242,7 @@ def _(types: Tensor, coords: Tensor, selection_values: Tensor) -> tuple[Tensor, 
 
 
 @torch.library.custom_op(
-    "torchfont::reorder_subpaths",
-    mutates_args=(),
-    device_types="cpu",
-    schema="(Tensor types, Tensor coords, Tensor keys) -> (Tensor, Tensor)",
+    "torchfont::reorder_subpaths", mutates_args=(), device_types="cpu"
 )
 def reorder_subpaths(
     types: Tensor, coords: Tensor, keys: Tensor
@@ -287,10 +259,7 @@ def _(types: Tensor, coords: Tensor, keys: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
-    "torchfont::reverse_closed_subpaths",
-    mutates_args=(),
-    device_types="cpu",
-    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
+    "torchfont::reverse_closed_subpaths", mutates_args=(), device_types="cpu"
 )
 def reverse_closed_subpaths(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Reverse the winding direction of every closed subpath."""
@@ -303,12 +272,7 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     return _dynamic_outline(types, coords)
 
 
-@torch.library.custom_op(
-    "torchfont::bbox_center",
-    mutates_args=(),
-    device_types="cpu",
-    schema="(Tensor types, Tensor coords) -> Tensor",
-)
+@torch.library.custom_op("torchfont::bbox_center", mutates_args=(), device_types="cpu")
 def bbox_center(types: Tensor, coords: Tensor) -> Tensor:
     """Return the tight bounding-box centre as a ``(2,)`` tensor.
 
@@ -329,13 +293,7 @@ def _(types: Tensor, coords: Tensor) -> Tensor:
 
 
 @torch.library.custom_op(
-    "torchfont::render_bitmap",
-    mutates_args=(),
-    device_types="cpu",
-    schema=(
-        "(Tensor types, Tensor coords, int size, str mode, str fill_rule, "
-        "bool antialias) -> Tensor"
-    ),
+    "torchfont::render_bitmap", mutates_args=(), device_types="cpu"
 )
 def render_bitmap(
     types: Tensor,

--- a/torchfont/_ops.py
+++ b/torchfont/_ops.py
@@ -1,0 +1,345 @@
+"""Rust outline kernels registered as PyTorch custom operators.
+
+Each Rust kernel crosses a CPU and NumPy boundary. Calling one directly from a
+compiled region would break the graph, because Dynamo cannot trace into an
+extension module. Registering the boundary with :func:`torch.library.custom_op`
+turns each kernel into a single opaque graph node instead, so
+:func:`torch.compile` captures a whole outline pipeline without breaking.
+
+Every operator here:
+
+* takes and returns tensors, never NumPy arrays or Python scalars, so no value
+  escapes into the graph as a constant;
+* is registered only for CPU tensors, matching the device of the Rust kernel;
+* accepts the native kernel's actual dtypes: ``torch.long`` element types and
+  ``torch.float32`` coordinates;
+* declares a fake implementation so shape propagation works without running the
+  kernel. Most of these kernels change the number of path elements, which makes
+  the output length data-dependent; those fakes allocate an unbacked dynamic
+  size.
+
+None of them register an autograd formula. They reorder or re-encode path
+elements, so no gradient is defined. Callers reject outlines that require grad
+before reaching this layer, which produces an error naming the kernel.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import torch
+from torch import Tensor
+
+from torchfont import _torchfont
+from torchfont._outline import COORD_DIM
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from torchfont._torchfont import _BitmapMode, _FillRule
+
+
+def _arrays(types: Tensor, coords: Tensor) -> tuple[np.ndarray, np.ndarray]:
+    """Return NumPy views accepted by the CPU float32 Rust kernels."""
+    if types.dtype is not torch.long:
+        msg = f"types must have dtype torch.long, got {types.dtype}"
+        raise TypeError(msg)
+    if coords.dtype is not torch.float32:
+        msg = f"coords must have dtype torch.float32, got {coords.dtype}"
+        raise TypeError(msg)
+    return (
+        types.detach().contiguous().numpy(),
+        coords.detach().contiguous().reshape(-1).numpy(),
+    )
+
+
+def _restore(
+    out_types: np.ndarray,
+    out_coords: np.ndarray,
+) -> tuple[Tensor, Tensor]:
+    """Rebuild CPU tensors returned by the native kernel."""
+    return (
+        torch.from_numpy(out_types),
+        torch.from_numpy(out_coords).view(-1, COORD_DIM),
+    )
+
+
+def _dynamic_outline(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Allocate a fake outline whose element count is data-dependent."""
+    length = torch.library.get_ctx().new_dynamic_size()
+    return (
+        types.new_empty(length),
+        coords.new_empty(length, COORD_DIM),
+    )
+
+
+def _selection(values: Tensor) -> np.ndarray:
+    if values.dtype is not torch.float32:
+        msg = f"selection values must have dtype torch.float32, got {values.dtype}"
+        raise TypeError(msg)
+    return values.detach().contiguous().numpy()
+
+
+@torch.library.custom_op(
+    "torchfont::quad_to_cubic", mutates_args=(), device_types="cpu"
+)
+def quad_to_cubic(
+    types: Tensor, coords: Tensor, merge_curves: bool
+) -> tuple[Tensor, Tensor]:
+    """Convert quadratic segments to cubic segments."""
+    out = _torchfont.quad_to_cubic(*_arrays(types, coords), merge_curves)
+    return _restore(*out)
+
+
+@quad_to_cubic.register_fake
+def _(types: Tensor, coords: Tensor, merge_curves: bool) -> tuple[Tensor, Tensor]:
+    if merge_curves:
+        return _dynamic_outline(types, coords)
+    return types.new_empty(types.shape), coords.new_empty(coords.shape)
+
+
+@torch.library.custom_op(
+    "torchfont::cubic_to_quad", mutates_args=(), device_types="cpu"
+)
+def cubic_to_quad(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Convert cubic segments to sequences of quadratic segments."""
+    out = _torchfont.cubic_to_quad(*_arrays(types, coords))
+    return _restore(*out)
+
+
+@cubic_to_quad.register_fake
+def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op("torchfont::merge_curves", mutates_args=(), device_types="cpu")
+def merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Merge adjacent pieces of the same parent curve or line."""
+    out = _torchfont.merge_curves(*_arrays(types, coords))
+    return _restore(*out)
+
+
+@merge_curves.register_fake
+def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
+    "torchfont::split_segments", mutates_args=(), device_types="cpu"
+)
+def split_segments(
+    types: Tensor,
+    coords: Tensor,
+    selection_values: Tensor,
+    position_values: Tensor,
+    split_probability: float,
+    split_range: list[float],
+) -> tuple[Tensor, Tensor]:
+    """Split segments according to explicit selection and position values.
+
+    ``split_range`` is a list rather than a tuple because operator schemas do not
+    support tuple arguments.
+    """
+    low, high = split_range
+    out = _torchfont.random_split_segments(
+        *_arrays(types, coords),
+        _selection(selection_values),
+        _selection(position_values),
+        split_probability,
+        (low, high),
+    )
+    return _restore(*out)
+
+
+@split_segments.register_fake
+def _(
+    types: Tensor,
+    coords: Tensor,
+    selection_values: Tensor,
+    position_values: Tensor,
+    split_probability: float,
+    split_range: list[float],
+) -> tuple[Tensor, Tensor]:
+    del selection_values, position_values, split_probability, split_range
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
+    "torchfont::remove_overlaps", mutates_args=(), device_types="cpu"
+)
+def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Merge overlapping subpaths with Skia PathOps winding simplification."""
+    out = _torchfont.remove_overlaps(*_arrays(types, coords))
+    return _restore(*out)
+
+
+@remove_overlaps.register_fake
+def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
+    "torchfont::remove_overlap_groups", mutates_args=(), device_types="cpu"
+)
+def remove_overlap_groups(
+    types: Tensor, coords: Tensor, selection_values: Tensor
+) -> tuple[Tensor, Tensor]:
+    """Simplify overlap groups according to explicit selection values."""
+    out = _torchfont.random_remove_overlaps(
+        *_arrays(types, coords), _selection(selection_values)
+    )
+    return _restore(*out)
+
+
+@remove_overlap_groups.register_fake
+def _(types: Tensor, coords: Tensor, selection_values: Tensor) -> tuple[Tensor, Tensor]:
+    del selection_values
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
+    "torchfont::normalize_subpath_start_points",
+    mutates_args=(),
+    device_types="cpu",
+)
+def normalize_subpath_start_points(
+    types: Tensor, coords: Tensor
+) -> tuple[Tensor, Tensor]:
+    """Choose a deterministic start point for each closed subpath."""
+    out = _torchfont.normalize_subpath_start_points(*_arrays(types, coords))
+    return _restore(*out)
+
+
+@normalize_subpath_start_points.register_fake
+def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
+    "torchfont::set_subpath_start_points", mutates_args=(), device_types="cpu"
+)
+def set_subpath_start_points(
+    types: Tensor, coords: Tensor, selection_values: Tensor
+) -> tuple[Tensor, Tensor]:
+    """Set closed-subpath start points from explicit unit-interval values."""
+    out = _torchfont.randomize_subpath_start_points(
+        *_arrays(types, coords), _selection(selection_values)
+    )
+    return _restore(*out)
+
+
+@set_subpath_start_points.register_fake
+def _(types: Tensor, coords: Tensor, selection_values: Tensor) -> tuple[Tensor, Tensor]:
+    del selection_values
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
+    "torchfont::reorder_subpaths", mutates_args=(), device_types="cpu"
+)
+def reorder_subpaths(
+    types: Tensor, coords: Tensor, keys: Tensor
+) -> tuple[Tensor, Tensor]:
+    """Order subpaths by explicit sort keys."""
+    out = _torchfont.randomize_subpath_order(*_arrays(types, coords), _selection(keys))
+    return _restore(*out)
+
+
+@reorder_subpaths.register_fake
+def _(types: Tensor, coords: Tensor, keys: Tensor) -> tuple[Tensor, Tensor]:
+    del keys
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op(
+    "torchfont::reverse_closed_subpaths", mutates_args=(), device_types="cpu"
+)
+def reverse_closed_subpaths(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    """Reverse the winding direction of every closed subpath."""
+    out = _torchfont.reverse_closed_subpaths(*_arrays(types, coords))
+    return _restore(*out)
+
+
+@reverse_closed_subpaths.register_fake
+def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
+    return _dynamic_outline(types, coords)
+
+
+@torch.library.custom_op("torchfont::bbox_center", mutates_args=(), device_types="cpu")
+def bbox_center(types: Tensor, coords: Tensor) -> Tensor:
+    """Return the tight bounding-box centre as a ``(2,)`` tensor.
+
+    Empty outlines have no bounding box and yield the origin, matching the
+    reference frame an affine transform would use for them.
+    """
+    result = _torchfont.tight_bbox(*_arrays(types, coords))
+    if result is None:
+        return coords.new_zeros(2)
+    x_min, y_min, x_max, y_max = result
+    return coords.new_tensor([(x_min + x_max) / 2.0, (y_min + y_max) / 2.0])
+
+
+@bbox_center.register_fake
+def _(types: Tensor, coords: Tensor) -> Tensor:
+    del types
+    return coords.new_empty(2)
+
+
+@torch.library.custom_op(
+    "torchfont::render_bitmap", mutates_args=(), device_types="cpu"
+)
+def render_bitmap(
+    types: Tensor,
+    coords: Tensor,
+    size: int,
+    mode: str,
+    fill_rule: str,
+    antialias: bool,
+) -> Tensor:
+    """Rasterize an outline into a ``uint8`` greyscale ``H x W`` tensor.
+
+    ``mode`` and ``fill_rule`` are plain strings because operator schemas have no
+    literal string type. The Rust kernel rejects an unknown value, so they are
+    passed through rather than validated again here.
+    """
+    raw, width, height = _torchfont.render_bitmap(
+        *_arrays(types, coords),
+        size,
+        cast("_BitmapMode", mode),
+        cast("_FillRule", fill_rule),
+        antialias,
+    )
+    return torch.from_numpy(raw).view(height, width)
+
+
+@render_bitmap.register_fake
+def _(
+    types: Tensor,
+    coords: Tensor,
+    size: int,
+    mode: str,
+    fill_rule: str,
+    antialias: bool,
+) -> Tensor:
+    del types, fill_rule, antialias
+    options = torch.empty(0, dtype=torch.uint8, device=coords.device)
+    if mode == "bbox":
+        ctx = torch.library.get_ctx()
+        return options.new_empty((ctx.new_dynamic_size(), ctx.new_dynamic_size()))
+    return options.new_empty((size, size))
+
+
+__all__ = [
+    "bbox_center",
+    "cubic_to_quad",
+    "merge_curves",
+    "normalize_subpath_start_points",
+    "quad_to_cubic",
+    "remove_overlap_groups",
+    "remove_overlaps",
+    "render_bitmap",
+    "reorder_subpaths",
+    "reverse_closed_subpaths",
+    "set_subpath_start_points",
+    "split_segments",
+]

--- a/torchfont/_ops.py
+++ b/torchfont/_ops.py
@@ -81,7 +81,10 @@ def _selection(values: Tensor) -> np.ndarray:
 
 
 @torch.library.custom_op(
-    "torchfont::quad_to_cubic", mutates_args=(), device_types="cpu"
+    "torchfont::quad_to_cubic",
+    mutates_args=(),
+    device_types="cpu",
+    schema="(Tensor types, Tensor coords, bool merge_curves) -> (Tensor, Tensor)",
 )
 def quad_to_cubic(
     types: Tensor, coords: Tensor, merge_curves: bool
@@ -99,7 +102,10 @@ def _(types: Tensor, coords: Tensor, merge_curves: bool) -> tuple[Tensor, Tensor
 
 
 @torch.library.custom_op(
-    "torchfont::cubic_to_quad", mutates_args=(), device_types="cpu"
+    "torchfont::cubic_to_quad",
+    mutates_args=(),
+    device_types="cpu",
+    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
 )
 def cubic_to_quad(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Convert cubic segments to sequences of quadratic segments."""
@@ -112,7 +118,12 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     return _dynamic_outline(types, coords)
 
 
-@torch.library.custom_op("torchfont::merge_curves", mutates_args=(), device_types="cpu")
+@torch.library.custom_op(
+    "torchfont::merge_curves",
+    mutates_args=(),
+    device_types="cpu",
+    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
+)
 def merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Merge adjacent pieces of the same parent curve or line."""
     out = _torchfont.merge_curves(*_arrays(types, coords))
@@ -125,7 +136,14 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
-    "torchfont::split_segments", mutates_args=(), device_types="cpu"
+    "torchfont::split_segments",
+    mutates_args=(),
+    device_types="cpu",
+    schema=(
+        "(Tensor types, Tensor coords, Tensor selection_values, "
+        "Tensor position_values, float split_probability, float[] split_range) "
+        "-> (Tensor, Tensor)"
+    ),
 )
 def split_segments(
     types: Tensor,
@@ -165,7 +183,10 @@ def _(
 
 
 @torch.library.custom_op(
-    "torchfont::remove_overlaps", mutates_args=(), device_types="cpu"
+    "torchfont::remove_overlaps",
+    mutates_args=(),
+    device_types="cpu",
+    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
 )
 def remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Merge overlapping subpaths with Skia PathOps winding simplification."""
@@ -179,7 +200,12 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
-    "torchfont::remove_overlap_groups", mutates_args=(), device_types="cpu"
+    "torchfont::remove_overlap_groups",
+    mutates_args=(),
+    device_types="cpu",
+    schema=(
+        "(Tensor types, Tensor coords, Tensor selection_values) -> (Tensor, Tensor)"
+    ),
 )
 def remove_overlap_groups(
     types: Tensor, coords: Tensor, selection_values: Tensor
@@ -201,6 +227,7 @@ def _(types: Tensor, coords: Tensor, selection_values: Tensor) -> tuple[Tensor, 
     "torchfont::normalize_subpath_start_points",
     mutates_args=(),
     device_types="cpu",
+    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
 )
 def normalize_subpath_start_points(
     types: Tensor, coords: Tensor
@@ -216,7 +243,12 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
-    "torchfont::set_subpath_start_points", mutates_args=(), device_types="cpu"
+    "torchfont::set_subpath_start_points",
+    mutates_args=(),
+    device_types="cpu",
+    schema=(
+        "(Tensor types, Tensor coords, Tensor selection_values) -> (Tensor, Tensor)"
+    ),
 )
 def set_subpath_start_points(
     types: Tensor, coords: Tensor, selection_values: Tensor
@@ -235,7 +267,10 @@ def _(types: Tensor, coords: Tensor, selection_values: Tensor) -> tuple[Tensor, 
 
 
 @torch.library.custom_op(
-    "torchfont::reorder_subpaths", mutates_args=(), device_types="cpu"
+    "torchfont::reorder_subpaths",
+    mutates_args=(),
+    device_types="cpu",
+    schema="(Tensor types, Tensor coords, Tensor keys) -> (Tensor, Tensor)",
 )
 def reorder_subpaths(
     types: Tensor, coords: Tensor, keys: Tensor
@@ -252,7 +287,10 @@ def _(types: Tensor, coords: Tensor, keys: Tensor) -> tuple[Tensor, Tensor]:
 
 
 @torch.library.custom_op(
-    "torchfont::reverse_closed_subpaths", mutates_args=(), device_types="cpu"
+    "torchfont::reverse_closed_subpaths",
+    mutates_args=(),
+    device_types="cpu",
+    schema="(Tensor types, Tensor coords) -> (Tensor, Tensor)",
 )
 def reverse_closed_subpaths(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     """Reverse the winding direction of every closed subpath."""
@@ -265,7 +303,12 @@ def _(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
     return _dynamic_outline(types, coords)
 
 
-@torch.library.custom_op("torchfont::bbox_center", mutates_args=(), device_types="cpu")
+@torch.library.custom_op(
+    "torchfont::bbox_center",
+    mutates_args=(),
+    device_types="cpu",
+    schema="(Tensor types, Tensor coords) -> Tensor",
+)
 def bbox_center(types: Tensor, coords: Tensor) -> Tensor:
     """Return the tight bounding-box centre as a ``(2,)`` tensor.
 
@@ -286,7 +329,13 @@ def _(types: Tensor, coords: Tensor) -> Tensor:
 
 
 @torch.library.custom_op(
-    "torchfont::render_bitmap", mutates_args=(), device_types="cpu"
+    "torchfont::render_bitmap",
+    mutates_args=(),
+    device_types="cpu",
+    schema=(
+        "(Tensor types, Tensor coords, int size, str mode, str fill_rule, "
+        "bool antialias) -> Tensor"
+    ),
 )
 def render_bitmap(
     types: Tensor,

--- a/torchfont/_outline.py
+++ b/torchfont/_outline.py
@@ -98,16 +98,8 @@ class Outline:
 
     @classmethod
     def _wrap(cls, types: Tensor, coords: Tensor) -> Outline:
-        """Pair tensors already known to satisfy every structural invariant.
-
-        Kernels that derive an outline from a validated outline use this to
-        avoid re-checking invariants they cannot have broken. Validation stays
-        at the boundary where untrusted tensors enter, in ``__post_init__``.
-        """
-        outline = cls.__new__(cls)
-        object.__setattr__(outline, "types", types)
-        object.__setattr__(outline, "coords", coords)
-        return outline
+        """Pair tensors produced by an operation on a valid outline."""
+        return cls(types, coords)
 
     @property
     def shape(self) -> torch.Size:

--- a/torchfont/_outline.py
+++ b/torchfont/_outline.py
@@ -1,10 +1,26 @@
 """Semantic glyph outline structure and encoding constants."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import TYPE_CHECKING
 
 import torch
 from torch import Tensor
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from types import EllipsisType
+
+    _Index = (
+        int
+        | slice
+        | Tensor
+        | list[int]
+        | tuple[int | slice | Tensor | EllipsisType | None, ...]
+        | None
+    )
 
 
 class ElementType(IntEnum):
@@ -21,18 +37,29 @@ class ElementType(IntEnum):
 
 TYPE_DIM: int = len(ElementType)
 COORD_DIM: int = 6
-_COORD_NDIM = 2
 
 
 @dataclass(frozen=True, eq=False)
 class Outline:
-    """One variable-length glyph outline encoded by two coupled tensors.
+    """Glyph outlines encoded by two coupled tensors.
 
-    ``types`` has shape ``(N,)`` and ``coords`` has shape ``(N, 6)`` with rows
-    ``[cx0, cy0, cx1, cy1, x, y]``. Rows correspond one-to-one. Coordinates
-    inactive for an element type, including every coordinate of ``CLOSE``,
-    ``END``, and ``PAD``, carry no semantic value. Producers keep both tensors
-    on the same device; an ``Outline`` is not a batched glyph representation.
+    ``types`` has shape ``(*batch, N)`` and ``coords`` has shape
+    ``(*batch, N, 6)`` with rows ``[cx0, cy0, cx1, cy1, x, y]``. Rows correspond
+    one-to-one. Coordinates inactive for an element type, including every
+    coordinate of ``CLOSE``, ``END``, and ``PAD``, carry no semantic value.
+
+    A single glyph has an empty ``batch`` shape; :func:`pad_outlines` stacks
+    single glyphs into a batch padded with ``ElementType.PAD``. Most transforms
+    operate on single glyphs only and reject batches explicitly.
+
+    An ``Outline`` holds references to its tensors rather than copies, so
+    mutating ``types`` or ``coords`` in place is visible through it, as tensor
+    aliasing normally behaves. Assigning to either attribute raises instead.
+
+    Warning:
+        Do not register ``Outline`` as a pytree node. Every transform would
+        silently stop doing anything.
+
     """
 
     types: Tensor
@@ -40,25 +67,201 @@ class Outline:
 
     def __post_init__(self) -> None:
         """Reject structurally invalid coupled tensors at construction."""
-        if self.types.ndim != 1:
-            msg = f"types must be 1-D, got {self.types.ndim}-D"
+        if self.types.ndim < 1:
+            msg = f"types must have at least 1 dimension, got {self.types.ndim}"
             raise ValueError(msg)
-        if self.coords.ndim != _COORD_NDIM or self.coords.shape[1] != COORD_DIM:
+        if self.coords.ndim != self.types.ndim + 1:
+            msg = (
+                f"coords must have exactly one more dimension than types, "
+                f"got {self.coords.ndim} and {self.types.ndim}"
+            )
+            raise ValueError(msg)
+        if self.coords.shape[-1] != COORD_DIM:
             shape = tuple(self.coords.shape)
-            msg = f"coords must have shape (N, {COORD_DIM}), got {shape}"
+            msg = f"coords must have shape (*batch, N, {COORD_DIM}), got {shape}"
             raise ValueError(msg)
-        if self.types.shape[0] != self.coords.shape[0]:
-            msg = "types and coords must have the same number of rows"
+        if self.types.shape != self.coords.shape[:-1]:
+            msg = (
+                "types shape must match coords without its last dimension, "
+                f"got {tuple(self.types.shape)} and {tuple(self.coords.shape)}"
+            )
             raise ValueError(msg)
         if self.types.dtype is not torch.long:
             msg = f"types must have dtype torch.long, got {self.types.dtype}"
             raise TypeError(msg)
-        if self.coords.dtype is not torch.float32:
-            msg = f"coords must have dtype torch.float32, got {self.coords.dtype}"
+        if not self.coords.dtype.is_floating_point:
+            msg = f"coords must have a floating point dtype, got {self.coords.dtype}"
             raise TypeError(msg)
         if self.types.device != self.coords.device:
             msg = "types and coords must be on the same device"
             raise ValueError(msg)
 
+    @classmethod
+    def _wrap(cls, types: Tensor, coords: Tensor) -> Outline:
+        """Pair tensors already known to satisfy every structural invariant.
 
-__all__ = ["COORD_DIM", "TYPE_DIM", "ElementType", "Outline"]
+        Kernels that derive an outline from a validated outline use this to
+        avoid re-checking invariants they cannot have broken. Validation stays
+        at the boundary where untrusted tensors enter, in ``__post_init__``.
+        """
+        outline = cls.__new__(cls)
+        object.__setattr__(outline, "types", types)
+        object.__setattr__(outline, "coords", coords)
+        return outline
+
+    @property
+    def shape(self) -> torch.Size:
+        """Shape of ``types``, that is ``(*batch, N)``."""
+        return self.types.shape
+
+    @property
+    def batch_shape(self) -> torch.Size:
+        """Leading batch dimensions, empty for a single glyph."""
+        return torch.Size(self.types.shape[:-1])
+
+    @property
+    def num_elements(self) -> int:
+        """Number of path elements per glyph, including padding."""
+        return self.types.shape[-1]
+
+    @property
+    def is_batched(self) -> bool:
+        """Whether this outline carries at least one batch dimension."""
+        return self.types.ndim > 1
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Floating point dtype of ``coords``."""
+        return self.coords.dtype
+
+    @property
+    def device(self) -> torch.device:
+        """Device shared by ``types`` and ``coords``."""
+        return self.coords.device
+
+    @property
+    def padding_mask(self) -> Tensor:
+        """Boolean mask that is ``True`` where an element is ``PAD``.
+
+        Pass this to attention modules expecting ``key_padding_mask``.
+        """
+        return self.types == ElementType.PAD.value
+
+    def to(
+        self,
+        device: torch.device | str | int | torch.dtype | None = None,
+        dtype: torch.dtype | None = None,
+        *,
+        non_blocking: bool = False,
+    ) -> Outline:
+        """Move or cast the outline, following :meth:`torch.Tensor.to`.
+
+        As with tensors, a dtype may be passed as the only positional argument.
+        A dtype applies to ``coords`` only and must be floating point, because
+        ``types`` is always ``torch.long``.
+        """
+        if isinstance(device, torch.dtype):
+            if dtype is not None:
+                msg = "dtype was given both positionally and by keyword"
+                raise TypeError(msg)
+            device, dtype = None, device
+        if dtype is not None and not dtype.is_floating_point:
+            msg = f"dtype must be floating point, got {dtype}"
+            raise TypeError(msg)
+        return self._wrap(
+            self.types.to(device=device, non_blocking=non_blocking),
+            self.coords.to(device=device, dtype=dtype, non_blocking=non_blocking),
+        )
+
+    def pin_memory(self) -> Outline:
+        """Return this outline with both tensors in pinned memory."""
+        return self._wrap(self.types.pin_memory(), self.coords.pin_memory())
+
+    def __len__(self) -> int:
+        """Size of the first dimension, following :func:`len` on a tensor."""
+        return self.types.shape[0]
+
+    def __getitem__(self, index: _Index) -> Outline:
+        """Index logical outline dimensions, keeping the coordinate axis intact."""
+        coord_index = (
+            (*index, slice(None)) if isinstance(index, tuple) else (index, slice(None))
+        )
+        types = self.types[index]
+        coords = self.coords[coord_index]
+        if types.ndim == 0:
+            msg = "indexing must preserve the outline element dimension"
+            raise IndexError(msg)
+        return self._wrap(types, coords)
+
+    def unbind(self) -> tuple[Outline, ...]:
+        """Split the first batch dimension without changing its contents."""
+        if not self.is_batched:
+            msg = "unbind requires a batched outline"
+            raise ValueError(msg)
+        return tuple(self[index] for index in range(self.types.shape[0]))
+
+    def _strip_padding(self) -> Outline:
+        """Drop trailing ``PAD`` elements along the last dimension."""
+        if self.is_batched:
+            msg = "padding can only be stripped from a single outline"
+            raise ValueError(msg)
+        kept = (self.types != ElementType.PAD.value).nonzero()
+        length = 0 if kept.numel() == 0 else int(kept[-1]) + 1
+        return self._wrap(self.types[:length], self.coords[:length])
+
+    def __repr__(self) -> str:
+        """Summarise shape, dtype, and device instead of dumping both tensors."""
+        return (
+            f"Outline(shape={tuple(self.shape)}, dtype={self.dtype}, "
+            f"device={self.device})"
+        )
+
+
+def pad_outlines(outlines: Sequence[Outline]) -> Outline:
+    """Stack single outlines into one batch padded with ``ElementType.PAD``.
+
+    Every input must be a single glyph on a common device with a common
+    ``coords`` dtype. Shorter outlines are padded to the longest length with
+    ``PAD`` element types and zero coordinates.
+
+    Use :attr:`Outline.padding_mask` on the result to recover which elements are
+    padding, and :meth:`Outline.unbind` to undo the padding.
+    """
+    if len(outlines) == 0:
+        msg = "outlines must not be empty"
+        raise ValueError(msg)
+    first = outlines[0]
+    # Only the dtype is checked: a mismatched shape or device makes the copy
+    # below raise, while a mismatched dtype would silently cast the coordinates.
+    if any(outline.dtype != first.dtype for outline in outlines):
+        msg = "all outlines must share one coords dtype"
+        raise ValueError(msg)
+    length = max(outline.num_elements for outline in outlines)
+    types = first.types.new_full((len(outlines), length), ElementType.PAD.value)
+    coords = first.coords.new_zeros((len(outlines), length, COORD_DIM))
+    for index, outline in enumerate(outlines):
+        end = outline.num_elements
+        types[index, :end] = outline.types
+        coords[index, :end] = outline.coords
+    return Outline._wrap(types, coords)  # noqa: SLF001
+
+
+def unpad_outlines(outline: Outline) -> tuple[Outline, ...]:
+    """Split a padded one-dimensional batch and remove trailing padding."""
+    if len(outline.batch_shape) != 1:
+        msg = (
+            "unpad_outlines requires exactly one batch dimension, got "
+            f"{tuple(outline.batch_shape)}"
+        )
+        raise ValueError(msg)
+    return tuple(part._strip_padding() for part in outline.unbind())  # noqa: SLF001
+
+
+__all__ = [
+    "COORD_DIM",
+    "TYPE_DIM",
+    "ElementType",
+    "Outline",
+    "pad_outlines",
+    "unpad_outlines",
+]

--- a/torchfont/nn/_embedding.py
+++ b/torchfont/nn/_embedding.py
@@ -7,16 +7,16 @@ import math
 import torch
 from torch import Tensor, nn
 
-from torchfont._outline import COORD_DIM, TYPE_DIM, ElementType
+from torchfont._outline import COORD_DIM, TYPE_DIM, ElementType, Outline
 from torchfont.nn._utils import _active_coordinate_mask
 
 
 class OutlineEmbedding(nn.Module):
     """Embed element types and continuous coordinates into token features.
 
-    The input tensors may be unbatched or have any number of leading batch
-    dimensions. Their shapes are ``(..., N)`` and ``(..., N, 6)``; the output
-    has shape ``(..., N, embedding_dim)``. Padding tokens produce zero vectors.
+    Accepts an :class:`~torchfont.Outline`, single or batched. Its shape is
+    ``(..., N)``, so the output has shape ``(..., N, embedding_dim)``. Padding
+    tokens produce zero vectors.
     """
 
     def __init__(
@@ -52,14 +52,9 @@ class OutlineEmbedding(nn.Module):
         with torch.no_grad():
             self.type_embedding.weight[ElementType.PAD.value].zero_()
 
-    def forward(self, types: Tensor, coords: Tensor) -> Tensor:
+    def forward(self, outline: Outline) -> Tensor:
         """Return the sum of element-type and coordinate embeddings."""
-        if types.shape != coords.shape[:-1]:
-            msg = (
-                "types shape must match coords without its last dimension, "
-                f"got {tuple(types.shape)} and {tuple(coords.shape)}"
-            )
-            raise ValueError(msg)
+        types, coords = outline.types, outline.coords
         active_coords = torch.where(_active_coordinate_mask(types), coords, 0)
         embedded = self.type_embedding(types) + self.coord_projection(active_coords)
         return torch.where((types != ElementType.PAD.value).unsqueeze(-1), embedded, 0)

--- a/torchfont/nn/_loss.py
+++ b/torchfont/nn/_loss.py
@@ -11,6 +11,8 @@ from torchfont.nn import functional
 if TYPE_CHECKING:
     from torch import Tensor
 
+    from torchfont._outline import Outline
+
 
 class OutlineLoss(nn.Module):
     """Combine element-type and active-coordinate losses.
@@ -33,15 +35,13 @@ class OutlineLoss(nn.Module):
         self,
         type_logits: Tensor,
         coordinate_prediction: Tensor,
-        target_types: Tensor,
-        target_coords: Tensor,
+        target: Outline,
     ) -> Tensor:
         """Return the weighted mean outline loss."""
         return functional.outline_loss(
             type_logits,
             coordinate_prediction,
-            target_types,
-            target_coords,
+            target,
             type_weight=self.type_weight,
             coordinate_weight=self.coordinate_weight,
         )

--- a/torchfont/nn/_utils.py
+++ b/torchfont/nn/_utils.py
@@ -1,5 +1,7 @@
 """Shared neural network helpers for outline tensors."""
 
+from __future__ import annotations
+
 import torch
 from torch import Tensor
 

--- a/torchfont/nn/functional.py
+++ b/torchfont/nn/functional.py
@@ -7,45 +7,37 @@ from typing import TYPE_CHECKING, Literal
 import torch
 from torch.nn import functional as _functional
 
-from torchfont._outline import COORD_DIM, TYPE_DIM, ElementType
+from torchfont._outline import TYPE_DIM, ElementType
 from torchfont.nn._utils import _active_coordinate_mask
 
 if TYPE_CHECKING:
     from torch import Tensor
+
+    from torchfont._outline import Outline
 
 _Reduction = Literal["none", "mean", "sum"]
 
 
 def coordinate_loss(
     prediction: Tensor,
-    target: Tensor,
-    types: Tensor,
+    target: Outline,
     reduction: _Reduction = "mean",
 ) -> Tensor:
     """Compute squared error over coordinates active for each target type.
 
-    ``prediction`` and ``target`` have shape ``(..., N, 6)`` and ``types`` has
-    shape ``(..., N)``. Inactive control points and coordinates belonging to
-    ``CLOSE``, ``END``, or ``PAD`` do not contribute to the loss.
+    ``prediction`` has shape ``(..., N, 6)`` and ``target`` is the outline it is
+    compared against. Inactive control points and coordinates belonging to
+    ``CLOSE``, ``END``, or ``PAD`` do not contribute.
     """
-    if prediction.shape != target.shape:
+    if prediction.shape != target.coords.shape:
         msg = (
-            "prediction and target must have the same shape, "
-            f"got {tuple(prediction.shape)} and {tuple(target.shape)}"
-        )
-        raise ValueError(msg)
-    if prediction.ndim == 0 or prediction.shape[-1] != COORD_DIM:
-        msg = f"prediction and target must have shape (..., N, {COORD_DIM})"
-        raise ValueError(msg)
-    if types.shape != target.shape[:-1]:
-        msg = (
-            "types shape must match target without its last dimension, "
-            f"got {tuple(types.shape)} and {tuple(target.shape)}"
+            "prediction must have the same shape as the target coordinates, "
+            f"got {tuple(prediction.shape)} and {tuple(target.coords.shape)}"
         )
         raise ValueError(msg)
 
-    mask = _active_coordinate_mask(types)
-    difference = torch.where(mask, prediction - target, 0)
+    mask = _active_coordinate_mask(target.types)
+    difference = torch.where(mask, prediction - target.coords, 0)
     loss = difference.square()
     if reduction == "none":
         return loss
@@ -57,11 +49,10 @@ def coordinate_loss(
     raise ValueError(msg)
 
 
-def outline_loss(  # noqa: PLR0913
+def outline_loss(
     type_logits: Tensor,
     coordinate_prediction: Tensor,
-    target_types: Tensor,
-    target_coords: Tensor,
+    target: Outline,
     *,
     type_weight: float = 1.0,
     coordinate_weight: float = 1.0,
@@ -72,30 +63,26 @@ def outline_loss(  # noqa: PLR0913
     averaged independently over coordinate scalars active for the target
     element types, then the two means are combined using the given weights.
     """
-    if type_logits.shape[:-1] != target_types.shape:
+    if type_logits.shape[:-1] != target.types.shape:
         msg = (
-            "type_logits shape without its last dimension must match "
-            "target_types, "
-            f"got {tuple(type_logits.shape)} and {tuple(target_types.shape)}"
+            "type_logits shape without its last dimension must match the target "
+            "element types, "
+            f"got {tuple(type_logits.shape)} and {tuple(target.types.shape)}"
         )
         raise ValueError(msg)
-    if type_logits.ndim == 0 or type_logits.shape[-1] != TYPE_DIM:
+    if type_logits.shape[-1] != TYPE_DIM:
         msg = f"type_logits must have shape (..., N, {TYPE_DIM})"
         raise ValueError(msg)
 
     type_loss = _functional.cross_entropy(
         type_logits.reshape(-1, TYPE_DIM),
-        target_types.reshape(-1),
+        target.types.reshape(-1),
         ignore_index=ElementType.PAD.value,
         reduction="sum",
     )
-    type_count = (target_types != ElementType.PAD.value).sum().clamp_min(1)
+    type_count = (target.types != ElementType.PAD.value).sum().clamp_min(1)
     type_loss = type_loss / type_count
-    coords_loss = coordinate_loss(
-        coordinate_prediction,
-        target_coords,
-        target_types,
-    )
+    coords_loss = coordinate_loss(coordinate_prediction, target)
     return type_weight * type_loss + coordinate_weight * coords_loss
 
 

--- a/torchfont/transforms/_glyph.py
+++ b/torchfont/transforms/_glyph.py
@@ -8,8 +8,12 @@ import torch
 from torch import nn
 
 from torchfont import _torchfont
-from torchfont._font import VariationLocation
-from torchfont._glyph import GlyphData, GlyphRef, GlyphSample
+from torchfont._glyph import (
+    GlyphData,
+    GlyphRef,
+    GlyphSample,
+    _glyph_data_targets,
+)
 from torchfont.transforms import functional as _functional
 
 if TYPE_CHECKING:
@@ -37,20 +41,16 @@ class LoadGlyph(nn.Module):
         outline = _functional.load_glyph(ref, location)
         if not isinstance(inpt, GlyphSample):
             return outline
-        weight, width, italic, slant, optical_size = _torchfont.glyph_targets(
-            ref.font.path, ref.font.ttc_index, location
-        )
+        metrics = _torchfont.glyph_targets(ref.font.path, ref.font.ttc_index, location)
         return GlyphData(
             data=outline,
             ref=ref,
-            location=VariationLocation(location),
-            font_idx=inpt.font_idx,
-            character_idx=inpt.character_idx,
-            weight=weight,
-            width=width,
-            italic=italic,
-            slant=slant,
-            optical_size=optical_size,
+            location=location,
+            **_glyph_data_targets(
+                font_idx=inpt.font_idx,
+                character_idx=inpt.character_idx,
+                metrics=metrics,
+            ),
         )
 
     def extra_repr(self) -> str:

--- a/torchfont/transforms/functional/_bitmap.py
+++ b/torchfont/transforms/functional/_bitmap.py
@@ -2,11 +2,11 @@
 
 from typing import Literal
 
-import torch
 from torch import Tensor
 
-from torchfont import _torchfont
+from torchfont import _ops
 from torchfont._outline import Outline
+from torchfont.transforms.functional._utils import _require_no_grad, _require_single
 
 BitmapMode = Literal["fixed", "bbox", "bbox_square"]
 FillRule = Literal["winding", "even_odd"]
@@ -43,13 +43,14 @@ def render_bitmap(
         ``"fixed"`` and ``"bbox_square"``, and variable ``(height, width)`` for
         ``"bbox"``.
 
+    Notes:
+        Integer coverage defines no gradient, so an outline that requires grad is
+        rejected.
+
     """
-    types = inpt.types.cpu().contiguous()
-    coords = inpt.coords.cpu().contiguous()
-    raw, width, height = _torchfont.render_bitmap(
-        types.numpy(), coords.reshape(-1).numpy(), size, mode, fill_rule, antialias
-    )
-    return torch.from_numpy(raw).view(height, width)
+    _require_single(inpt, "render_bitmap")
+    _require_no_grad(inpt, "render_bitmap")
+    return _ops.render_bitmap(inpt.types, inpt.coords, size, mode, fill_rule, antialias)
 
 
 __all__ = ["BitmapMode", "FillRule", "render_bitmap"]

--- a/torchfont/transforms/functional/_curves.py
+++ b/torchfont/transforms/functional/_curves.py
@@ -1,123 +1,71 @@
-"""Functional curve conversion and segment kernels."""
+"""Functional curve conversion and segment kernels.
 
-import torch
-from torch import Tensor
+Every kernel here re-encodes path elements in Rust and may change the number of
+elements, so none of them define a gradient.
+"""
 
-from torchfont import _torchfont
-from torchfont._outline import Outline
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from torchfont import _ops
 from torchfont.transforms.functional._utils import _native_outline
 
+if TYPE_CHECKING:
+    from torch import Tensor
 
-def _quad_to_cubic(
-    types: Tensor, coords: Tensor, *, merge_curves: bool = False
-) -> tuple[Tensor, Tensor]:
-    """Convert ``ElementType.QUAD_TO`` entries to ``ElementType.CURVE_TO``.
-
-    Accepts a 1-D ``types`` tensor and a 2-D ``coords`` tensor of shape
-    ``(N, 6)``. The output has the same shape as the input. Rows in ``coords``
-    use the ``[cx0, cy0, cx1, cy1, x, y]`` layout, with quadratic control
-    points read from ``[cx0, cy0]`` and endpoints from ``[x, y]``.
-
-    When ``merge_curves=True``, adjacent mergeable curves and lines are merged
-    in the same Rust call after conversion. The output length may differ from
-    the input in this mode.
-    """
-    types_device = types.device
-    coords_device = coords.device
-    types = types.cpu().contiguous()
-    coords = coords.cpu().contiguous()
-    out_types, out_coords = _torchfont.quad_to_cubic(
-        types.numpy(), coords.reshape(-1).numpy(), merge_curves
-    )
-    return (
-        torch.from_numpy(out_types).to(device=types_device),
-        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
-    )
-
-
-def _cubic_to_quad(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
-    """Convert ``ElementType.CURVE_TO`` entries to ``ElementType.QUAD_TO`` sequences.
-
-    Each cubic Bezier segment is replaced by the minimum number of quadratic
-    Bezier segments needed to approximate it within ~1e-3 em units
-    (roughly 1 font-unit in a 1000-UPM font), following the fonttools cu2qu
-    approach. Consecutive quadratics share implicit on-curve points at the
-    midpoints of adjacent off-curve control points (TrueType spline).
-
-    Unlike ``quad_to_cubic``, the output length may differ from the input
-    because a single cubic can expand into multiple quadratics.
-
-    Args:
-        types: 1-D ``torch.int64`` tensor of element types.
-        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
-
-    Returns:
-        A new variable-length outline tuple ``(types, coords)`` where each
-        ``CurveTo`` has been replaced by one or more ``QuadTo`` path elements.
-        Non-cubic path elements are passed through unchanged.
-
-    """
-    types_device = types.device
-    coords_device = coords.device
-    types = types.cpu().contiguous()
-    coords = coords.cpu().contiguous()
-    out_types, out_coords = _torchfont.cubic_to_quad(
-        types.numpy(), coords.reshape(-1).numpy()
-    )
-    return (
-        torch.from_numpy(out_types).to(device=types_device),
-        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
-    )
-
-
-def _merge_curves(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
-    """Merge adjacent segments that belong to the same parent curve or line.
-
-    Adjacent cubic and quadratic Bezier segments are merged when they are pieces
-    of a single parent curve (i.e. joined at smooth split points determined via
-    de Casteljau). Adjacent ``LineTo`` segments are merged when the three points are
-    collinear and the segments run in the same direction. Unlike the fonttools
-    ``merge_curves`` helper this transform also handles line segments.
-
-    The comparison tolerance is ~1e-3 em units (roughly
-    1 font-unit in a 1000-UPM font), matching the precision typically used by
-    fonttools.
-
-    Args:
-        types: 1-D ``torch.int64`` tensor of element types.
-        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
-
-    Returns:
-        A new variable-length outline tuple ``(types, coords)`` with mergeable
-        adjacent segments collapsed.
-
-    """
-    types_device = types.device
-    coords_device = coords.device
-    types = types.cpu().contiguous()
-    coords = coords.cpu().contiguous()
-    out_types, out_coords = _torchfont.merge_curves(
-        types.numpy(), coords.reshape(-1).numpy()
-    )
-    return (
-        torch.from_numpy(out_types).to(device=types_device),
-        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
-    )
+    from torchfont._outline import Outline
 
 
 def quad_to_cubic(inpt: Outline, *, merge_curves: bool = False) -> Outline:
-    """Convert quadratic segments to cubic segments."""
-    return Outline(*_quad_to_cubic(inpt.types, inpt.coords, merge_curves=merge_curves))
+    """Convert ``QUAD_TO`` elements to ``CURVE_TO`` elements.
+
+    Each quadratic segment maps exactly onto one cubic segment, so the output
+    length matches the input unless ``merge_curves`` is enabled.
+
+    Args:
+        inpt: Outline to convert.
+        merge_curves: Merge adjacent mergeable curves and lines in the same Rust
+            call after conversion. The output length may then differ from the
+            input.
+
+    """
+    return _native_outline(
+        inpt,
+        _ops.quad_to_cubic,
+        merge_curves,
+        name="quad_to_cubic",
+    )
 
 
 def cubic_to_quad(inpt: Outline) -> Outline:
-    """Convert cubic segments to quadratic segments."""
-    return Outline(*_cubic_to_quad(inpt.types, inpt.coords))
+    """Convert ``CURVE_TO`` elements to sequences of ``QUAD_TO`` elements.
+
+    Each cubic Bezier segment is replaced by the minimum number of quadratic
+    Bezier segments needed to approximate it within ~1e-3 em units (roughly one
+    font unit in a 1000-UPM font), following the fontTools cu2qu approach.
+    Consecutive quadratics share implicit on-curve points at the midpoints of
+    adjacent off-curve control points, as TrueType splines do.
+
+    Unlike :func:`quad_to_cubic`, the output length may differ from the input
+    because one cubic can expand into several quadratics.
+    """
+    return _native_outline(inpt, _ops.cubic_to_quad, name="cubic_to_quad")
 
 
 def merge_curves(inpt: Outline) -> Outline:
-    """Merge adjacent pieces of the same parent curve or line."""
-    return Outline(*_merge_curves(inpt.types, inpt.coords))
+    """Merge adjacent pieces of the same parent curve or line.
+
+    Adjacent cubic and quadratic Bezier segments are merged when they are pieces
+    of a single parent curve, that is when they join at smooth split points
+    determined via de Casteljau. Adjacent ``LINE_TO`` segments are merged when
+    the three points are collinear and the segments run in the same direction.
+    Unlike the fontTools ``merge_curves`` helper this also handles line segments.
+
+    The comparison tolerance is ~1e-3 em units, roughly one font unit in a
+    1000-UPM font, matching the precision fontTools typically uses.
+    """
+    return _native_outline(inpt, _ops.merge_curves, name="merge_curves")
 
 
 def split_segments(
@@ -131,11 +79,12 @@ def split_segments(
     """Split segments according to explicit selection and position values."""
     return _native_outline(
         inpt,
-        _torchfont.random_split_segments,
-        selection_values.cpu().contiguous().numpy(),
-        position_values.cpu().contiguous().numpy(),
+        _ops.split_segments,
+        selection_values,
+        position_values,
         split_probability,
-        split_range,
+        list(split_range),
+        name="split_segments",
     )
 
 

--- a/torchfont/transforms/functional/_geometry.py
+++ b/torchfont/transforms/functional/_geometry.py
@@ -22,8 +22,32 @@ import math
 import torch
 from torch import Tensor
 
-from torchfont import _torchfont
+from torchfont import _ops
 from torchfont._outline import ElementType, Outline
+from torchfont.transforms.functional._utils import (
+    _require_no_grad,
+    _require_single,
+    _same_types,
+)
+
+
+def _is_nan(value: float) -> bool:
+    """Return whether ``value`` is NaN, without calling :func:`math.isnan`.
+
+    Dynamo treats ``math.isnan`` as an operator returning a non-Tensor and cannot
+    trace it once ``torch.compile`` runs with ``dynamic=True``, which makes these
+    float parameters symbolic. NaN is the only float that compares false against
+    both zero comparisons.
+    """
+    return not (value <= 0.0 or value > 0.0)
+
+
+def _is_infinite(value: float) -> bool:
+    """Return whether ``value`` is infinite, without calling :func:`math.isfinite`.
+
+    Traceable for the same reason as :func:`_is_nan`.
+    """
+    return abs(value) == math.inf
 
 
 def _active_pairs(types: Tensor) -> tuple[Tensor, Tensor, Tensor]:
@@ -39,20 +63,18 @@ def _active_pairs(types: Tensor) -> tuple[Tensor, Tensor, Tensor]:
 
 
 def _bbox_center(types: Tensor, coords: Tensor) -> Tensor:
-    """Return the tight bounding-box centre via the Rust ``tight_bbox`` implementation.
+    """Return the tight bounding-box centre as a ``(2,)`` tensor.
 
-    Delegates to :func:`torchfont._torchfont.tight_bbox`, which evaluates true
+    Delegates to the ``torchfont::bbox_center`` operator, which evaluates true
     curve extrema for QUAD_TO and CURVE_TO segments rather than bounding the
     control-point hull.
+
+    The centre is the reference frame a transform is applied around, not a
+    differentiable output, so it is computed from detached coordinates. Gradients
+    therefore flow through the transformed coordinates but not through the choice
+    of centre.
     """
-    result = _torchfont.tight_bbox(
-        types.cpu().contiguous().numpy(),
-        coords.cpu().contiguous().reshape(-1).numpy(),
-    )
-    if result is None:
-        return coords.new_zeros(2)
-    x_min, y_min, x_max, y_max = result
-    return coords.new_tensor([(x_min + x_max) / 2.0, (y_min + y_max) / 2.0])
+    return _ops.bbox_center(types.detach(), coords.detach())
 
 
 def _apply_matrix(
@@ -94,14 +116,7 @@ def _preserve_closed_subpath_winding(
     types: Tensor,
     coords: Tensor,
 ) -> tuple[Tensor, Tensor]:
-    out_types, out_coords = _torchfont.reverse_closed_subpaths(
-        types.cpu().contiguous().numpy(),
-        coords.cpu().contiguous().reshape(-1).numpy(),
-    )
-    return (
-        torch.from_numpy(out_types).to(device=types.device),
-        torch.from_numpy(out_coords).view(-1, 6).to(device=coords.device),
-    )
+    return _ops.reverse_closed_subpaths(types.detach(), coords.detach())
 
 
 def _horizontal_flip(
@@ -117,7 +132,7 @@ def _horizontal_flip(
 
     Args:
         types: 1-D ``torch.int64`` tensor of element types.
-        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        coords: 2-D floating point tensor of shape ``(N, 6)``.
         preserve_winding: Reverse closed subpaths after reflection so their
             winding direction matches the input. Default: ``True``.
 
@@ -145,7 +160,7 @@ def _vertical_flip(
 
     Args:
         types: 1-D ``torch.int64`` tensor of element types.
-        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        coords: 2-D floating point tensor of shape ``(N, 6)``.
         preserve_winding: Reverse closed subpaths after reflection so their
             winding direction matches the input. Default: ``True``.
 
@@ -181,7 +196,7 @@ def _affine(
 
     Args:
         types: 1-D ``torch.int64`` tensor of element types.
-        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
+        coords: 2-D floating point tensor of shape ``(N, 6)``.
         angle: Counter-clockwise rotation in degrees.
         translate: Translation ``(tx, ty)`` in em units applied
             after rotation and scaling. Values must be finite.
@@ -193,16 +208,16 @@ def _affine(
         ``types`` is returned unchanged (same object).
 
     """
-    if not math.isfinite(scale) or scale <= 0:
+    if _is_nan(scale) or _is_infinite(scale) or scale <= 0:
         msg = "scale must be positive and finite"
         raise ValueError(msg)
-    if math.isnan(angle):
+    if _is_nan(angle):
         msg = "angle must be finite"
         raise ValueError(msg)
-    if math.isnan(shear):
+    if _is_nan(shear):
         msg = "shear must be finite"
         raise ValueError(msg)
-    if not all(math.isfinite(value) for value in translate):
+    if any(_is_nan(value) or _is_infinite(value) for value in translate):
         msg = "translate values must be finite"
         raise ValueError(msg)
     matrix = _rotation_scale_shear_matrix(angle, scale, shear, like=coords)
@@ -211,17 +226,33 @@ def _affine(
 
 
 def horizontal_flip(inpt: Outline, *, preserve_winding: bool = True) -> Outline:
-    """Flip an outline horizontally around its tight bounding-box centre."""
-    return Outline(
-        *_horizontal_flip(inpt.types, inpt.coords, preserve_winding=preserve_winding)
+    """Flip an outline horizontally around its tight bounding-box centre.
+
+    Differentiable only when ``preserve_winding`` is ``False``; reversing
+    subpaths reorders elements in Rust and defines no gradient.
+    """
+    _require_single(inpt, "horizontal_flip")
+    if preserve_winding:
+        _require_no_grad(inpt, "horizontal_flip(preserve_winding=True)")
+    out_types, out_coords = _horizontal_flip(
+        inpt.types, inpt.coords, preserve_winding=preserve_winding
     )
+    return Outline._wrap(out_types, out_coords)  # noqa: SLF001
 
 
 def vertical_flip(inpt: Outline, *, preserve_winding: bool = True) -> Outline:
-    """Flip an outline vertically around its tight bounding-box centre."""
-    return Outline(
-        *_vertical_flip(inpt.types, inpt.coords, preserve_winding=preserve_winding)
+    """Flip an outline vertically around its tight bounding-box centre.
+
+    Differentiable only when ``preserve_winding`` is ``False``; reversing
+    subpaths reorders elements in Rust and defines no gradient.
+    """
+    _require_single(inpt, "vertical_flip")
+    if preserve_winding:
+        _require_no_grad(inpt, "vertical_flip(preserve_winding=True)")
+    out_types, out_coords = _vertical_flip(
+        inpt.types, inpt.coords, preserve_winding=preserve_winding
     )
+    return Outline._wrap(out_types, out_coords)  # noqa: SLF001
 
 
 def affine(
@@ -232,21 +263,31 @@ def affine(
     scale: float = 1.0,
     shear: float = 0.0,
 ) -> Outline:
-    """Apply a deterministic affine transformation."""
-    return Outline(
-        *_affine(
+    """Apply a deterministic affine transformation.
+
+    Differentiable with respect to ``coords``. The bounding-box centre the
+    transform pivots around is treated as a constant reference frame.
+    """
+    _require_single(inpt, "affine")
+    return _same_types(
+        inpt,
+        _affine(
             inpt.types,
             inpt.coords,
             angle=angle,
             translate=translate,
             scale=scale,
             shear=shear,
-        )
+        )[1],
     )
 
 
 def coord_jitter(inpt: Outline, noise: Tensor) -> Outline:
-    """Add caller-provided noise to active coordinate pairs."""
+    """Add caller-provided noise to active coordinate pairs.
+
+    Differentiable with respect to both ``coords`` and ``noise``.
+    """
+    _require_single(inpt, "coord_jitter")
     types, coords = inpt.types, inpt.coords
     noise_tail_shape = (3, 2)
     if (
@@ -261,8 +302,8 @@ def coord_jitter(inpt: Outline, noise: Tensor) -> Outline:
     active = torch.stack(_active_pairs(types), dim=1).unsqueeze(-1)
     points = coords.reshape(-1, 3, 2)
     noise = noise[: types.size(0)].to(device=coords.device, dtype=coords.dtype)
-    return Outline(
-        types, torch.where(active, points + noise, points).reshape_as(coords)
+    return _same_types(
+        inpt, torch.where(active, points + noise, points).reshape_as(coords)
     )
 
 

--- a/torchfont/transforms/functional/_glyph.py
+++ b/torchfont/transforms/functional/_glyph.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 import torch
 
 from torchfont import _torchfont
-from torchfont._font import VariationLocation
 from torchfont._outline import COORD_DIM, Outline
 
 if TYPE_CHECKING:
@@ -22,7 +21,9 @@ def load_glyph(
 ) -> Outline:
     """Load one glyph outline at an explicit or default location."""
     normalized_location = (
-        None if location is None else dict(VariationLocation(location))
+        None
+        if location is None
+        else {str(tag): float(value) for tag, value in location.items()}
     )
     raw_types, raw_coords = _torchfont.load_glyph(
         ref.font.path,
@@ -30,7 +31,7 @@ def load_glyph(
         ref.codepoint,
         normalized_location,
     )
-    return Outline(
+    return Outline._wrap(  # noqa: SLF001
         torch.from_numpy(raw_types),
         torch.from_numpy(raw_coords).view(-1, COORD_DIM),
     )

--- a/torchfont/transforms/functional/_outline.py
+++ b/torchfont/transforms/functional/_outline.py
@@ -1,51 +1,34 @@
 """Functional whole-outline kernels."""
 
-import torch
-from torch import Tensor
+from __future__ import annotations
 
-from torchfont import _torchfont
-from torchfont._outline import Outline
+from typing import TYPE_CHECKING
+
+from torchfont import _ops
 from torchfont.transforms.functional._utils import _native_outline
 
+if TYPE_CHECKING:
+    from torch import Tensor
 
-def _remove_overlaps(types: Tensor, coords: Tensor) -> tuple[Tensor, Tensor]:
-    """Merge overlapping subpaths using Skia PathOps winding simplification.
-
-    Args:
-        types: 1-D ``torch.int64`` tensor of element types.
-        coords: 2-D ``torch.float32`` tensor of shape ``(N, 6)``.
-
-    Returns:
-        A new variable-length outline tuple ``(types, coords)`` with overlapping
-        subpath edges removed when Skia PathOps can resolve the outline. If
-        PathOps cannot simplify an otherwise valid outline, the original outline
-        is returned unchanged.
-
-    """
-    types_device = types.device
-    coords_device = coords.device
-    types = types.cpu().contiguous()
-    coords = coords.cpu().contiguous()
-    out_types, out_coords = _torchfont.remove_overlaps(
-        types.numpy(), coords.reshape(-1).numpy()
-    )
-    return (
-        torch.from_numpy(out_types).to(device=types_device),
-        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
-    )
+    from torchfont._outline import Outline
 
 
 def remove_overlaps(inpt: Outline) -> Outline:
-    """Merge overlapping subpaths."""
-    return Outline(*_remove_overlaps(inpt.types, inpt.coords))
+    """Merge overlapping subpaths using Skia PathOps winding simplification.
+
+    If PathOps cannot simplify an otherwise valid outline, the original outline
+    is returned unchanged.
+    """
+    return _native_outline(inpt, _ops.remove_overlaps, name="remove_overlaps")
 
 
 def remove_overlap_groups(inpt: Outline, selection_values: Tensor) -> Outline:
     """Simplify overlap groups according to explicit selection values."""
     return _native_outline(
         inpt,
-        _torchfont.random_remove_overlaps,
-        selection_values.cpu().contiguous().numpy(),
+        _ops.remove_overlap_groups,
+        selection_values,
+        name="remove_overlap_groups",
     )
 
 

--- a/torchfont/transforms/functional/_subpath.py
+++ b/torchfont/transforms/functional/_subpath.py
@@ -1,48 +1,45 @@
-"""Functional subpath kernels."""
+"""Functional subpath kernels.
 
-import torch
-from torch import Tensor
+Every kernel here reorders or re-encodes path elements in Rust, so none of them
+define a gradient. Subpath boundaries are derived from the ``CLOSE`` and ``END``
+element types rather than stored alongside the outline.
+"""
 
-from torchfont import _torchfont
-from torchfont._outline import Outline
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from torchfont import _ops
 from torchfont.transforms.functional._utils import _native_outline
 
+if TYPE_CHECKING:
+    from torch import Tensor
 
-def _normalize_subpath_start_points(
-    types: Tensor,
-    coords: Tensor,
-) -> tuple[Tensor, Tensor]:
-    """Move each subpath start to its lexicographically smallest endpoint.
-
-    ``(x, y)`` endpoint order is used as the deterministic key. Open subpaths
-    (those without a closing ``Close``), ``END``, and ``PAD`` element types are
-    returned unchanged. When rotation crosses the old closing edge, that implicit
-    edge is materialised as ``LINE_TO`` so the represented geometry is preserved.
-    """
-    types_device = types.device
-    coords_device = coords.device
-    types = types.cpu().contiguous()
-    coords = coords.cpu().contiguous()
-    out_types, out_coords = _torchfont.normalize_subpath_start_points(
-        types.numpy(), coords.reshape(-1).numpy()
-    )
-    return (
-        torch.from_numpy(out_types).to(device=types_device),
-        torch.from_numpy(out_coords).view(-1, 6).to(device=coords_device),
-    )
+    from torchfont._outline import Outline
 
 
 def normalize_subpath_start_points(inpt: Outline) -> Outline:
-    """Choose a deterministic start point for each closed subpath."""
-    return Outline(*_normalize_subpath_start_points(inpt.types, inpt.coords))
+    """Choose a deterministic start point for each closed subpath.
+
+    Each subpath start moves to its lexicographically smallest ``(x, y)``
+    endpoint. Open subpaths, ``END``, and ``PAD`` elements are unchanged. When
+    rotation crosses the old closing edge, that implicit edge is materialised as
+    ``LINE_TO`` so the represented geometry is preserved.
+    """
+    return _native_outline(
+        inpt,
+        _ops.normalize_subpath_start_points,
+        name="normalize_subpath_start_points",
+    )
 
 
 def set_subpath_start_points(inpt: Outline, selection_values: Tensor) -> Outline:
     """Set closed-subpath start points from explicit unit-interval values."""
     return _native_outline(
         inpt,
-        _torchfont.randomize_subpath_start_points,
-        selection_values.cpu().contiguous().numpy(),
+        _ops.set_subpath_start_points,
+        selection_values,
+        name="set_subpath_start_points",
     )
 
 
@@ -50,8 +47,9 @@ def reorder_subpaths(inpt: Outline, keys: Tensor) -> Outline:
     """Order subpaths by explicit sort keys."""
     return _native_outline(
         inpt,
-        _torchfont.randomize_subpath_order,
-        keys.cpu().contiguous().numpy(),
+        _ops.reorder_subpaths,
+        keys,
+        name="reorder_subpaths",
     )
 
 

--- a/torchfont/transforms/functional/_utils.py
+++ b/torchfont/transforms/functional/_utils.py
@@ -2,33 +2,58 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import torch
-
-from torchfont._outline import COORD_DIM, Outline
+from torchfont._outline import Outline
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import numpy as np
-    from numpy.typing import NDArray
+    from torch import Tensor
+
+
+def _require_single(inpt: Outline, name: str) -> None:
+    """Reject a batched outline for a kernel defined on one glyph."""
+    if inpt.is_batched:
+        msg = (
+            f"{name} operates on a single outline, got batch shape "
+            f"{tuple(inpt.batch_shape)}; iterate with unpad_outlines() first"
+        )
+        raise ValueError(msg)
+
+
+def _require_no_grad(inpt: Outline, name: str) -> None:
+    """Reject an outline that requires grad for a non-differentiable kernel.
+
+    Kernels implemented in Rust change outline topology, so no gradient is
+    defined for them. Failing here names the kernel instead of surfacing an
+    error from deep inside the operator.
+    """
+    if inpt.coords.requires_grad or inpt.types.requires_grad:
+        msg = (
+            f"{name} is implemented in Rust and is not differentiable; "
+            "detach its coords first"
+        )
+        raise RuntimeError(msg)
 
 
 def _native_outline(
     inpt: Outline,
-    operation: Callable[
-        ..., tuple[NDArray[np.integer[Any]], NDArray[np.floating[Any]]]
-    ],
+    operation: Callable[..., tuple[Tensor, Tensor]],
     *args: object,
+    name: str,
 ) -> Outline:
-    """Run a native outline operation on CPU and restore the input devices."""
-    types_device = inpt.types.device
-    coords_device = inpt.coords.device
-    types = inpt.types.cpu().contiguous()
-    coords = inpt.coords.cpu().contiguous()
-    out_types, out_coords = operation(types.numpy(), coords.reshape(-1).numpy(), *args)
-    return Outline(
-        torch.from_numpy(out_types).to(device=types_device),
-        torch.from_numpy(out_coords).view(-1, COORD_DIM).to(device=coords_device),
-    )
+    """Run a Rust outline operator, checking preconditions once at the boundary.
+
+    ``operation`` is a :mod:`torchfont._ops` custom operator, so the Rust call is
+    one opaque node that :func:`torch.compile` can capture.
+    """
+    _require_single(inpt, name)
+    _require_no_grad(inpt, name)
+    out_types, out_coords = operation(inpt.types, inpt.coords, *args)
+    return Outline._wrap(out_types, out_coords)  # noqa: SLF001
+
+
+def _same_types(inpt: Outline, coords: Tensor) -> Outline:
+    """Pair new coordinates with the element types of an existing outline."""
+    return Outline._wrap(inpt.types, coords)  # noqa: SLF001

--- a/uv.lock
+++ b/uv.lock
@@ -1601,7 +1601,7 @@ lint = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=1.21.3" },
-    { name = "torch", specifier = ">=2.3.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", specifier = ">=2.4.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -1601,7 +1601,7 @@ lint = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=1.21.3" },
-    { name = "torch", specifier = ">=2.4.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", specifier = ">=2.5.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 
 [package.metadata.requires-dev]
@@ -1614,7 +1614,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "ruff", specifier = ">=0.16.0" },
     { name = "skia-pathops", specifier = ">=0.9.2" },
-    { name = "torchvision", specifier = ">=0.18.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchvision", specifier = ">=0.20.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "ty", specifier = ">=0.0.63" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },


### PR DESCRIPTION
## Summary

- introduce a lightweight `Outline` container for coupled element-type and coordinate tensors, including explicit padding helpers
- keep dataset indices as Python integers and optional continuous targets as `float | None`
- let applications define their own `DataLoader.collate_fn` instead of installing or prescribing a global batch representation
- update `torchfont.nn` and transform APIs to consume `Outline`
- register native outline operations as PyTorch custom operators with explicit device, dtype, autograd, and `torch.compile` behavior
- update English and Japanese user documentation and examples for the public API

## Motivation

The previous representation mixed scalar metadata with tensors and encouraged batching behavior owned by the library. This made the public data model less consistent with ordinary PyTorch and TorchVision usage, while native operations could also obscure device and dtype boundaries.

This change keeps metadata as ordinary Python values until application-level collation, makes variable-length outline batching explicit, and exposes native operation constraints through standard PyTorch behavior.

## User impact

- `VariationLocation` is replaced by `dict[str, float]`
- `GlyphData.font_idx` and `character_idx` are Python integers
- continuous targets are `float | None`
- `GlyphData.data` can contain an `Outline`
- use `pad_outlines()` in a local `collate_fn` when batching variable-length outlines
- neural-network helpers and outline transforms now accept `Outline`

## Validation

- `mise run check`
- `mise run test`: 383 passed, 16 skipped
- `mise exec -- npm run docs:build`
- `git diff --check`
