### PR TITLE
Simplify transform examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ pip install torchfont
 ## Quickstart
 
 ```python
-import math
-
-import torch
 from torch.utils.data import DataLoader
 
 from torchfont import GlyphData, Outline, pad_outlines
@@ -54,20 +51,8 @@ from torchfont.datasets import GlyphDataset
 from torchfont.transforms import LoadGlyph
 
 
-def collate_fn(samples: list[GlyphData[Outline]]):
-    return {
-        "outline": pad_outlines([sample.data for sample in samples]),
-        "font_idx": torch.tensor(
-            [sample.font_idx for sample in samples], dtype=torch.long
-        ),
-        "weight": torch.tensor(
-            [
-                math.nan if sample.weight is None else sample.weight
-                for sample in samples
-            ],
-            dtype=torch.float32,
-        ),
-    }
+def collate_fn(samples: list[GlyphData[Outline]]) -> Outline:
+    return pad_outlines([sample.data for sample in samples])
 
 
 dataset = GlyphDataset(
@@ -83,15 +68,14 @@ loader = DataLoader(
     shuffle=True,
     collate_fn=collate_fn,
 )
-batch = next(iter(loader))
+outlines = next(iter(loader))
 
-print(batch["outline"].shape)  # (8, L)
-print(batch["outline"].coords.shape)  # (8, L, 6)
-print(batch["weight"].shape)  # (8,)
+print(outlines.types.shape)  # (8, L)
+print(outlines.coords.shape)  # (8, L, 6)
 ```
 
-Define `collate_fn` locally to choose the targets and missing-value representation
-required by your model. Use `pad_outlines` to pad variable-length outlines.
+Use `pad_outlines` to pad variable-length outlines. A model that also needs
+targets can add them to the batch in its local `collate_fn`.
 
 ## What TorchFont Focuses On
 

--- a/examples/google_fonts.py
+++ b/examples/google_fonts.py
@@ -7,44 +7,37 @@ import torch
 from torch import Tensor
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
-from torchvision.transforms import v2
+from torchvision.transforms import v2 as T
 from tqdm import tqdm
 
+from torchfont import transforms as FT
 from torchfont.datasets import GlyphDataset
 from torchfont.glyphsets import LATIN_CORE
-from torchfont.transforms import (
-    Compose,
-    LoadGlyph,
-    QuadToCubic,
-    RandomAffine,
-    RemoveOverlaps,
-    RenderBitmap,
-)
 
 if TYPE_CHECKING:
     from torchfont import GlyphData, GlyphSample, Outline
 
 
-class GlyphPipeline(torch.nn.Module):
+class TransformPipeline(torch.nn.Module):
     """Build two model inputs from one shared outline pipeline."""
 
     def __init__(self) -> None:
         super().__init__()
-        self.prepare_outline = Compose(
+        self.prepare_outline = FT.Compose(
             [
-                LoadGlyph(location="random"),
-                RemoveOverlaps(),
-                QuadToCubic(merge_curves=True),
-                RandomAffine(degrees=5.0, translate=(0.05, 0.05)),
+                FT.LoadGlyph(location="random"),
+                FT.RemoveOverlaps(),
+                FT.QuadToCubic(merge_curves=True),
+                FT.RandomAffine(degrees=5.0, translate=(0.05, 0.05)),
             ]
         )
-        self.rasterize = Compose(
+        self.rasterize = FT.Compose(
             [
-                RenderBitmap(size=96),
-                v2.ToImage(),
-                v2.Resize((64, 64), antialias=True),
-                v2.ToDtype(torch.float32, scale=True),
-                v2.ToPureTensor(),
+                FT.RenderBitmap(size=96),
+                T.ToImage(),
+                T.Resize((64, 64), antialias=True),
+                T.ToDtype(torch.float32, scale=True),
+                T.ToPureTensor(),
             ]
         )
 
@@ -90,7 +83,7 @@ def main() -> None:
             "ufl/*/*.ttf",
             "!ofl/adobeblank/*.ttf",
         ),
-        transform=GlyphPipeline(),
+        transform=TransformPipeline(),
     )
 
     dataloader = DataLoader(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ select = ["ALL"]
 ignore = ["COM812", "CPY001", "D203", "D213", "EXE002"]
 
 [tool.ruff.lint.per-file-ignores]
-"examples/**/*.py" = ["D", "T201"]
+"examples/**/*.py" = ["D", "N812", "T201"]
 # Operator signatures are fixed by the schema each kernel is registered with.
 "torchfont/_ops.py" = ["FBT001", "PLR0913", "PLR0917"]
 "torchfont/transforms/functional/_geometry.py" = ["PLR0913"]


### PR DESCRIPTION
## Summary

- simplify the README quickstart collation example to return a padded `Outline` directly
- make the displayed `types` and `coords` batch shapes explicit
- use `FT` for TorchFont transforms and `T` for TorchVision transforms in the Google Fonts example
- rename the example pipeline to `TransformPipeline` and allow the conventional uppercase module aliases in examples

## Why

The quickstart previously introduced target selection and missing-value handling before users needed those concepts. The streamlined version keeps the first batching example focused on variable-length outlines, while the Google Fonts example now distinguishes font and image transforms without a long import list.

## Validation

- `mise run check`
- `uv run pytest tests/test_examples.py`
- executed the README batching snippet against `tests/fonts` and verified shapes `(8, L)` and `(8, L, 6)`
- `git diff --check`
