### PR TITLE
Release v0.12.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     given-names: "Takumu"
     email: "fjktkm@gmail.com"
     orcid: "https://orcid.org/0009-0005-0691-414X"
-version: 0.12.2
-date-released: 2026-08-07
+version: 0.12.3
+date-released: 2026-08-09
 license: MIT
 repository-code: "https://github.com/torchfont/torchfont"
 url: "https://torchfont.readthedocs.io/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "google-fonts-glyphsets",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the package version to `0.12.3` in `Cargo.toml` and `Cargo.lock`
- update `CITATION.cff` to version `0.12.3` with the 2026-08-09 release date

This release includes the redesigned glyph data model and transform examples, expanded English and Japanese documentation, and the new advanced guides added since v0.12.2.

## Validation

- `mise run check`
- built `torchfont-0.12.3-cp310-abi3-manylinux_2_35_x86_64.whl` with maturin
- verified Cargo metadata reports version `0.12.3`
- `git diff --check`
