### PR TITLE
Release v0.12.4

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     given-names: "Takumu"
     email: "fjktkm@gmail.com"
     orcid: "https://orcid.org/0009-0005-0691-414X"
-version: 0.12.3
-date-released: 2026-08-09
+version: 0.12.4
+date-released: 2026-08-12
 license: MIT
 repository-code: "https://github.com/torchfont/torchfont"
 url: "https://torchfont.readthedocs.io/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "google-fonts-glyphsets",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
Bump version to 0.12.4 in `Cargo.toml`, `Cargo.lock`, and `CITATION.cff`, following the same pattern as previous releases (e.g. #362).