### PR TITLE
Document release targets and process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,55 +140,39 @@ jobs:
           path: dist
 
   windows:
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: windows-latest
     needs: check
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-latest
-            target: x64
-            python_arch: x64
-          - runner: windows-11-arm
-            target: aarch64
-            python_arch: arm64
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
-          architecture: ${{ matrix.platform.python_arch }}
+          architecture: x64
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.platform.target }}
+          target: x64
           args: --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@v7
         with:
           python-version: "3.14t"
-          architecture: ${{ matrix.platform.python_arch }}
+          architecture: x64
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.platform.target }}
+          target: x64
           args: --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-windows-${{ matrix.platform.target }}
+          name: wheels-windows-x64
           path: dist
 
   macos:
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: macos-latest
     needs: check
-    strategy:
-      matrix:
-        platform:
-          - runner: macos-15-intel
-            target: x86_64
-          - runner: macos-latest
-            target: aarch64
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -197,7 +181,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.platform.target }}
+          target: aarch64
           args: --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@v7
@@ -206,13 +190,13 @@ jobs:
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.platform.target }}
+          target: aarch64
           args: --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-macos-${{ matrix.platform.target }}
+          name: wheels-macos-aarch64
           path: dist
 
   sdist:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,55 @@ Keep `docs/en/` and `docs/ja/` aligned when changing user-facing docs.
   into their own PRs.
 - Ensure CI passes before requesting review.
 
+## Release
+
+### Binary Build Matrix
+
+TorchFont publishes wheels for the intersection of the targets supported by
+maturin and PyO3, prebuilt Skia, and PyTorch.
+
+| Platform | Rust target | maturin / PyO3 | Prebuilt Skia | PyTorch | **TorchFont** |
+| --- | --- | :---: | :---: | :---: | :---: |
+| manylinux x86-64 | `x86_64-unknown-linux-gnu` | ✅ | ✅ | ✅ | **✅** |
+| manylinux x86 | `i686-unknown-linux-gnu` | ✅ | ❌ | ❌ | **❌** |
+| manylinux ARM64 | `aarch64-unknown-linux-gnu` | ✅ | ✅ | ✅ | **✅** |
+| manylinux ARMv7 | `armv7-unknown-linux-gnueabihf` | ✅ | ❌ | ❌ | **❌** |
+| manylinux s390x | `s390x-unknown-linux-gnu` | ✅ | ❌ | ❌ | **❌** |
+| manylinux PowerPC 64 LE | `powerpc64le-unknown-linux-gnu` | ✅ | ❌ | ❌ | **❌** |
+| musllinux x86-64 | `x86_64-unknown-linux-musl` | ✅ | ❌ | ❌ | **❌** |
+| musllinux x86 | `i686-unknown-linux-musl` | ✅ | ❌ | ❌ | **❌** |
+| musllinux ARM64 | `aarch64-unknown-linux-musl` | ✅ | ❌ | ❌ | **❌** |
+| musllinux ARMv7 | `armv7-unknown-linux-musleabihf` | ✅ | ❌ | ❌ | **❌** |
+| Windows x86-64 | `x86_64-pc-windows-msvc` | ✅ | ✅ | ✅ | **✅** |
+| Windows x86 | `i686-pc-windows-msvc` | ✅ | ❌ | ❌ | **❌** |
+| Windows ARM64 | `aarch64-pc-windows-msvc` | ✅ | ✅ | ❌ | **❌** |
+| macOS Intel | `x86_64-apple-darwin` | ✅ | ✅ | ❌ | **❌** |
+| macOS Apple silicon | `aarch64-apple-darwin` | ✅ | ✅ | ✅ | **✅** |
+| Emscripten | `wasm32-unknown-emscripten` | ✅ | ✅ | ❌ | **❌** |
+| Android ARM64 | `aarch64-linux-android` | ✅ | ✅ | ❌ | **❌** |
+| Android x86-64 | `x86_64-linux-android` | ✅ | ✅ | ❌ | **❌** |
+
+Use these upstream references when reviewing the matrix:
+
+- [maturin distribution guide](https://www.maturin.rs/distribution.html) for
+  packaging targets
+- [rust-skia platform support](https://github.com/rust-skia/rust-skia#platform-support-build-targets-and-prebuilt-binaries)
+  for prebuilt Skia binaries
+- [PyTorch binary support policy](https://github.com/pytorch/pytorch/blob/main/RELEASE.md)
+  for officially supported platforms
+
+### Release Process
+
+1. Open a release pull request that updates the version in `Cargo.toml` and
+   `Cargo.lock`, and the version and release date in `CITATION.cff`.
+2. Merge the pull request into `main` after CI passes.
+3. Create a GitHub Release from `main` with a matching `vX.Y.Z` tag and
+   GitHub-generated release notes.
+4. Confirm that the tag-triggered CI builds, attests, and publishes the wheels
+   and source distribution to PyPI.
+5. Verify the published GitHub Release and the wheel and source distributions
+   for the new version on PyPI.
+
 ## Need Help?
 
 Open a GitHub Discussion or issue if anything here is unclear. The more context


### PR DESCRIPTION
## Summary

- document the supported binary build matrix and upstream constraints
- document the release process from version bump through PyPI verification
- remove unsupported Windows ARM64 and macOS Intel wheel builds
- simplify the remaining single-target Windows and macOS jobs

## Validation

- mise run check
- mise run test (383 passed, 12 skipped)