### PR TITLE
Align nn module layout with PyTorch

### DIFF
--- a/torchfont/nn/__init__.py
+++ b/torchfont/nn/__init__.py
@@ -1,7 +1,6 @@
 """Neural network building blocks for font outlines."""
 
 from torchfont.nn import functional
-from torchfont.nn._embedding import OutlineEmbedding
-from torchfont.nn._loss import OutlineLoss
+from torchfont.nn.modules import OutlineEmbedding, OutlineLoss
 
 __all__ = ["OutlineEmbedding", "OutlineLoss", "functional"]

--- a/torchfont/nn/modules/__init__.py
+++ b/torchfont/nn/modules/__init__.py
@@ -1,0 +1,6 @@
+"""Neural network modules for font outlines."""
+
+from torchfont.nn.modules.embedding import OutlineEmbedding
+from torchfont.nn.modules.loss import OutlineLoss
+
+__all__ = ["OutlineEmbedding", "OutlineLoss"]

--- a/torchfont/nn/modules/embedding.py
+++ b/torchfont/nn/modules/embedding.py
@@ -26,6 +26,7 @@ class OutlineEmbedding(nn.Module):
         device: torch.device | str | None = None,
         dtype: torch.dtype | None = None,
     ) -> None:
+        """Initialize the element-type embedding and coordinate projection."""
         super().__init__()
         self.embedding_dim = embedding_dim
         self.type_embedding = nn.Embedding(
@@ -60,6 +61,7 @@ class OutlineEmbedding(nn.Module):
         return torch.where((types != ElementType.PAD.value).unsqueeze(-1), embedded, 0)
 
     def extra_repr(self) -> str:
+        """Return the module configuration for :func:`repr`."""
         return f"embedding_dim={self.embedding_dim}"
 
 

--- a/torchfont/nn/modules/loss.py
+++ b/torchfont/nn/modules/loss.py
@@ -27,6 +27,7 @@ class OutlineLoss(nn.Module):
         type_weight: float = 1.0,
         coordinate_weight: float = 1.0,
     ) -> None:
+        """Initialize the weights applied to both loss components."""
         super().__init__()
         self.type_weight = type_weight
         self.coordinate_weight = coordinate_weight
@@ -47,6 +48,7 @@ class OutlineLoss(nn.Module):
         )
 
     def extra_repr(self) -> str:
+        """Return the module configuration for :func:`repr`."""
         return (
             f"type_weight={self.type_weight}, "
             f"coordinate_weight={self.coordinate_weight}"


### PR DESCRIPTION
## Summary

- move `OutlineEmbedding` and `OutlineLoss` into `torchfont.nn.modules`
- re-export both modules from `torchfont.nn` so the public API remains unchanged
- keep shared stateless operations in `torchfont.nn.functional`

## Rationale

PyTorch places stateful `nn.Module` implementations under `torch.nn.modules` while exposing them from `torch.nn`. TorchFont now follows the same organization without adding compatibility aliases for the old private implementation modules.

## User impact

Existing public imports such as `from torchfont.nn import OutlineEmbedding, OutlineLoss` are unchanged. The implementation module paths now reflect their role as reusable neural network modules.

## Validation

- `mise run python-check`
- `uv run pytest tests/nn` (26 passed)
- `mise run test` (383 passed, 12 skipped)
- `git diff --check`