### PR TITLE
Release v0.12.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     given-names: "Takumu"
     email: "fjktkm@gmail.com"
     orcid: "https://orcid.org/0009-0005-0691-414X"
-version: 0.12.4
-date-released: 2026-08-12
+version: 0.12.5
+date-released: 2026-08-14
 license: MIT
 repository-code: "https://github.com/torchfont/torchfont"
 url: "https://torchfont.readthedocs.io/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "torchfont"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "google-fonts-glyphsets",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchfont"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 description = "Datasets, Transforms and Models specific to Vector Fonts"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.12.5 in `Cargo.toml`/`Cargo.lock` and `CITATION.cff`, per the release process in CONTRIBUTING.md.

## Test plan
- [x] `mise run format`
- [x] `mise run check`
- [ ] CI passes on this PR