### PR TITLE
Add gitsubmodule ecosystem to Dependabot and sort alphabetically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
@@ -14,21 +23,12 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: weekly
     groups:
-      python-dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: weekly
-    groups:
-      rust-dependencies:
+      submodule-dependencies:
         patterns:
           - "*"
 
@@ -38,5 +38,14 @@ updates:
       interval: weekly
     groups:
       npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      python-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary
- Add `package-ecosystem: "gitsubmodule"` to track version updates for the four `data/` submodules (Google Fonts, Font Awesome, Material Design Icons, Source Han Code JP), following [Dependabot's supported ecosystems](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories)
- Reorder all `package-ecosystem` entries alphabetically for consistency

## Test plan
- [x] Validated YAML syntax