### PR TITLE
Set OutlineLoss default coordinate_weight to 100

### DIFF
--- a/torchfont/nn/functional.py
+++ b/torchfont/nn/functional.py
@@ -55,7 +55,7 @@ def outline_loss(
     target: Outline,
     *,
     type_weight: float = 1.0,
-    coordinate_weight: float = 1.0,
+    coordinate_weight: float = 100.0,
 ) -> Tensor:
     """Combine element-type classification and active-coordinate regression.
 

--- a/torchfont/nn/modules/loss.py
+++ b/torchfont/nn/modules/loss.py
@@ -25,7 +25,7 @@ class OutlineLoss(nn.Module):
         self,
         *,
         type_weight: float = 1.0,
-        coordinate_weight: float = 1.0,
+        coordinate_weight: float = 100.0,
     ) -> None:
         """Initialize the weights applied to both loss components."""
         super().__init__()


### PR DESCRIPTION
## Summary
- Change `OutlineLoss` / `outline_loss` default `coordinate_weight` from `1.0` to `100.0`, per the sweep results in [torchfont/loss-weight](https://github.com/torchfont/loss-weight).
- The sweep (with `type_weight` fixed at `1.0`) found `coordinate_weight=100` gives the best bitmap IoU/MSE among the tested values, with failure rate still flat compared to the blowup seen at 200+.

## Test plan
- [x] `ruff format` / `ruff check` on changed files
- [x] `ty check`
- [ ] CI